### PR TITLE
Add @crowdsignal/components

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,0 +1,3 @@
+# Crowdsignal components
+
+The main frontend components directory for our apps.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@crowdsignal/components",
+  "version": "0.1.0",
+  "description": "Crowdsignal frontend component library.",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "author": "Automattic Inc.",
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/components/README.md",
+  "license": "GPL-2.0-or-later",
+  "main": "src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "scripts": {
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "dependencies": {
+    "@crowdsignal/styles": "^0.1.0",
+    "@wordpress/element": "^3.1.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+import { omit } from 'lodash';
+
+/**
+ * Style dependencies
+ */
+import { Button } from './styles.js';
+
+const ButtonComponent = ( {
+    accent,
+    borderless,
+    children,
+    className,
+    compact,
+    disabled,
+    facebook,
+    highlight,
+    large,
+    scary,
+    twitter,
+    ...props
+}, ref ) => {
+    if ( props.href && ! disabled ) {
+        const rel = props.target
+            ? ( props.rel || '' ).replace( /noopener|noreferrer/g, '' ) + ' noopener noreferrer'
+            : props.rel;
+
+        return (
+            <Button as={ 'a' } ref={ ref } { ...props } rel={ rel } className={ className }>
+                { children }
+            </Button>
+        );
+    }
+
+    const buttonProps = omit( props, [ 'href', 'rel', 'target' ] );
+
+    return (
+        <Button ref={ ref } type="button" { ...buttonProps } className={ className } disabled={ disabled }>
+            { children }
+        </Button>
+    );
+};
+
+export default forwardRef( ButtonComponent );

--- a/packages/components/src/button/styles.js
+++ b/packages/components/src/button/styles.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { color } from '@crowdsignal/styles';
+
+const baseButton = css`
+	align-items: center;
+	background-color: ${ color( 'neutral', 0 ) };
+	border-color: ${ color( 'border' ) };
+	border-radius: 5px;
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 14px;
+	height: 32px;
+	justify-content: center;
+	line-height: 24px;
+	outline: 0;
+	padding: 3px 15px 2px;
+	position: relative;
+	text-align: center;
+	transition: background-color 0.1s ease-out, border-color 0.1s ease-out;
+	white-space: nowrap;
+	width: fit-content;
+
+	&:hover {
+		border-color: ${ color( 'text' ) };
+	}
+
+	&:disabled,
+	&:disabled:hover {
+		background-color: ${ color( 'surface' ) };
+		color: ${ color( 'text-subtle' ) };
+	}
+`;
+
+const borderlessButton = css`
+	border: 0;
+	background-color: transparent;
+`;
+
+const primaryButton = ( isBorderless ) => css`
+	background-color: ${ color( 'primary' ) };
+	border-color: ${ color( 'primary', 'dark' ) };
+	color: ${ isBorderless ? color( 'primary' ) : color( 'text-inverted' ) };
+
+	&:hover {
+		background-color: ${ color( 'primary', 'light' ) };
+	}
+
+	&:disabled,
+	&:disabled:hover {
+		background-color: ${ color( 'primary', 10 ) };
+		border-color: ${ color( 'primary', 20 ) };
+	}
+`;
+
+const secondaryButton = ( isBorderless ) => css`
+	background-color: ${ color( 'secondary' ) };
+	border-color: ${ color( 'secondary', 'dark' ) };
+	color: ${ isBorderless ? color( 'secondary' ) : color( 'text-inverted' ) };
+
+	&:hover {
+		background-color: ${ color( 'secondary', 'light' ) };
+	}
+
+	&:disabled,
+	&:disabled:hover {
+		background-color: ${ color( 'secondary', 10 ) };
+		border-color: ${ color( 'secondary', 20 ) };
+	}
+`;
+
+const highlightButton = ( isBorderless ) => css`
+	background-color: ${ color( 'highlight' ) };
+	border-color: ${ color( 'highlight', 'dark' ) };
+	color: ${ isBorderless ? color( 'highlight') : color( 'text-inverted' ) };
+
+	&:hover {
+		background-color: ${ color( 'highlight', 'light' ) };
+	}
+
+	&:disabled,
+	&:disabled:hover {
+		background-color: ${ color( 'highlight', 10 ) };
+		border-color: ${ color( 'highlight', 20 ) };
+	}
+`;
+
+const scaryButton = ( isBorderless ) => css`
+	background-color: ${ color( 'error' ) };
+	border-color: ${ color( 'error', 'dark' ) };
+	color: ${ isBorderless ? color( 'error' ) : color( 'text-inverted' ) };
+
+	&:hover {
+		background-color: ${ color( 'error', 'light' ) };
+	}
+
+	&:disabled,
+	&:disabled:hover {
+		background-color: ${ color( 'error', 10 ) };
+		border-color: ${ color( 'error', 20 ) };
+	}
+`;
+
+const compactButton = () => css`
+	font-size: 12px;
+	height: 45px;
+	padding: 9px 30px;
+`;
+
+const largeButton = () => css`
+`;
+
+export const Button = styled.button( ( {
+	borderless,
+	compact,
+	highlight,
+	large,
+	primary,
+	scary,
+	secondary,
+} ) => {
+	return css`
+		${ baseButton };
+
+		${ scary && scaryButton( borderless ) };
+		${ highlight && highlightButton( borderless ) };
+		${ secondary && secondaryButton( borderless ) };
+		${ primary && primaryButton( borderless ) };
+
+		${ borderless && borderlessButton };
+
+		${ compact && compactButton( borderless ) };
+		${ large && largeButton( borderless ) };
+	`;
+} );

--- a/packages/components/src/crowdsignal-footer/README.md
+++ b/packages/components/src/crowdsignal-footer/README.md
@@ -1,0 +1,3 @@
+# Crowdsignal Footer
+
+

--- a/packages/components/src/crowdsignal-footer/index.js
+++ b/packages/components/src/crowdsignal-footer/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Footer,
+	FooterLink,
+	Logo,
+	UpgradeTooltip,
+} from './styles.js';
+
+const CrowdsignalFooterUpgradeLink = ( { source } ) => (
+	<UpgradeTooltip>
+		{ createInterpolateElement(
+			__(
+				'Hide Crowdsignal ads <br />and get unlimited <br /> signals - <a>Upgrade</a>',
+				'components'
+			),
+			{
+				br: <br />,
+				a: (
+					<a
+						href={ `https://crowdsignal.com/pricing?ref=${ source }` }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		) }
+	</UpgradeTooltip>
+);
+
+const CrowdsignalFooter = ( {
+	logo,
+	message,
+	source,
+	style = {},
+	upgradeLink,
+} ) => (
+	<Footer>
+		<FooterLink
+			as="a"
+			href={ `https://crowdsignal.com?ref=${ source }` }
+			target="_blank"
+			rel="noopener noreferrer"
+			style={ style }
+		>
+			{ message }
+		</FooterLink>
+
+		{ upgradeLink && (
+			<Tooltip text={ <UpgradeTooltip source={ source } /> } position="top center">
+				<a
+					href={ `https://crowdsignal.com/pricing?ref=${ source }` }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ __( 'Hide', 'components' ) }
+				</a>
+			</Tooltip>
+		) }
+
+		<Logo
+			href={ `https://crowdsignal.com?ref=${ source }` }
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<img
+				src="https://app.crowdsignal.com/images/svg/cs-logo-dots.svg"
+				alt="Crowdsignal"
+			/>
+		</Logo>
+	</Footer>
+);
+
+export default CrowdsignalFooter;

--- a/packages/components/src/crowdsignal-footer/styles.js
+++ b/packages/components/src/crowdsignal-footer/styles.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { color } from '@crowdsignal/styles';
+
+export const Footer = styled.div`
+	align-items: center;
+	display: flex;
+	margin-top: 16px;
+	width: 100%;
+`;
+
+export const FooterLink = styled.div( ( { style } ) => {
+	return css`
+		display: inline-flex;
+		text-decoration: none;
+		text-transform: uppercase;
+		vertical-align: middle;
+
+		&:not(:hover) {
+			color: ${ style.color || color( 'text' ) };
+			opacity: 0.4;
+		}
+	`;
+} );
+
+export const UpgradeTooltip = styled.span`
+	background-color: #a4a4a4;
+	border: 0;
+	border-radius: 2px;
+	box-shadow: none;
+	color: ${ color( 'text-inverted' ) };
+	cursor: pointer;
+	display: inline-flex;
+	font-family: sans-serif;
+	font-size: 10px;
+	margin-left: 16px;
+	padding: 2px 8px;
+	text-decoration: none;
+	vertical-align: middle;
+`;
+
+export const Logo = styled.div`
+	display: inline-flex;
+`;

--- a/packages/components/src/crowdsignal-footer/util.js
+++ b/packages/components/src/crowdsignal-footer/util.js
@@ -1,0 +1,5 @@
+export const pricingLink = ( { source } ) => ( {
+	href: `https://crowdsignal.com/pricing?ref=${ source }`
+	target: 'blank',
+	rel: 'noopener noreferrer',
+} );

--- a/packages/components/src/form-text-input/index.js
+++ b/packages/components/src/form-text-input/index.js
@@ -1,0 +1,20 @@
+/**
+ * Style dependencies
+ */
+import { InputPrefix, InputWrapper, Input } from './styles';
+
+const FormTextInput = ( { className, compact, error, inputRef, prefix, style, warning, ...props } ) => {
+	return (
+		<InputWrapper className={ className } style={ style }>
+			{ prefix && (
+				<InputPrefix>
+					{ prefix }
+				</InputPrefix>
+			) }
+
+			<Input ref={ inputRef } type="text" { ...props } />
+		</InputWrapper>
+	);
+};
+
+export default FormTextInput;

--- a/packages/components/src/form-text-input/styles.js
+++ b/packages/components/src/form-text-input/styles.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+const InputWrapper = styled.div( ( { error, warning } ) => {
+	let borderColor = color( 'border' );
+
+	if ( error ) {
+		borderColor = color( 'error' );
+	}
+
+	if ( warning ) {
+		borderColor = color( 'warning' );
+	}
+
+	return css`
+		border: 1px solid ${ borderColor };
+		border-radius: 5px;
+		box-shadow: none;
+		box-sizing: border-box;
+		display: flex;
+		font-size: 12px;
+		height: 32px;
+		line-height: 30px;
+		margin: 0;
+		padding: 0 8px;
+		width: 100%;
+	`;
+} );
+
+const InputPrefix = styled.span`
+	color: ${ color( 'text-subtle' ) };
+`;
+
+const Input = styled.input`
+	border: 0;
+	box-shadow: none;
+	box-sizing: border-box;
+	flex: 1;
+	height: 30px;
+	line-height: 30px;
+	margin: 0;
+	outline: 0;
+	padding: 0;
+`;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,0 +1,4 @@
+export { default as Button } from './button';
+export { default as CrowdsignalFooter } from './crowdsignal-footer';
+// export { default as FormTextInput } from './form-text-input';
+export { default as StyleProvider } from './style-provider';

--- a/packages/components/src/style-provider/README.md
+++ b/packages/components/src/style-provider/README.md
@@ -1,0 +1,39 @@
+# StyleProvider
+
+`<StyleProvider>` acts as a namespace boundary for styled components.  
+
+## Usage
+
+```javascript
+import { StyleProvider } from '@crowdsignal/components';
+
+const WrapperComponent = () => (
+	<StyleProvider namespace="my-app">
+		<App />
+	</StyleProvider>
+);
+```
+
+## Props
+
+### namespace
+
+All classes from inside the `<StyleProvider>` instance will generate class names in the following format: `{ namespace }-{ hash }`.
+
+- Type: `String`
+- Required: Yes
+
+### container
+
+An optional container to inject the generated CSS into. By default styles are injected into `document.head`.
+
+- Type: `Element`
+- Required: No
+- Default: `document.head`
+
+### reset
+
+When set to `true`, the reset stylesheet will be injected along with child styles.
+
+- Type: `Boolean`
+- Required: No

--- a/packages/components/src/style-provider/index.js
+++ b/packages/components/src/style-provider/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { CacheProvider, Global } from '@emotion/core';
+import createCache from '@emotion/cache';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { reset as resetCSS } from '@crowdsignal/styles';
+
+const StyleProvider = ( { container, children, namespace, reset } ) => {
+	const [ cache ] = useState(
+		createCache( {
+			key: namespace,
+			container: container || document.head,
+		} )
+	);
+
+	return (
+		<CacheProvider value={ cache }>
+			{ reset && (
+				<Global styles={ resetCSS } />
+			) }
+
+			{ children }
+		</CacheProvider>
+	);
+};
+
+export default StyleProvider;


### PR DESCRIPTION
This package will be the host of our main shared component library.  
For a start, I added `<CrowdsignalFooter>` and `<StyleProvider>` which are required by the feedback widget.

In addition, I also migrated our old `<Button>` and `<FormTextInput>` components, but decided not to use them in the widget after all, as it has its own distinct look and making it look like the dashboard could take away from it.  
But as they're already moved over, it doesn't hurt to have them included.

Depends on #4.