### PR TITLE
Update @crowdsignal/styles reset stylesheet

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,7 +6,7 @@ import { Global } from '@emotion/core';
 /**
  * Internal dependencies
  */
-import { StyleProvider } from '@crowdsignal/components';
+import StyleProvider from '../packages/components/src/style-provider';
 
 export const decorators = [
 	( Story ) => (

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { Global } from '@emotion/core';
+
+/**
+ * Internal dependencies
+ */
+import { StyleProvider } from '@crowdsignal/components';
+
+export const decorators = [
+	( Story ) => (
+		<StyleProvider reset>
+			<Story />
+		</StyleProvider>
+	),
+];

--- a/packages/components/src/style-provider/index.js
+++ b/packages/components/src/style-provider/index.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { reset as resetCSS } from '@crowdsignal/styles';
+import { resetStyles as resetStyles } from '@crowdsignal/styles';
 
 const StyleProvider = ( { container, children, namespace, reset } ) => {
 	const [ cache ] = useState(
@@ -20,7 +20,13 @@ const StyleProvider = ( { container, children, namespace, reset } ) => {
 
 	return (
 		<CacheProvider value={ cache }>
-			{ reset && <Global styles={ resetCSS } /> }
+			{ reset && (
+				<Global
+					styles={ resetStyles( {
+						shadowRoot: container instanceof window.ShadowRoot,
+					} ) }
+				/>
+			) }
 
 			{ children }
 		</CacheProvider>

--- a/packages/styles/src/colors.js
+++ b/packages/styles/src/colors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import Palette from '@automattic/color-studio';
-import { includes, isObject, keys } from 'lodash';
+import { includes, isObject, join, keys, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -148,3 +148,20 @@ export const color = ( domain, value = 'default' ) => {
 
 	return defaultColorMap[ domain ][ value ];
 };
+
+const toCSS = ( colors, prefix = '' ) => {
+	if ( isObject( colors ) ) {
+		return join(
+			map( colors, ( value, key ) =>
+				toCSS( value, `${ prefix }-${ key }` )
+			),
+			''
+		);
+	}
+
+	const colorVarName = prefix.match( /^\-(.*?)(\-default)?$/i );
+
+	return `--color-${ colorVarName[ 1 ] }: ${ colors };`;
+};
+
+export const colorVars = () => toCSS( defaultColorMap );

--- a/packages/styles/src/reset.js
+++ b/packages/styles/src/reset.js
@@ -6,14 +6,25 @@ import { css } from '@emotion/core';
 /**
  * Internal dependencies
  */
-import { color } from './colors';
+import { colorVars } from './colors';
 
-export const reset = css`
-	:host {
-		color: ${ color( 'text' ) };
+export const resetStyles = ( { shadowRoot = false } ) => css`
+	${ shadowRoot ? ':host' : ':root' } {
+		${ colorVars() };
+
+		color: var( --color-text );
 		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
 			Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
 			'Segoe UI Symbol';
+	}
+
+	body {
+		margin: 0;
+		padding: 0;
+	}
+
+	a {
+		color: var( --color-text );
 	}
 
 	button,


### PR DESCRIPTION
This patch is a quick fix for our reset stylesheet which adjusts the next two things:

- Use `:host` when injecting the stylesheet into a shadow DOM node, or `:root` otherwise.
- Inject our entire color palette into the stylesheet as CSS variables. This makes for more performant css-in-js styling and enables regular CSS - or SCSS - to be used as well.

This is not the endgame quite yet. I'm thinking about splitting the responsibilities between injecting variables and the reset sheet so it's cleaner and we have more control when applying these in our widgets.  
In the mean time, it does the job.

# Testing

You can try loading storybook and verifying the CSS color variables show up as expected and the default styles are applied.