### PR TITLE
Add @crowdsignal/hooks

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,23 +2,22 @@
   "name": "@crowdsignal/components",
   "version": "0.1.0",
   "description": "Crowdsignal frontend component library.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
   "keywords": [
     "crowdsignal"
   ],
-  "author": "Automattic Inc.",
   "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/components/README.md",
-  "license": "GPL-2.0-or-later",
-  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
   },
-  "scripts": {
-  },
   "bugs": {
     "url": "https://github.com/Automattic/crowdsignal-ui/issues"
   },
+  "main": "src/index.js",
   "dependencies": {
+    "@crowdsignal/hooks": "^0.1.0",
     "@crowdsignal/styles": "^0.1.0",
     "@wordpress/element": "^3.1.1",
     "@wordpress/i18n": "^4.1.1",

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -1,75 +1,19 @@
 /**
  * External dependencies
  */
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useLayoutEffect, useRef, useState } from '@wordpress/element';
 import classnames from 'classnames';
-import { first, forEach, some } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { useBlur } from '@crowdsignal/hooks';
 import { getPopoverOffset } from './util';
 
 /**
  * Style dependencies
  */
 import { Wrapper } from './styles';
-
-const getDocumentRoots = ( elements ) =>
-	elements
-		.map( ( { current } ) => {
-			return current ? current.ownerDocument : null;
-		} )
-		.filter( ( ownerDocument ) => !! ownerDocument )
-		.reduce(
-			( documents, ownerDocument ) => [
-				...documents,
-				...( documents.includes( ownerDocument )
-					? []
-					: [ ownerDocument ] ),
-			],
-			[]
-		);
-
-export const useOnOutsideClick = ( onOutsideClick, elements = [] ) => {
-	const handleClick = useCallback(
-		( event ) => {
-			const target = first( event.composedPath() );
-
-			if (
-				some(
-					elements,
-					( element ) =>
-						! element.current || element.current.contains( target )
-				)
-			) {
-				return;
-			}
-
-			onOutsideClick();
-		},
-		[ onOutsideClick, ...elements ]
-	);
-
-	useEffect( () => {
-		const documentRoots = getDocumentRoots( elements );
-
-		forEach( documentRoots, ( root ) =>
-			root.addEventListener( 'mousedown', handleClick )
-		);
-
-		return () =>
-			forEach( documentRoots, ( root ) =>
-				root.removeEventListener( 'mousedown', handleClick )
-			);
-	}, [ handleClick, ...elements ] );
-};
 
 const Popover = ( {
 	children,
@@ -87,9 +31,9 @@ const Popover = ( {
 		setOffset(
 			getPopoverOffset( position, popover.current, context.current )
 		);
-	}, [ context.current, popover.current, position ] );
+	}, [ context.current, isVisible, popover.current, position ] );
 
-	useOnOutsideClick( onClose, [ popover, context ] );
+	useBlur( onClose, [ popover, context ] );
 
 	const classes = classnames( 'popover', className );
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,0 +1,3 @@
+# @crowdsignal/hooks
+
+A library containing useful hooks that are used by or in conjuction with Crowdsignal components.

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@crowdsignal/hooks",
+  "version": "0.1.0",
+  "description": "Crowdsignal's component hooks.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/hooks/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@wordpress/element": "^3.1.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -1,0 +1,1 @@
+export { default as useBlur } from './use-blur';

--- a/packages/hooks/src/use-blur/README.md
+++ b/packages/hooks/src/use-blur/README.md
@@ -1,0 +1,46 @@
+# useBlur( callback, elements )
+
+`useBlur` can be used to trigger a callback when all of the elements passed in the second argument have lost focus.  
+
+## Usage
+
+```javascript
+import { useRef, useState } from '@wordpress/element';
+import { useBlur } from '@crowdsignal/hooks';
+
+const Dropdown = () => {
+	const [ isActive, setIsActive ] = useState( false );
+
+	const toggle = useRef();
+	const dropdown = useRef();
+
+	const toggleDropdown = setIsActive( ! isActive );
+
+	useBlur( toggleDropdown, [ toggle, dropdown ] );
+
+	return (
+		<>
+			<button ref={ toggle } onClick={ toggleDropdown }></button>
+
+			{ isActive && (
+				<div ref={ dropdown }>
+					...
+				</div>
+			) }
+		</>
+	);
+};
+```
+
+### Arguments
+
+**callback**: The callback to invoke when all elements have lost focus.
+
+- Type: `Function`
+- Required: Yes
+
+**elements**: Refs for elements to monitor.
+
+- Type: `Array<Ref>`
+- Required: No
+- Default: `[]`

--- a/packages/hooks/src/use-blur/index.js
+++ b/packages/hooks/src/use-blur/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect } from '@wordpress/element';
+import { first, forEach, some } from 'lodash';
+
+const getDocumentRoots = ( elements ) =>
+	elements
+		.map( ( { current } ) => {
+			return current ? current.ownerDocument : null;
+		} )
+		.filter( ( ownerDocument ) => !! ownerDocument )
+		.reduce(
+			( documents, ownerDocument ) => [
+				...documents,
+				...( documents.includes( ownerDocument )
+					? []
+					: [ ownerDocument ] ),
+			],
+			[]
+		);
+
+const useBlur = ( onBlur, elements = [] ) => {
+	const handleClick = useCallback(
+		( event ) => {
+			const target = first( event.composedPath() );
+
+			if (
+				some(
+					elements,
+					( element ) =>
+						! element.current || element.current.contains( target )
+				)
+			) {
+				return;
+			}
+
+			onBlur();
+		},
+		[ onBlur, ...elements ]
+	);
+
+	useEffect( () => {
+		const documentRoots = getDocumentRoots( elements );
+
+		forEach( documentRoots, ( root ) =>
+			root.addEventListener( 'mousedown', handleClick )
+		);
+
+		return () =>
+			forEach( documentRoots, ( root ) =>
+				root.removeEventListener( 'mousedown', handleClick )
+			);
+	}, [ handleClick, ...elements ] );
+};
+
+export default useBlur;


### PR DESCRIPTION
This patch creates a new package called `@crowdsignal/hooks` which should serve as a collection for any of the custom hooks shared between our components.

Initially, I moved `useOnOutsideClick` - previously defined in `Popover` - into the new package and renamed it to `useBlur` so it can easily be used by other components as well.

# Testing

The new package and hook can be tested by running `yarn storybook` and verifying the `Popover` component is still working as it did.