### PR TITLE
Implement a TabNavigation component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -2,3 +2,4 @@ export { default as Button } from './button';
 export { default as CrowdsignalFooter } from './crowdsignal-footer';
 export { default as Popover } from './popover';
 export { default as StyleProvider } from './style-provider';
+export { default as TabNavigation } from './tab-navigation';

--- a/packages/components/src/tab-navigation/README.md
+++ b/packages/components/src/tab-navigation/README.md
@@ -1,0 +1,36 @@
+# Tab Navigation
+
+Tabs navigation component.
+
+## Usage
+
+```javascript
+import { TabNavigation } from '@crowdsignal/components';
+
+const Navigation = () => (
+	<TabNavigation>
+		<TabNavigation.Tab isSelected href="#">
+			Foo
+		</TabNavigation.Tab>
+		<TabNavigation.Tab href="#">Bar</TabNavigation.Tab>
+		<TabNavigation.Tab href="#">Baz</TabNavigation.Tab>
+	</TabNavigation>
+);
+```
+
+## TabNavigation
+
+Wrapper element which renders the navigation bar.
+
+### Props
+
+None.
+
+## TabNavigation.Tab
+
+Used for rendering individual tabs inside the navigation component.  
+Tabs are rendered as `button` elements unless a `href` property is present, in which case they'll render as `a`.
+
+### Props
+
+All props are passed down to the `button` or `a` element underneath.

--- a/packages/components/src/tab-navigation/index.js
+++ b/packages/components/src/tab-navigation/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Tab from './tab';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const TabNavigation = ( { children, className } ) => {
+	const classes = classnames( 'tab-navigation', className );
+
+	return <ul className={ classes }>{ children }</ul>;
+};
+
+TabNavigation.Tab = Tab;
+
+export default TabNavigation;

--- a/packages/components/src/tab-navigation/stories/index.js
+++ b/packages/components/src/tab-navigation/stories/index.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import TabNavigation from '../';
+
+export default {
+	title: 'Components/Tab Navigation',
+	component: TabNavigation,
+};
+
+const Default = () => (
+	<TabNavigation>
+		<TabNavigation.Tab isSelected href="#">
+			Foo
+		</TabNavigation.Tab>
+		<TabNavigation.Tab href="#">Bar</TabNavigation.Tab>
+		<TabNavigation.Tab href="#">Baz</TabNavigation.Tab>
+	</TabNavigation>
+);
+export { Default as TabNavigation };

--- a/packages/components/src/tab-navigation/style.scss
+++ b/packages/components/src/tab-navigation/style.scss
@@ -1,0 +1,50 @@
+.tab-navigation {
+	align-items: flex-start;
+	border-bottom: 1px solid var(--color-border);
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: row;
+	height: 64px;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+
+	&.is-compact {
+		height: 42px;
+	}
+}
+
+.tab-navigation__item {
+	height: 100%;
+}
+
+.tab-navigation__button {
+	box-sizing: border-box;
+	background: transparent;
+	border: 0;
+	border-bottom: 3px solid transparent;
+	color: var(--color-text);
+	cursor: pointer;
+	display: inline-block;
+	font-size: 14px;
+	height: 100%;
+	line-height: 63px;
+	outline: 0;
+	padding: 0 16px;
+	transition: background-color .1s ease-out, border-color .1s ease-out, color .1s ease-out;
+	text-decoration: none;
+
+	&:hover {
+		background-color: var(--color-neutral-0);
+		color: var(--color-text);
+	}
+
+	.tab-navigation.is-compact & {
+		line-height: 41px;
+	}
+
+	.tab-navigation__item.is-selected & {
+		border-color: var(--color-neutral-70);
+		font-weight: bold;
+	}
+}

--- a/packages/components/src/tab-navigation/tab.js
+++ b/packages/components/src/tab-navigation/tab.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+const Tab = ( { children, href, isSelected, ...props } ) => {
+	const ButtonComponent = href ? 'a' : 'button';
+
+	const classes = classnames( 'tab-navigation__item', {
+		'is-selected': isSelected,
+	} );
+
+	return (
+		<li className={ classes }>
+			<ButtonComponent
+				className="tab-navigation__button"
+				href={ href }
+				{ ...props }
+			>
+				{ children }
+			</ButtonComponent>
+		</li>
+	);
+};
+
+export default Tab;


### PR DESCRIPTION
This patch implements a `<TabNavigation>` component which will be used as secondary navigation throughout Crowdsignal.

![Screen Shot 2021-07-07 at 11 05 38 PM](https://user-images.githubusercontent.com/8056203/124828828-11a49380-df78-11eb-917a-45ad68e0f9b4.png)

# Testing

The new component can be seen and tested in storybook.