### PR TITLE
Add @crowdsignal/rest-api

### DIFF
--- a/packages/rest-api/README.md
+++ b/packages/rest-api/README.md
@@ -1,0 +1,4 @@
+# @crowdsignal/rest-api
+
+This package servers as an abstraction layer for our REST API at `https://api.crowdsignal.com`.  
+See individual sub-module READMEs for the details on each endpoint.

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@crowdsignal/rest-api",
+  "version": "0.1.0",
+  "description": "JS bindings for Crowdsignal API.",
+  "keywords": [
+    "crowdsignal",
+    "api"
+  ],
+  "author": "Automattic Inc.",
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/rest-api/README.md",
+  "license": "GPL-2.0-or-later",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "dependencies": {
+    "@crowdsignal/http": "^0.1.0"
+  }
+}

--- a/packages/rest-api/src/feedback/README.md
+++ b/packages/rest-api/src/feedback/README.md
@@ -1,0 +1,69 @@
+# Feedback Survey
+
+## fetchFeedbackSurvey
+
+Returns a feedback survey.
+
+```javascript
+import { fetchFeedbackSurvey } from '@crowdsignal/rest-api';
+
+const survey = await fetchFeedbackSurvey( surveyId );
+```
+
+### Params
+
+**surveyId**: Survey ID for the feedback survey.
+
+- Type: `Number`
+- Required: Yes
+
+### Return
+
+```json
+{
+	...
+}
+```
+
+## updateFeedbackResponse
+
+Submits a response for a feedback survey.
+
+```javascript
+import { updateFeedbackResponse } from '@crowdsignal/rest-api';
+
+const response = updateFeedbackResponse( surveyId, data );
+```
+
+### Params
+
+**surveyId**: Survey ID for the feedback survey to submit the response to.
+
+- Type: `Number`
+- Required: Yes
+
+**data**: Response data
+
+- Type: `Object`
+- Required: Yes
+
+**data.email**: Email field of the response
+
+- Type: `String`
+- Required: No
+- Default: `''`
+
+**data.feedback**: Feedback field of the response
+
+- Type: `String`
+- Required: No
+- Default: `''`
+
+### Return
+
+```json
+{
+	...
+}
+```
+

--- a/packages/rest-api/src/feedback/index.js
+++ b/packages/rest-api/src/feedback/index.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { http } from '@crowdsignal/http';
+
+export const fetchFeedbackSurvey = ( surveyId ) => http( {
+	host: 'https://api.crowdsignal.com',
+	path: `/v3/feedback/${ surveyId }`,
+	method: 'GET',
+	mode: 'cors',
+} );
+
+export const updateFeedbackResponse = ( surveyId, data ) => http( {
+	host: 'https://api.crowdsignal.com',
+	path: `/v3/feedback/${ surveyId }/response`,
+	method: 'POST',
+	mode: 'cors',
+	body: JSON.stringify( data ),
+} );

--- a/packages/rest-api/src/index.js
+++ b/packages/rest-api/src/index.js
@@ -1,0 +1,1 @@
+export * from './feedback';


### PR DESCRIPTION
This patch adds a new `@crowdsignal/rest-api` package which will serve as an abstraction layer for our `api.crowdsignal.com` API.

The idea is this package would be used to transform any data going between the app and the API in order to improve or expand compatibility.

Depends on #2.