### PR TITLE
Implement a PopoverMenu component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,4 +1,5 @@
 export { default as Button } from './button';
 export { default as CrowdsignalFooter } from './crowdsignal-footer';
 export { default as Popover } from './popover';
+export { default as PopoverMenu } from './popover-menu';
 export { default as StyleProvider } from './style-provider';

--- a/packages/components/src/popover-menu/README.md
+++ b/packages/components/src/popover-menu/README.md
@@ -1,0 +1,97 @@
+# Popover Menu
+
+Component for displaying a popover menu.
+
+## Usage
+
+```javascript
+import { useRef, useState } from '@wordpress/element';
+import { PopoverMenu } from '@crowdsignal/components';
+
+const Menu () => {
+	const [ active, setActive ] = useState( false );
+	const toggle = useRef();
+
+	const hideMenu = () => setActive( false );
+	const toggleMenu = () => setActive( ! active );
+
+	return (
+		<>
+			<button ref={ toggle } onClick={ toggleMenu }>
+				Toggle Menu
+			</button>
+
+			<PopoverMenu
+				isVisible={ active }
+				context={ toggle }
+				onClose={ hideMenu }
+			>
+				<PopoverMenu.Item>
+					Foo
+				</PopoverMenu.Item>
+				<PopoverMenu.Item>
+					Bar
+				</PopoverMenu.Item>
+
+				<PopoverMenu.Separator />
+
+				<PopoverMenu.Item href="#">
+					Link
+				</PopoverMenu.Item>
+			</PopoverMenu>
+		</>
+	);
+};
+```
+
+## PopoverMenu
+
+Responsible for displaying the menu. Essentially, a styled version of `Popover`.
+
+### Props
+
+**className**: Set a custom className for the main popover container.
+
+- Type: `String|Object`
+- Required: No
+- Default: `''`
+
+**context**: A reference to the element the popover should attach itself to.
+
+- Type: `ref`
+- Required: Yes
+
+**isVisible**: Controls opening and closing of the popover.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+**onClose**: The callback that will be called when the popover should be closed.
+
+- Type: `Function`
+- Required: Yes
+
+**position**: Determines the position of the popover relative to the context element.
+
+- Type: `String` - (`auto`, ``top left`, `top right`, `center left`, `center right`, `bottom left`, `bottom right`)
+- Required: No
+- Default: `bottom left`
+
+
+## PopoverMenu.Item
+
+These components are responsible for rendering individual menu items.  
+They will be rendered as regular `button` elements unless a `href` property is set, in which case it'll be an `a` instead.
+
+### Props
+
+All props are passed down to the `button` or `a` element underneath.
+
+## PopoverMenu.Separator
+
+Can be used to render a separator line between items to split them into different groups for improved user experience.
+
+### Props
+
+None.

--- a/packages/components/src/popover-menu/index.js
+++ b/packages/components/src/popover-menu/index.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import Popover from '../popover';
+import Item from './item';
+import Separator from './separator';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PopoverMenu = ( { children, ...popoverProps } ) => (
+	<Popover { ...popoverProps }>
+		<div className="popover-menu">{ children }</div>
+	</Popover>
+);
+
+PopoverMenu.Item = Item;
+PopoverMenu.Separator = Separator;
+
+export default PopoverMenu;

--- a/packages/components/src/popover-menu/item.js
+++ b/packages/components/src/popover-menu/item.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+const PopoverMenuItem = ( { children, className, ...props } ) => {
+	const Element = !! props.href ? 'a' : 'button';
+	const classes = classnames( 'popover-menu__item', className );
+
+	return (
+		<Element className={ classes } { ...props }>
+			{ children }
+		</Element>
+	);
+};
+
+export default PopoverMenuItem;

--- a/packages/components/src/popover-menu/separator.js
+++ b/packages/components/src/popover-menu/separator.js
@@ -1,0 +1,3 @@
+const PopoverMenuSeparator = () => <div className="popover-menu__separator" />;
+
+export default PopoverMenuSeparator;

--- a/packages/components/src/popover-menu/stories/index.js
+++ b/packages/components/src/popover-menu/stories/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../button';
+import PopoverMenu from '../';
+
+export default {
+	title: 'Components/Popover Menu',
+	component: PopoverMenu,
+};
+
+const Default = () => {
+	const [ active, setActive ] = useState( false );
+	const toggle = useRef();
+
+	const hideMenu = () => setActive( false );
+	const toggleMenu = () => setActive( ! active );
+
+	return (
+		<>
+			<Button ref={ toggle } onClick={ toggleMenu }>
+				Toggle Menu
+			</Button>
+
+			<PopoverMenu
+				isVisible={ active }
+				context={ toggle }
+				onClose={ hideMenu }
+			>
+				<PopoverMenu.Item>Option A</PopoverMenu.Item>
+				<PopoverMenu.Item>Option B</PopoverMenu.Item>
+
+				<PopoverMenu.Separator />
+
+				<PopoverMenu.Item href="#">Link</PopoverMenu.Item>
+			</PopoverMenu>
+		</>
+	);
+};
+export { Default as PopoverMenu };

--- a/packages/components/src/popover-menu/style.scss
+++ b/packages/components/src/popover-menu/style.scss
@@ -1,0 +1,73 @@
+.popover-menu {
+	background-color: var(--color-surface);
+	border-color: var(--color-border);
+	border-radius: 5px;
+	border-style: solid;
+	border-width: 1px;
+	box-shadow: 1px 1px 3px 0 var(--color-shadow);
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	padding: 5px 0;
+	position: relative;
+	width: fit-content;
+	z-index: 100;
+
+	&::before,
+	&::after {
+		border-style: solid;
+		content: '';
+		display: block;
+		height: 0;
+		position: absolute;
+		width: 0;
+		z-index: 1;
+	}
+
+	&::before {
+		border-color: var(--color-border);
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+		border-width: 10px;
+		right: 7px;
+		top: -10px;
+	}
+
+	&::after {
+		border-color: var(--color-surface);
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+		border-width: 9px;
+		right: 8px;
+		top: -8px;
+	}
+}
+
+.popover-menu__item {
+	align-items: center;
+	background-color: transparent;
+	border: 0;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: flex;
+	font-size: 12px;
+	height: 24px;
+	justify-content: left;
+	line-height: 20px;
+	padding: 0 7px;
+	text-align: left;
+	text-decoration: none;
+	width: 100%;
+
+	&:hover {
+		background-color: var(--color-neutral-0);
+	}
+}
+
+.popover-menu__separator {
+	border-bottom: 1px solid var(--color-border);
+	height: 0;
+	margin: 8px 0;
+}


### PR DESCRIPTION
This patch implements a `<PopoverMenu>` component for... displaying menus in a popover 🎉 

![Screen Shot 2021-07-07 at 10 32 42 PM](https://user-images.githubusercontent.com/8056203/124824926-43672b80-df73-11eb-90bf-5e76fee31922.png)

# Testing

The new component can be seen and tested in storybook under `Components/PopoverMenu`.