### PR TITLE
Implement PageHeader and EditablePageHeader components

### DIFF
--- a/packages/components/src/editable-page-header/README.md
+++ b/packages/components/src/editable-page-header/README.md
@@ -1,0 +1,31 @@
+# Editable Page Header
+
+Renders a page header which can be edited in place.
+
+## Usage
+
+```javascript
+import { EditablePageHeader } from '@crowdsignal/components';
+
+const MyPage = () => (
+	<EditablePageHeader
+		onChange={ updateHeader }
+		text={ headerText }
+	/>
+
+	...
+);
+```
+
+### Props
+
+**onChange**: Callback that will be invoked when the header value has been edited.
+
+- Type: `Function`
+- Required: Yes
+
+**text**: The text to display.
+
+- Type: `string`
+- Required: No
+- Default `''`

--- a/packages/components/src/editable-page-header/form.js
+++ b/packages/components/src/editable-page-header/form.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useBlur } from '@crowdsignal/hooks';
+
+const PageHeaderForm = ( { onCancel, onChange, value } ) => {
+	const form = useRef();
+
+	const handleChange = () => {
+		const data = new window.FormData( form.current );
+
+		if ( data.get( 'value' ) !== value ) {
+			return onChange( data.get( 'value' ) );
+		}
+
+		onCancel();
+	};
+
+	const handleSubmit = ( event ) => {
+		handleChange();
+		event.preventDefault();
+	};
+
+	useBlur( handleChange, [ form ] );
+
+	useEffect( () => form.current.children[ 0 ].select(), [ form.current ] );
+
+	return (
+		<form
+			ref={ form }
+			className="editable-page-header__form"
+			onSubmit={ handleSubmit }
+		>
+			<input
+				className="editable-page-header__input"
+				type="text"
+				name="value"
+				defaultValue={ value }
+			/>
+		</form>
+	);
+};
+
+export default PageHeaderForm;

--- a/packages/components/src/editable-page-header/index.js
+++ b/packages/components/src/editable-page-header/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PageHeader from '../page-header';
+import Form from './form';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const EditablePageHeader = ( { onChange, text } ) => {
+	const [ active, setActive ] = useState( false );
+
+	useEffect( () => setActive( false ), [ text ] );
+
+	const showForm = () => setActive( true );
+	const hideForm = () => setActive( false );
+
+	return (
+		<div className="editable-page-header">
+			{ ! active && (
+				<PageHeader onClick={ showForm }>{ text }</PageHeader>
+			) }
+
+			{ active && (
+				<Form
+					value={ text }
+					onChange={ onChange }
+					onCancel={ hideForm }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default EditablePageHeader;

--- a/packages/components/src/editable-page-header/stories/index.js
+++ b/packages/components/src/editable-page-header/stories/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import EditablePageHeader from '../';
+
+export default {
+	title: 'Components/Editable Page Header',
+	component: EditablePageHeader,
+};
+
+const Default = () => {
+	const [ header, setHeader ] = useState(
+		'The quick brown fox jumps over the lazy dog'
+	);
+
+	return <EditablePageHeader text={ header } onChange={ setHeader } />;
+};
+export { Default as EditablePageHeader };

--- a/packages/components/src/editable-page-header/style.scss
+++ b/packages/components/src/editable-page-header/style.scss
@@ -1,0 +1,23 @@
+.editable-page-header {
+	align-items: center;
+	display: flex;
+}
+
+.editable-page-header__form {
+	width: 100%;
+}
+
+.editable-page-header__input {
+	background-color: transparent;
+	border: 0;
+	color: var(--color-text);
+	display: inline-flex;
+	font-size: 24px;
+	font-weight: 700;
+	heght: 40px;
+	line-height: 40px;
+	margin: 0;
+	outline: 0;
+	padding: 0;
+	width: 100%;
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,6 +1,8 @@
 export { default as Button } from './button';
 export { default as CrowdsignalFooter } from './crowdsignal-footer';
 export { default as CrowdsignalLogo } from './crowdsignal-logo';
+export { default as EditablePageHeader } from './editable-page-header';
+export { default as PageHeader } from './page-header';
 export { default as Popover } from './popover';
 export { default as PopoverMenu } from './popover-menu';
 export { default as StyleProvider } from './style-provider';

--- a/packages/components/src/page-header/README.md
+++ b/packages/components/src/page-header/README.md
@@ -1,0 +1,21 @@
+# Page Header
+
+This component will render its contents as a Crowdsignal page header.
+
+## Usage
+
+```javascript
+import { PageHeader } from '@crowdsignal/components';
+
+const MyPage = () => (
+	<PageHeader>
+		The quick brown fox jumps over the lazy dog.
+	</PageHeader>
+
+	...
+);
+```
+
+### Props
+
+All props will be passed down to the underlying `h1` element.

--- a/packages/components/src/page-header/index.js
+++ b/packages/components/src/page-header/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PageHeader = ( { children, className, ...props } ) => {
+	const classes = classnames( 'page-header', className );
+
+	return (
+		<h1 className={ classes } { ...props }>
+			{ children }
+		</h1>
+	);
+};
+
+export default PageHeader;

--- a/packages/components/src/page-header/stories/index.js
+++ b/packages/components/src/page-header/stories/index.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import PageHeader from '../';
+
+export default {
+	title: 'Components/Page Header',
+	component: PageHeader,
+};
+
+const Default = () => (
+	<PageHeader>The quick brown fox jumps over the lazy dog</PageHeader>
+);
+export { Default as PageHeader };

--- a/packages/components/src/page-header/style.scss
+++ b/packages/components/src/page-header/style.scss
@@ -1,0 +1,8 @@
+.page-header {
+	display: inline-flex;
+	font-size: 24px;
+	font-weight: 700;
+	height: 40px;
+	line-height: 40px;
+	margin: 0;
+}


### PR DESCRIPTION
This patch implements a `<PageHeader>` and an `<EditablePageHeader>` components for displaying page headers across the dashboard in both editable and non-editable forms.

![Screen Shot 2021-07-07 at 11 26 49 PM](https://user-images.githubusercontent.com/8056203/124830916-d6f02a80-df7a-11eb-81a1-7f1ead6d595f.png)

# Testing

Both components can be seen and tested inside storybook.