### PR TITLE
Add @crowdsignal/router

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,58 @@
+# @crowdsignal/router
+
+A single-page-application router that runs on top of `@wordpress/element`.
+
+## Usage
+
+```javascript
+import { Router, Route, Switch } from '@crowdsignal/router';
+
+const App = () => (
+	<Router>
+		<Switch>
+			<Route path="/page/:pageId" component={ Page } />
+			<Route path="/" component={ Home } />
+			<Route path="/*_" component={ NotFound } />
+		</Switch>
+	</Router>
+);
+```
+
+## Router
+
+Wrapper component responsible for maintaining up-to-date information on the current location and passing it down to its children via the context API.  
+It will automatically catch any local links within the application but this behavior can be restricted by using `allowedRoutes`.
+Usually, you'd wrap the entire application with a single `<Router>`.
+
+### Params
+
+**allowedRoutes**: Only local URLs matching this regular expression will trigger the router.
+
+- Type: RegExp
+- Required: No
+- Default: `/.*/i`
+
+## Route
+
+The `Route` component will render its `component` whenever the current URL matches the `path`. If the path contains named segments, like `:pageId` in the above example, they're passed as props to the `component` as well.
+
+### Params
+
+**component**: The component that should be rendered whenever the route is a match.
+
+- Type: Component
+- Required: Yes
+
+**path**: The path to match against.
+
+- Type: String
+- Required: Yes
+
+
+## Switch
+
+When `Route` components are wrapped with a `Switch`, only the first one with a matching path will be rendered.
+
+### Params
+
+None.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@crowdsignal/router",
+  "version": "0.1.0",
+  "description": "Simple frontend router for @wordpress/element.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal",
+    "router"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/router/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@wordpress/element": "^3.1.1",
+    "history": "^5.0.0",
+    "lodash": "^4.17.21",
+    "route-parser": "^0.0.5"
+  }
+}

--- a/packages/router/src/context.js
+++ b/packages/router/src/context.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+import { createBrowserHistory } from 'history';
+
+/**
+ * Internal dependencies
+ */
+import { parseLocation } from './util';
+
+export const history = createBrowserHistory();
+
+export const RouterContext = createContext( parseLocation( history.location ) );

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -1,0 +1,3 @@
+export * from './route';
+export * from './router';
+export * from './switch';

--- a/packages/router/src/route.js
+++ b/packages/router/src/route.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { createElement, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { RouterContext } from './context';
+import { matchRoute } from './util';
+
+export const Route = ( { component, path } ) => {
+	const currentLocation = useContext( RouterContext );
+
+	const match = matchRoute( path, currentLocation.path );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	return createElement( component, { ...match, ...currentLocation.query } );
+};

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { RouterContext, history } from './context';
+import { getLinkElement, hasLocalTarget, parseLocation } from './util';
+
+export const Router = ( { children, allowedRoutes = /.*/i } ) => {
+	const [ route, setRoute ] = useState( parseLocation( history.location ) );
+
+	const handleRouteChange = useCallback(
+		( historyEvent ) => setRoute( parseLocation( historyEvent.location ) ),
+		[ setRoute ]
+	);
+
+	const handleLinkClick = useCallback( ( event ) => {
+		const linkElement = getLinkElement( event.target );
+
+		if ( ! linkElement || ! hasLocalTarget( linkElement, allowedRoutes ) ) {
+			return;
+		}
+
+		const url = new URL( linkElement.href );
+
+		event.preventDefault();
+		history.push( `${ url.pathname }${ url.search }` );
+	}, [] );
+
+	useEffect( () => {
+		const unsubscribe = history.listen( handleRouteChange );
+		// eslint-disable-next-line @wordpress/no-global-event-listener
+		window.addEventListener( 'click', handleLinkClick );
+
+		return () => {
+			unsubscribe();
+			// eslint-disable-next-line @wordpress/no-global-event-listener
+			window.removeEventListener( 'click', handleLinkClick );
+		};
+	}, [] );
+
+	return (
+		<RouterContext.Provider value={ route }>
+			{ children }
+		</RouterContext.Provider>
+	);
+};

--- a/packages/router/src/switch.js
+++ b/packages/router/src/switch.js
@@ -1,0 +1,36 @@
+/**
+ * External components
+ */
+import {
+	Children,
+	cloneElement,
+	isValidElement,
+	useContext,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { RouterContext } from './context';
+import { matchRoute } from './util';
+
+export const Switch = ( { children } ) => {
+	const currentLocation = useContext( RouterContext );
+
+	let match = null;
+
+	Children.forEach( children, ( child ) => {
+		if ( ! isValidElement( child ) ) {
+			return;
+		}
+
+		match =
+			! match &&
+			child.props.path &&
+			matchRoute( child.props.path, currentLocation.path )
+				? child
+				: match;
+	} );
+
+	return cloneElement( match );
+};

--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { fromPairs, isUndefined, map, split, trimStart } from 'lodash';
+import RouteParser from 'route-parser';
+
+/**
+ * Parses query strings and returns an object.
+ *
+ * @param  {string} queryString String to parse.
+ * @return {Object}             Query params.
+ */
+export const parseQuery = ( queryString ) => {
+	const queryParams = map(
+		split( trimStart( queryString, '?' ), '&' ),
+		( param ) => {
+			const [ key, value ] = split( param, '=' );
+
+			return [ key, ! isUndefined( value ) ? value : true ];
+		}
+	);
+
+	return fromPairs( queryParams );
+};
+
+/**
+ * Converts a Location object to the router's internal format.
+ *
+ * @param  {Location} location Window location.
+ * @return {Object}            Route properties.
+ */
+export const parseLocation = ( location ) => ( {
+	path: location.pathname,
+	hash: location.hash,
+	query: parseQuery( location.search ),
+} );
+
+/**
+ * Returns the wrapping <a> element or null if none exists.
+ *
+ * @param  {Node} element Element to inspect.
+ * @return {Node}         Wrapping <a> element.
+ */
+export const getLinkElement = ( element ) => {
+	if ( ! element ) {
+		return null;
+	}
+
+	return ! element.nodeName.match( /^a$/i )
+		? getLinkElement( element.parentNode )
+		: element;
+};
+
+/**
+ * Returns true if the given element has a href attribute
+ * pointing at the current domain and matching the includePattern.
+ *
+ * @param  {Node}    element        Element to inspect.
+ * @param  {RegExp}  includePattern Only the URLs matching the pattern will be included.
+ * @return {boolean}                True when the element has a matching href attribtue.
+ */
+export const hasLocalTarget = ( element, includePattern ) => {
+	if ( ! element.href || element.target.match( /_?blank$/i ) ) {
+		return false;
+	}
+
+	const url = new URL( element.href );
+
+	return (
+		window.location.origin === url.origin &&
+		url.pathname.match( includePattern )
+	);
+};
+
+/**
+ * Attempts to match the path against the pattern and
+ * returns an object with props when successful.
+ *
+ * @param  {string} pattern Route pattern.
+ * @param  {string} path    Path.
+ * @return {Object}         Matched props. False if the given path is not a match.
+ */
+export const matchRoute = ( pattern, path ) => {
+	const route = new RouteParser( pattern );
+
+	return route.match( path );
+};


### PR DESCRIPTION
This patch adds and implements a new `@crowdsignal/router` which will be used for efficient navigation throughout the new Crowdsignal frontend, while still allowing to maintain compatibility with legacy views.

For the exact description of the API, see `README.md`.

# Testing

Testing instructions can be found in  d63837-code.