### PR TITLE
Add @crowdsignal/feedback-widget

### DIFF
--- a/apps/feedback-widget/README.md
+++ b/apps/feedback-widget/README.md
@@ -1,0 +1,14 @@
+# Feedback widget
+
+Embed the feedback widget on your page and collect feedback with Crowdsignal.com.
+
+## Usage
+
+Add the following JS snippet to enable the feedback widget to your page. Make sure to replace `surveyId` with a valid feedback survey ID.
+
+```html
+<script src="https://app.crowdsignal.com/js/feedback-1.0.0.js"></script>
+<script>
+    crowdsignal.FeedbackWidget( surveyId );
+</script>
+```

--- a/apps/feedback-widget/babel.config.js
+++ b/apps/feedback-widget/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	presets: [
+		'@automattic/calypso-build/babel/wordpress-element',
+		'@automattic/calypso-build/babel/default',
+	],
+	plugins: [
+		'@babel/plugin-transform-runtime',
+		'@wordpress/babel-plugin-import-jsx-pragma',
+	],
+};

--- a/apps/feedback-widget/package.json
+++ b/apps/feedback-widget/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@crowdsignal/feedback-widget",
+  "version": "1.0.0",
+  "description": "Feedback button widget for Crowdsignal.com.",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "author": "Automattic Inc.",
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/feedback-widget/README.md",
+  "license": "GPL-2.0-or-later",
+  "main": "src/index.js",
+  "browser": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "scripts": {
+    "build": "calypso-build ./src/index.js",
+    "build:wp": "calypso-build ./src/index.js --env WP"
+  },
+  "dependencies": {
+    "@crowdsignal/components": "^0.1.0",
+    "@crowdsignal/rest-api": "^0.1.0",
+    "@crowdsignal/styles": "^0.1.0",
+    "@wordpress/components": "^14.1.1",
+    "@wordpress/element": "^3.1.1",
+    "@wordpress/i18n": "^4.1.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/apps/feedback-widget/src/constants.js
+++ b/apps/feedback-widget/src/constants.js
@@ -1,0 +1,16 @@
+export const View = Object.freeze( {
+	QUESTION: 'question',
+	SUBMIT: 'submit',
+} );
+
+export const Status = Object.freeze( {
+	OPEN: 'open',
+	CLOSED: 'closed',
+	CLOSED_AFTER: 'closed-after',
+} );
+
+export const ToggleMode = Object.freeze( {
+	CLICK: 'click',
+	HOVER: 'hover',
+	PAGE_LOAD: 'load',
+} );

--- a/apps/feedback-widget/src/form.js
+++ b/apps/feedback-widget/src/form.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { RawHTML, useState } from '@wordpress/element';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { updateFeedbackResponse } from '@crowdsignal/rest-api';
+
+/**
+ * Style dependencies
+ */
+import { Form, Input, Header, Button } from './styles/form-styles.js';
+
+const FeedbackForm = ( {
+	onSubmit,
+	settings,
+	surveyId,
+} ) => {
+	const [ errors, setErrors ] = useState( {} );
+	const [ submitting, setSubmitting ] = useState( false );
+	const [ formData, setFormData ] = useState( {
+		feedback: '',
+		email: '',
+	} );
+
+	const handleChange = ( field ) =>
+		( event ) => setFormData( {
+			...formData,
+			[ field ]: event.target.value,
+		} );
+
+	const handleSubmit = async ( event ) => {
+		event.preventDefault();
+
+		setSubmitting( true );
+
+		const validation = {
+			feedback: isEmpty( formData.feedback ),
+			email:
+				settings.requireEmail &&
+				( isEmpty( formData.email ) || formData.email.match( /^\s+@\s+$/ ) ),
+		};
+		setErrors( validation );
+
+		if ( validation.feedback || validation.email ) {
+			return;
+		}
+
+		try {
+			await updateFeedbackResponse( surveyId, formData );
+			onSubmit();
+		} finally {
+			setSubmitting( false );
+		}
+	};
+
+	const { text, style } = settings;
+
+	return (
+		<Form onSubmit={ handleSubmit }>
+			<Header>
+				<RawHTML>{ text.header }</RawHTML>
+			</Header>
+
+			<Input
+				as="textarea"
+				error={ errors.feedback }
+				placeholder={ text.feedback }
+				rows={ 6 }
+				value={ formData.feedback }
+				onChange={ handleChange( 'feedback' ) }
+				{ ...style }
+			/>
+
+			<Input
+				error={ errors.email }
+				placeholder={ text.email }
+				value={ formData.email }
+				onChange={ handleChange( 'email' ) }
+				{ ...style }
+			/>
+
+			<Button primary type="submit" disabled={ submitting }>
+				{ text.submitButton }
+			</Button>
+		</Form>
+	);
+};
+
+export default FeedbackForm;

--- a/apps/feedback-widget/src/hooks.js
+++ b/apps/feedback-widget/src/hooks.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+export const useFeedbackSurvey = ( surveyId ) => {
+	const [ survey, setSurvey ] = useState( null );
+
+	useEffect( () => {
+		try {
+			setSurvey( await fetchSurvey( surveyId ) );
+		} catch ( error ) {
+			console.error( 'Unexpected!' );
+		}
+	}, [ surveyId ] );
+
+	return survey;
+};

--- a/apps/feedback-widget/src/index.js
+++ b/apps/feedback-widget/src/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/core';
+
+import { render } from '@wordpress/element';
+import { isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { StyleProvider } from '@crowdsignal/components';
+import FeedbackWidget from './widget';
+
+const renderWidget = ( surveyId ) => {
+	const wrapperElement = document.createElement( 'div' );
+	document.body.appendChild( wrapperElement );
+
+	const shadowRoot = wrapperElement.attachShadow( { mode: 'closed' } );
+
+	render(
+		<StyleProvider
+			reset
+			namespace="feedback-widget"
+			container={ shadowRoot }
+		>
+			<FeedbackWidget surveyId={ surveyId } />
+		</StyleProvider>,
+		shadowRoot
+	);
+};
+
+export default renderWidget;
+
+export { default as FeedbackWidget } from './widget';

--- a/apps/feedback-widget/src/popover.js
+++ b/apps/feedback-widget/src/popover.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CrowdsignalFooter } from '@crowdsignal/components';
+import FeedbackForm from './form';
+import FeedbackSubmit from './submit';
+import { View } from './constants';
+
+/**
+ * Style dependencies
+ */
+import { Popover } from './styles/popover-styles';
+
+const FeedbackPopover = ( { settings, surveyId } ) => {
+	const [ currentView, setCurrentView ] = useState( View.QUESTION );
+	const [ height, setHeight ] = useState( 'auto' );
+
+	const popover = useRef( null );
+
+	const handleSubmit = () => {
+		setHeight( `${ popover.current.offsetHeight }px` );
+		setCurrentView( View.SUBMIT );
+	};
+
+	return (
+		<Popover
+			ref={ popover }
+			height={ height }
+			{ ...settings.style }
+		>
+			{ currentView === View.QUESTION && (
+				<FeedbackForm
+					surveyId={ surveyId }
+					onSubmit={ handleSubmit }
+					settings={ settings }
+				/>
+			) }
+
+			{ currentView === View.SUBMIT && (
+				<FeedbackSubmit settings={ settings } />
+			) }
+
+			{ settings.showBranding && (
+				<CrowdsignalFooter
+					logo
+					source="feedback-widget"
+					message={ __(
+						'Collect your own feedback with Crowdsignal',
+						'feedback-widget',
+					) }
+				/>
+			) }
+		</Popover>
+	);
+};
+
+export default FeedbackPopover;

--- a/apps/feedback-widget/src/styles/form-styles.js
+++ b/apps/feedback-widget/src/styles/form-styles.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { color } from '@crowdsignal/styles';
+
+export const Form = styled.form`
+	align-items: flex-end;
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	width: 100%;
+`;
+
+export const Header = styled.h3( ( {
+	textColor,
+} ) => {
+	return css`
+		color: ${ textColor || color( `text` ) };
+		flex-grow: 1;
+		font-size: 36px;
+		font-weight: bold;
+		margin: 0 0 32px;
+		text-align: left;
+		width: 100%;
+	`;
+} );
+
+const inputError = css`
+	border: 3px solid ${ color( `error` ) };
+	box-sizing: border-box;
+	content: "";
+	display: block;
+	position: absolute;
+	top: -4px;
+	left: -4px;
+	bottom: -4px;
+	right: -4px;
+	z-index: -1;
+`;
+
+export const Input = styled.input( ( {
+	error,
+	textSize,
+} ) => {
+	return css`
+		border: 1px solid ${ color( 'border' ) };
+		box-sizing: border-box;
+		display: flex;
+		font-size: ${ textSize || '18px' };
+		margin: 0 0 24px;
+		outline: 0;
+		padding: 16px;
+		position: relative;
+		width: 100%;
+		z-index: 1;
+
+		${ error && inputError };
+	`;
+} );
+
+export const Button = styled.button( ( {
+	buttonColor,
+	buttonTextColor,
+} ) => {
+	return css`
+		background-color: ${ buttonColor || color( 'primary' ) };
+		border-color: ${ buttonColor || color( 'primary', 'dark' ) };
+		border-radius: 5px;
+		border-width: 1px 1px 2px;
+		box-sizing: border-box;
+		color: ${ buttonTextColor || color( 'text-inverted' ) };
+		cursor: pointer;
+		font-size: 14px;
+		font-weight: bold;
+		height: 45px;
+		padding: 9px 30px;
+		transition: background-color .1s ease-out, border-color .1s ease-out;
+		white-space: nowrap;
+		width: fit-content;
+	`;
+} );

--- a/apps/feedback-widget/src/styles/popover-styles.js
+++ b/apps/feedback-widget/src/styles/popover-styles.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { breakpoint, color } from '@crowdsignal/styles';
+import { wpPopoverStyles } from './wordpress-popover';
+
+// needs to go into the main one!!!
+export const PopoverWrapper = styled.div`
+	display: flex;
+	position: fixed;
+	z-index: 9999999;
+
+	${ props => props.position };
+
+	${ wpPopoverStyles }
+
+	& .components-popover .components-popover__content {
+		backgroundColor: transparent;
+
+	}
+`;
+
+export const Popover = styled.div( ( {
+	backgroundColor,
+	buttonColor,
+	height,
+	textColor,
+} ) => {
+	return css`
+		background-color: ${ backgroundColor || color( 'surface' ) };
+		border-top: 10px solid ${ buttonColor || color( 'secondary' ) };
+		box-shadow: 1px 1px 7px ${ color( 'shadow' ) };
+		box-sizing: border-box;
+		color: ${ textColor || color( 'text' ) };
+		display: flex;
+		flex-direction: column;
+		height: ${ height || 'auto' };
+		max-height: 480px;
+		outline: 0;
+		overflow-y: scroll;
+		padding: 24px;
+		width: 240px;
+		text-align: left;
+		z-index: 100;
+
+		${ breakpoint( '>360px' ) } {
+			max-height: 640px;
+			width: 300px;
+		}
+
+		${ breakpoint( '>480px' ) } {
+			max-height: auto;
+			width: 380px;
+		}
+	`;
+} );

--- a/apps/feedback-widget/src/styles/toggle-styles.js
+++ b/apps/feedback-widget/src/styles/toggle-styles.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { color } from '@crowdsignal/styles';
+
+const verticalToggleWrapper = ( { align } ) => {
+	return css`
+		margin-top: -50%;
+		transform-origin: top ${ align === 'right' ? 'left' : 'right' };
+		transform: rotateZ(270deg) ${ align === 'right' ? 'translateX(-100%)' : 'translateY(-100%)' };
+	`;
+};
+
+export const ToggleWrapper = styled.div`
+	margin: 0;
+
+	${ props => props.isVertical && verticalToggleWrapper( props ) };
+`;
+
+// is it the icon?
+const activeToggle = css`
+	padding-left: 12px;
+`;
+
+export const Toggle = styled.button( ( {
+	backgroundColor,
+	isOpen,
+	textColor,
+} ) => {
+	return css`
+		align-items: center;
+		box-shadow: 1px 1px 7px ${ color( 'shadow' ) };
+		border: 0;
+		cursor: pointer;
+		background-color: ${ backgroundColor || color( 'secondary' ) };
+		color: ${ textColor || color( 'text-inverted' ) };
+		display: flex;
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 1.5;
+		padding: 10px 16px;
+		white-space: nowrap;
+
+		> svg {
+			fill: currentColor;
+		}
+
+		${ isOpen && activeToggle() };
+	`;
+} );

--- a/apps/feedback-widget/src/styles/wordpress-popover.js
+++ b/apps/feedback-widget/src/styles/wordpress-popover.js
@@ -1,0 +1,234 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/core';
+
+export const wpPopoverStyles = () => {
+	return css`
+		& .components-popover {
+			position: fixed;
+			z-index: 1000000;
+			top: 0;
+			left: 0;
+			opacity: 0;
+		}
+
+		& .components-popover.is-expanded, .components-popover[data-x-axis][data-y-axis] {
+			opacity: 1;
+		}
+
+		& .components-popover.is-expanded {
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			z-index: 1000000 !important;
+		}
+
+		& .components-popover:not(.is-without-arrow) {
+			margin-left: 2px;
+		}
+
+		& .components-popover:not(.is-without-arrow)::before {
+			border: 8px solid #ccc;
+		}
+
+		& .components-popover:not(.is-without-arrow).is-alternate::before {
+			border-color: #1e1e1e;
+		}
+
+		& .components-popover:not(.is-without-arrow)::after {
+			border: 8px solid #fff;
+		}
+
+		& .components-popover:not(.is-without-arrow)::before, .components-popover:not(.is-without-arrow)::after {
+			content: "";
+			position: absolute;
+			height: 0;
+			width: 0;
+			line-height: 0;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=top] {
+			margin-top: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=top]::before {
+			bottom: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=top]::after {
+			bottom: -6px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=top]::before, .components-popover:not(.is-without-arrow)[data-y-axis=top]::after {
+			border-bottom: none;
+			border-left-color: transparent;
+			border-right-color: transparent;
+			border-top-style: solid;
+			margin-left: -10px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=bottom] {
+			margin-top: 8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=bottom]::before {
+			top: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=bottom]::after {
+			top: -6px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=bottom]::before, .components-popover:not(.is-without-arrow)[data-y-axis=bottom]::after {
+			border-bottom-style: solid;
+			border-left-color: transparent;
+			border-right-color: transparent;
+			border-top: none;
+			margin-left: -10px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=left] {
+			margin-left: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=left]::before {
+			right: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=left]::after {
+			right: -6px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=left]::before, .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=left]::after {
+			border-bottom-color: transparent;
+			border-left-style: solid;
+			border-right: none;
+			border-top-color: transparent;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=right] {
+			margin-left: 8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=right]::before {
+			left: -8px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=right]::after {
+			left: -6px;
+		}
+
+		& .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=right]::before, .components-popover:not(.is-without-arrow)[data-y-axis=middle][data-x-axis=right]::after {
+			border-bottom-color: transparent;
+			border-left: none;
+			border-right-style: solid;
+			border-top-color: transparent;
+		}
+
+		& .components-popover[data-y-axis=top] {
+			bottom: 100%;
+		}
+
+		& .components-popover[data-y-axis=bottom] {
+			top: 100%;
+		}
+
+		& .components-popover[data-y-axis=middle] {
+			align-items: center;
+			display: flex;
+		}
+
+		& .components-popover.is-from-top {
+			margin-top: 12px;
+		}
+
+		& .components-popover.is-from-bottom {
+			margin-top: -12px;
+		}
+
+		& .components-popover.is-from-left:not(.is-from-top):not(.is-from-bottom) {
+			margin-left: 12px;
+		}
+
+		& .components-popover.is-from-right:not(.is-from-top):not(.is-from-bottom) {
+			margin-right: 12px;
+		}
+
+		& .components-popover__content {
+			height: 100%;
+			background: #fff;
+			border: 1px solid #ccc;
+			box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+			border-radius: 2px;
+		}
+
+		& .is-alternate .components-popover__content {
+			border: 1px solid #1e1e1e;
+			box-shadow: none;
+		}
+
+		& .components-popover .components-popover__content {
+			position: absolute;
+			height: auto;
+			overflow-y: auto;
+		}
+
+		& .components-popover.is-expanded .components-popover__content {
+			position: static;
+			height: calc(100% - 48px);
+			overflow-y: visible;
+			min-width: auto;
+			border: none;
+			border-top: 1px solid #1e1e1e;
+		}
+
+		& .components-popover[data-y-axis=top] .components-popover__content {
+			bottom: 100%;
+		}
+
+		& .components-popover[data-x-axis=center] .components-popover__content {
+			left: 50%;
+			transform: translateX(-50%);
+		}
+
+		& .components-popover[data-x-axis=right] .components-popover__content {
+			position: absolute;
+			left: 100%;
+		}
+
+		& .components-popover:not([data-y-axis=middle])[data-x-axis=right] .components-popover__content {
+			margin-left: -25px;
+		}
+
+		& .components-popover[data-x-axis=left] .components-popover__content {
+			position: absolute;
+			right: 100%;
+		}
+
+		& .components-popover:not([data-y-axis=middle])[data-x-axis=left] .components-popover__content {
+			margin-right: -25px;
+		}
+
+		& .components-popover__header {
+			align-items: center;
+			background: #fff;
+			display: flex;
+			height: 48px;
+			justify-content: space-between;
+			padding: 0 8px 0 16px;
+		}
+
+		& .components-popover__header-title {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			width: 100%;
+		}
+
+		& .components-popover__close.components-button {
+			z-index: 5;
+		}
+	`;
+};

--- a/apps/feedback-widget/src/submit.js
+++ b/apps/feedback-widget/src/submit.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Header } from './styles/form-styles.js'
+
+const FeedbackSubmit = ( { settings } ) => (
+	<Header { ...settings.style }>
+		<RawHTML>{ settings.text.submitMessage }</RawHTML>
+	</Header>
+);
+
+export default FeedbackSubmit;

--- a/apps/feedback-widget/src/toggle.js
+++ b/apps/feedback-widget/src/toggle.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import {
+	forwardRef,
+	RawHTML,
+	useCallback,
+	useEffect,
+	useLayoutEffect
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleMode } from './constants';
+
+/**
+ * Style dependencies
+ */
+import { ToggleWrapper, Toggle } from './styles/toggle-styles.js';
+
+const FeedbackToggle = ( { isOpen, onClick, onToggle, settings }, ref ) => {
+	const { position, style, text, toggleMode } = settings;
+	const [ y, x ] = position.split( ' ' );
+
+	useLayoutEffect( onToggle, [ isOpen ] );
+
+	useEffect( () => {
+		if ( isOpen || toggleMode !== ToggleMode.PAGE_LOAD ) {
+			return;
+		}
+
+		onClick();
+	}, [ toggleMode, isOpen ] );
+
+	const handleHover = useCallback( () => {
+		if ( isOpen || settings.toggleMode !== ToggleMode.HOVER ) {
+			return;
+		}
+
+		onClick();
+	}, [ settings.toggleMode, isOpen ] );
+
+	return (
+		<ToggleWrapper
+			align={ x }
+			isVertical={ y === 'center' }
+		>
+			<Toggle
+				as="button"
+				ref={ ref }
+				vertical={ y === 'center' }
+				onClick={ onClick }
+				onMouseEnter={ handleHover }
+			>
+				{ ! isOpen && (
+					<RawHTML>{ text.toggle }</RawHTML>
+				) }
+
+				{ isOpen && (
+					<>
+						{ __( 'Close', 'feedback-widget' ) }
+					</>
+				) }
+			</Toggle>
+		</ToggleWrapper>
+	);
+};
+
+export default forwardRef( FeedbackToggle );

--- a/apps/feedback-widget/src/util.js
+++ b/apps/feedback-widget/src/util.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+
+const addFrameOffsets = ( offset, frame ) => ( {
+	left: offset.left + frame.x + window.scrollX,
+	right:
+		offset.right +
+		( window.innerWidth > frame.left + frame.width
+			? window.innerWidth - frame.left - frame.width
+			: 0 ),
+	top: offset.top + frame.y + window.scrollY,
+	bottom:
+		offset.bottom +
+		( window.innerHeight > frame.top + frame.height
+			? window.innerHeight - frame.top - frame.height
+			: 0 ),
+} );
+
+const getToggleHorizontalPosition = ( align, width, offset ) => {
+	return {
+		left: align === 'left' ? offset.left : null,
+		right: align === 'right' ? offset.right : null,
+	};
+};
+
+const getToggleVerticalPosition = ( verticalAlign, height, offset ) => {
+	if ( verticalAlign === 'center' ) {
+		return {
+			top: ( window.innerHeight - height ) / 2,
+			bottom: null,
+		};
+	}
+
+	return {
+		top: verticalAlign === 'top' ? offset.top : null,
+		bottom: verticalAlign === 'bottom' ? offset.bottom : null,
+	};
+};
+
+export const getTogglePosition = (
+	position,
+	width,
+	height,
+	padding,
+	frameElement = null
+) => {
+	const [ y, x ] = position.split( ' ' );
+
+	let offset = {
+		left: isObject( padding ) ? padding.left : padding,
+		right: isObject( padding ) ? padding.right : padding,
+		top: isObject( padding ) ? padding.top : padding,
+		bottom: isObject( padding ) ? padding.bottom : padding,
+	};
+
+	if ( frameElement ) {
+		offset = addFrameOffsets(
+			offset,
+			frameElement.getBoundingClientRect()
+		);
+	}
+
+	return {
+		...getToggleHorizontalPosition( x, width, offset ),
+		...getToggleVerticalPosition( y, height, offset ),
+	};
+};
+
+export const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
+	if ( verticalAlign !== 'center' ) {
+		return position;
+	}
+
+	return {
+		...position,
+		left: position.left !== null ? position.left - width + height : null,
+		right: position.right !== null ? position.right - width + height : null,
+	};
+};
+
+export const getPopoverPosition = ( position ) => {
+	const [ y, x ] = position.split( ' ' );
+
+	if ( y !== 'center' ) {
+		return;
+	}
+
+	return x === 'left' ? 'middle right' : 'middle left';
+};

--- a/apps/feedback-widget/src/widget.js
+++ b/apps/feedback-widget/src/widget.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { Dropdown } from '@wordpress/components';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { fetchFeedbackSurvey } from '@crowdsignal/rest-api';
+import FeedbackPopover from './popover';
+import FeedbackToggle from './toggle';
+import { adjustFrameOffset, getPopoverPosition, getTogglePosition } from './util';
+import { ToggleMode } from './constants'
+
+/**
+ * Style dependencies
+ */
+import { PopoverWrapper } from './styles/popover-styles';
+
+const settings = {
+	emailRequired: true,
+	position: 'center right',
+	style: {
+	},
+	text: {
+		email: 'Your email',
+		feedback: 'Please give some feedback',
+		header: 'Oh, hi Mark!',
+		submitButton: 'All in!',
+		submitMessage: 'Much success!',
+		toggle: 'Get to the chopper!',
+	},
+	toggleMode: ToggleMode.CLICK,
+	showBranding: true,
+};
+
+const FeedbackWidget = ( {
+	surveyId,
+} ) => {
+	const [ survey, setSurvey ] = useState( null );
+	const [ position, setPosition ] = useState( {} );
+
+	const toggle = useRef( null );
+
+	const updatePosition = useCallback( () => {
+		const [ y, x ] = settings.position.split( ' ' );
+
+		setPosition(
+			adjustFrameOffset(
+				getTogglePosition(
+					settings.position,
+					toggle.current.offsetWidth,
+					y === 'center'
+						? toggle.current.offsetWidth
+						: toggle.current.offsetHeight,
+					{
+						top: 20,
+						bottom: 20,
+						left: y === 'center' ? 0 : 20,
+						right: y === 'center' ? 0 : 20,
+					},
+					document.body
+				),
+				y,
+				toggle.current.offsetWidth,
+				toggle.current.offsetHeight,
+			)
+		);
+	}, [ toggle.current ] );
+
+	useLayoutEffect( () => {
+		updatePosition();
+	}, [ updatePosition ] );
+
+	useEffect( () => {
+		const fetchData = async () => {
+			const survey = await fetchFeedbackSurvey( surveyId );
+			console.log( survey );
+		};
+
+		fetchData();
+	}, [] );
+
+	return (
+		<PopoverWrapper position={ position }>
+			<Dropdown
+				popoverProps={ {
+					position: getPopoverPosition( settings.position ),
+				} }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<FeedbackToggle
+						ref={ toggle }
+						isOpen={ isOpen }
+						onClick={ onToggle }
+						onToggle={ updatePosition }
+						settings={ settings }
+					/>
+				) }
+				renderContent={ () => (
+					<FeedbackPopover surveyId={ surveyId } settings={ settings } />
+				) }
+			/>
+		</PopoverWrapper>
+	);
+};
+
+export default FeedbackWidget;

--- a/apps/feedback-widget/webpack.config.js
+++ b/apps/feedback-widget/webpack.config.js
@@ -1,0 +1,39 @@
+const path = require( 'path' );
+const package = require( './package.json' );
+const webpack = require( 'webpack' );
+const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
+
+function getWebpackConfig( env, { entry, ...argv } ) {
+	const baseConfig = getBaseConfig( env, argv );
+
+	const buildSuffix = argv.env.WP === 'WP' ? '.wp' : '';
+
+	return {
+		...baseConfig,
+		output: {
+			...baseConfig.output,
+			filename: `feedback-${ package.version }${ buildSuffix }.js`,
+			library: {
+				name: [ 'crowdsignal', 'FeedbackWidget' ],
+				type: 'assign',
+				export: 'default',
+			},
+		},
+		plugins: [
+			...baseConfig.plugins.map(
+				( plugin ) => {
+					if ( plugin.constructor.name !== 'DefinePlugin' ) {
+						return plugin;
+					}
+
+					return new webpack.DefinePlugin( {
+						...plugin.definitions,
+						'process.env.COMPONENT_SYSTEM_PHASE': JSON.stringify( 1 )
+					} );
+				}
+			),
+		]
+	};
+}
+
+module.exports = getWebpackConfig;


### PR DESCRIPTION
This adds a stand-alone implementation of our Feedback Button widget from Crowdsignal Forms.

**Note:** The feedback button block relies on `<Dropdown>` from `@wordpress/components` for the popover. I've had to manually copy the CSS for that for the component to work correctly here although it's still not 100% ideal. As a long term solution we should implement our own version of that and avoid relying on `@wordpress/components` outside of block editor.

**Note:** The settings are temporarily hardcoded as a `settings` object inside `widget.js` until we have proper API support for them.

Depends on #3 and #5.
 
# Testing

- Run `yarn workspace @crowdsignal/feedback-widget run build` to build the widget.
- Run `yarn workspace @crowdsignal/feedback-widget run build:wp` to build a cut-down version of the widget for WordPress sites. Without including libraries that WordPress already provides.
- Test the widget by including the script on a page and creating a `FeedbackWidget` through either a script or manually.