### PR TITLE
Initialize the dashboard app

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -24,6 +24,7 @@
     "@crowdsignal/router": "^0.1.0",
     "@wordpress/element": "^3.1.1",
     "@wordpress/i18n": "^4.1.1",
+    "classnames": "^2.2.5",
     "lodash": "^4.17.21"
   },
   "scripts": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@crowdsignal/dashboard",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Crowdsignal dashboard.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "browser": true,
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/dashboard/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@crowdsignal/block-editor": "^0.1.0",
+    "@crowdsignal/components": "^0.1.0",
+    "@crowdsignal/router": "^0.1.0",
+    "@wordpress/element": "^3.1.1",
+    "@wordpress/i18n": "^4.1.1",
+    "lodash": "^4.17.21"
+  },
+  "scripts": {
+    "build": "calypso-build ./src/index.js"
+  }
+}

--- a/apps/dashboard/src/components/app/index.js
+++ b/apps/dashboard/src/components/app/index.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import { Route, Router, Switch } from '@crowdsignal/router';
+import Masterbar from '../masterbar';
+import PollEditor from '../poll-editor';
+import PollResults from '../poll-results';
+
+const allowedRoutes = /^\/(edit)\/.*/i;
+
+const NotFound = () => <div className="app__not-found">404</div>;
+
+const App = () => {
+	return (
+		<Router allowedRoutes={ allowedRoutes }>
+			<div className="app">
+				<Masterbar />
+
+				<main className="app__content">
+					<Switch>
+						<Route
+							path="/edit/poll/:pollId"
+							component={ PollEditor }
+						/>
+						<Route
+							path="/edit/poll/:pollId/results"
+							component={ PollResults }
+						/>
+
+						<Route path="*any" component={ NotFound } />
+					</Switch>
+				</main>
+			</div>
+		</Router>
+	);
+};
+
+export default App;

--- a/apps/dashboard/src/components/masterbar/index.js
+++ b/apps/dashboard/src/components/masterbar/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { CrowdsignalLogo } from '@crowdsignal/components';
 import LoggedIn from './logged-in';
 import LoggedOut from './logged-out';
 
@@ -21,7 +22,9 @@ const Masterbar = ( { isAdmin, user } ) => {
 
 	return (
 		<header className={ classes }>
-			<a href="/" className="masterbar__logo-link"></a>
+			<a href="/" className="masterbar__logo-link">
+				<CrowdsignalLogo size={ 48 } />
+			</a>
 
 			{ user && <LoggedIn isAdmin={ isAdmin } user={ user } /> }
 			{ ! user && <LoggedOut /> }

--- a/apps/dashboard/src/components/masterbar/index.js
+++ b/apps/dashboard/src/components/masterbar/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import LoggedIn from './logged-in';
+import LoggedOut from './logged-out';
+
+/**
+ * Style dependencies
+ */
+import './styles.scss';
+
+const Masterbar = ( { isAdmin, user } ) => {
+	const classes = classnames( 'masterbar', {
+		'is-admin': isAdmin,
+	} );
+
+	return (
+		<header className={ classes }>
+			<a href="/" className="masterbar__logo-link"></a>
+
+			{ user && <LoggedIn isAdmin={ isAdmin } user={ user } /> }
+			{ ! user && <LoggedOut /> }
+		</header>
+	);
+};
+
+export default Masterbar;

--- a/apps/dashboard/src/components/masterbar/logged-in.js
+++ b/apps/dashboard/src/components/masterbar/logged-in.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import UserMenu from './user-menu';
+
+const LoggedInMasterbar = ( { isAdmin, user } ) => {
+	return (
+		<>
+			<nav className="masterbar__navigation">
+				<ul className="masterbar__navigation-list">
+					<li>
+						<a
+							className="masterbar__navigation-button"
+							href="/dashboard"
+						>
+							{ __( 'Dashboard', 'dashboard' ) }
+						</a>
+					</li>
+					<li>
+						<a
+							className="masterbar__navigation-button"
+							href="/contact-groups"
+						>
+							{ __( 'Contacts', 'dashboard' ) }
+						</a>
+					</li>
+					<li>
+						<a
+							className="masterbar__navigation-button"
+							href="https://crowdsignal.com/support"
+							target="blank"
+							rel="noopener noreferrer"
+						>
+							{ __( 'Help', 'dashboard' ) }
+						</a>
+					</li>
+
+					{ isAdmin && (
+						<li>
+							<a
+								className="masterbar__navigation-button"
+								href="/admin"
+							>
+								{ __( 'Admin', 'dashboard' ) }
+							</a>
+						</li>
+					) }
+
+					{ isAdmin && window.BILLING_DEBUG && (
+						<li>
+							<a
+								className="masterbar__navigation-button"
+								href="/dashboard"
+							>
+								{ __( 'Billing', 'dashboard' ) }
+							</a>
+						</li>
+					) }
+				</ul>
+			</nav>
+
+			<UserMenu user={ user } />
+		</>
+	);
+};
+
+export default LoggedInMasterbar;

--- a/apps/dashboard/src/components/masterbar/logged-out.js
+++ b/apps/dashboard/src/components/masterbar/logged-out.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const LoggedOutMasterbar = () => (
+	<nav className="masterbar__navigation">
+		<ul className="masterbar__navigation-list">
+			<li>
+				<a
+					className="masterbar__navigation-button"
+					href="https://crowdsignal.com/features"
+				>
+					{ __( 'Features', 'dashboard' ) }
+				</a>
+			</li>
+			<li>
+				<a
+					className="masterbar__navigation-button"
+					href="https://crowdsignal.com/pricing"
+				>
+					{ __( 'Pricing', 'dashboard' ) }
+				</a>
+			</li>
+		</ul>
+	</nav>
+);
+
+export default LoggedOutMasterbar;

--- a/apps/dashboard/src/components/masterbar/stories/index.js
+++ b/apps/dashboard/src/components/masterbar/stories/index.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import Masterbar from '../';
+import * as Type from '../../../util/user/account-types';
+
+export default {
+	title: 'Dashboard/Components/Masterbar',
+	component: Masterbar,
+};
+
+const user = {
+	id: 123456,
+	signalCount: 15,
+	type: 7,
+	profile: {
+		name: 'Muriel Cooper',
+	},
+	account: {
+		type: Type.FREE,
+	},
+};
+
+export const LoggedIn = () => <Masterbar user={ user } />;
+
+export const LoggedOut = () => <Masterbar />;
+
+export const Admin = () => <Masterbar isAdmin user={ user } />;

--- a/apps/dashboard/src/components/masterbar/styles.scss
+++ b/apps/dashboard/src/components/masterbar/styles.scss
@@ -1,0 +1,69 @@
+.masterbar {
+	align-items: center;
+	background: var(--color-secondary-90);
+	box-sizing: border-box;
+	display: flex;
+	height: 64px;
+	justify-content: center;
+	padding: 0;
+	position: relative;
+	width: 100%;
+
+	&.is-admin {
+		background: linear-gradient(135deg, var(--color-secondary-90) 10%, var(--color-highlight) 100%);
+	}
+}
+
+.masterbar__navigation {
+	flex: 1;
+}
+
+.masterbar__logo-link {
+	display: block;
+	margin: 0 32px;
+}
+
+.masterbar__navigation-list {
+	display: flex;
+	justify-content: flex-start;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+}
+
+.masterbar__navigation-button {
+	align-items: center;
+	background: none;
+	border: 0;
+	color: var(--color-text-inverted);
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 14px;
+	font-weight: bold;
+	height: 64px;
+	line-height: 64px;
+	outline: 0;
+	padding: 0 32px;
+	text-decoration: none;
+}
+
+.masterbar__navigation-button.is-user-toggle {
+	& .icon {
+		display: inline-flex;
+		margin: 0 0 0 10px;
+		transform: rotate(0);
+		transition: transform .15s cubic-bezier(.175,.885,.32,1.275);
+
+		.masterbar.with-user-menu & {
+			transform: rotate(180deg);
+		}
+	}
+}
+
+.masterbar__user-menu .popover-menu {
+	min-width: 180px;
+}
+
+.masterbar__login-popover {
+
+}

--- a/apps/dashboard/src/components/masterbar/user-menu.js
+++ b/apps/dashboard/src/components/masterbar/user-menu.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PopoverMenu } from '@crowdsignal/components';
+import {
+	hasCapability,
+	isJetpackPro,
+	isCorporate,
+	isEnterprise,
+	isVIP,
+} from '../../util/user';
+import { MANAGE_MULTI_USER } from '../../util/user/capabilities';
+
+const MasterbarUserMenu = ( { user } ) => {
+	const [ showUserMenu, setShowUserMenu ] = useState( false );
+
+	const userMenuToggle = useRef();
+
+	const toggleUserMenu = () => setShowUserMenu( ! showUserMenu );
+
+	const showUpgradeLink =
+		! isJetpackPro( user ) &&
+		! isCorporate( user ) &&
+		! isEnterprise( user ) &&
+		! isVIP( user );
+
+	return (
+		<>
+			<button
+				ref={ userMenuToggle }
+				className="masterbar__navigation-button is-user-toggle"
+				onClick={ toggleUserMenu }
+			>
+				{ user.profile.name }
+			</button>
+
+			<PopoverMenu
+				className="masterbar__user-menu"
+				context={ userMenuToggle }
+				isVisible={ showUserMenu }
+				onClose={ toggleUserMenu }
+			>
+				{ showUpgradeLink && (
+					<>
+						<PopoverMenu.Item
+							href={ `/upgrade.php?source=header-link-${ user.account.type }` }
+						>
+							{ __( 'Upgrade your account', 'dashboard' ) }
+						</PopoverMenu.Item>
+						<PopoverMenu.Separator />
+					</>
+				) }
+
+				<PopoverMenu.Item href="/account">
+					{ __( 'My Account', 'dashboard' ) }
+				</PopoverMenu.Item>
+				<PopoverMenu.Item href="/account/whitelist.php">
+					{ __( 'Whitelist', 'dashboard' ) }
+				</PopoverMenu.Item>
+				<PopoverMenu.Item href="/delete-requests">
+					{ __( 'Delete Requests', 'dashboard' ) }
+				</PopoverMenu.Item>
+
+				{ hasCapability( user, MANAGE_MULTI_USER ) && (
+					<PopoverMenu.Item href="/users/list-users.php">
+						{ __( 'Users', 'dashboard' ) }
+					</PopoverMenu.Item>
+				) }
+
+				<PopoverMenu.Separator />
+				<PopoverMenu.Item href="https://crowdsignal.com/blog">
+					{ __( 'Crowdsignal Blog', 'dashboard' ) }
+				</PopoverMenu.Item>
+				<PopoverMenu.Item href="https://crowdsignal.com/contact">
+					{ __( 'Feedback', 'dashboard' ) }
+				</PopoverMenu.Item>
+				<PopoverMenu.Item href="/logout.php">
+					{ __( 'Sign out', 'dashboard' ) }
+				</PopoverMenu.Item>
+			</PopoverMenu>
+		</>
+	);
+};
+
+export default MasterbarUserMenu;

--- a/apps/dashboard/src/components/poll-editor/index.js
+++ b/apps/dashboard/src/components/poll-editor/index.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { BlockEditor } from '@crowdsignal/block-editor';
+import PollNavigation from '../poll-navigation';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PollEditor = ( { pollId } ) => {
+	return (
+		<div className="poll-editor">
+			<PollNavigation
+				activeTab={ PollNavigation.Tab.EDITOR }
+				pollId={ pollId }
+			/>
+
+			<BlockEditor />
+		</div>
+	);
+};
+
+export default PollEditor;

--- a/apps/dashboard/src/components/poll-editor/style.scss
+++ b/apps/dashboard/src/components/poll-editor/style.scss
@@ -1,0 +1,8 @@
+.poll-editor {
+	.iso-editor {
+		--wp-admin-theme-color: var( --color-text );
+
+		border-top: 0;
+		color: var( --color-text );
+	}
+}

--- a/apps/dashboard/src/components/poll-navigation/index.js
+++ b/apps/dashboard/src/components/poll-navigation/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PageHeader, TabNavigation } from '@crowdsignal/components';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const Tab = {
+	EDITOR: 'editor',
+	RESULTS: 'results',
+};
+
+const PollNavigation = ( { activeTab, pollId } ) => (
+	<div className="poll-navigation">
+		<PageHeader>My Great New Poll</PageHeader>
+
+		<TabNavigation>
+			<TabNavigation.Tab
+				isSelected={ activeTab === Tab.EDITOR }
+				href={ `/edit/poll/${ pollId }` }
+			>
+				{ __( 'Edior', 'dashboard' ) }
+			</TabNavigation.Tab>
+			<TabNavigation.Tab
+				isSelected={ activeTab === Tab.RESULTS }
+				href={ `/edit/poll/${ pollId }/results` }
+			>
+				{ __( 'Results', 'dashboard' ) }
+			</TabNavigation.Tab>
+		</TabNavigation>
+	</div>
+);
+
+PollNavigation.Tab = Tab;
+
+export default PollNavigation;

--- a/apps/dashboard/src/components/poll-navigation/style.scss
+++ b/apps/dashboard/src/components/poll-navigation/style.scss
@@ -1,0 +1,12 @@
+.poll-navigation {
+	align-items: center;
+	border-bottom: 1px solid var(--color-border);
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	padding: 0 32px;
+	width: 100%;
+
+	.tab-navigation {
+		border-bottom: 0;
+	}
+}

--- a/apps/dashboard/src/components/poll-results/index.js
+++ b/apps/dashboard/src/components/poll-results/index.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import PollNavigation from '../poll-navigation';
+
+const PollResults = ( { pollId } ) => {
+	return (
+		<div className="poll-results">
+			<PollNavigation
+				activeTab={ PollNavigation.Tab.RESULTS }
+				pollId={ pollId }
+			/>
+			Poll Results
+		</div>
+	);
+};
+
+export default PollResults;

--- a/apps/dashboard/src/index.js
+++ b/apps/dashboard/src/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { StyleProvider } from '@crowdsignal/components';
+import App from './components/app';
+
+const renderApp = () =>
+	render(
+		<StyleProvider reset>
+			<App />
+		</StyleProvider>,
+		document.getElementById( 'crowdsignal-dashboard' )
+	);
+
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'load', renderApp );

--- a/apps/dashboard/src/util/user/account-types.js
+++ b/apps/dashboard/src/util/user/account-types.js
@@ -1,0 +1,19 @@
+/**
+ * Constants denoting Crowdsignal's different account types
+ */
+
+export const FREE = 10;
+export const PWYW_9 = 12;
+export const PWYW_19 = 13;
+export const PWYW_29 = 14;
+export const PWYW_39 = 15;
+export const PWYW_49 = 16;
+export const PRO = 20;
+export const JETPACK_PRO = 22;
+export const CORPORATE = 30;
+export const CORPORATE_6_MONTHLY = 32;
+export const ENTERPRISE = 35;
+export const VIP = 40;
+export const PREMIUM = 50;
+export const BUSINESS = 60;
+export const TEAM = 70;

--- a/apps/dashboard/src/util/user/capabilities.js
+++ b/apps/dashboard/src/util/user/capabilities.js
@@ -1,0 +1,45 @@
+/**
+ * Constants denoting Crowdsignal's user capabilities
+ */
+
+export const UNLIMITED_QUESTIONS = 'unlimited-questions';
+export const DEVICE_REPORT = 'device-report';
+export const UNLIMITED_EMAIL_RESPONSES = 'unlimited-email-responses';
+export const CUSTOM_STYLE = 'custom-style';
+export const OVERRIDES = 'overrides';
+export const POLL = 'feature-poll';
+export const RATING = 'feature-rating';
+export const SURVEY = 'feature-survey';
+export const QUIZ = 'feature-quiz';
+export const FORMS = 'feature-forms';
+export const DASHBOARD = 'dashboard';
+export const DASHBOARD_MIGRATE = 'dashboard-migrate';
+export const API_VOTE = 'api-vote';
+export const JAVASCRIPT = 'javascript';
+export const MULTI_USER = 'multi-user';
+export const ADMIN_MULTI_USER = 'admin-multi-user';
+export const MANAGE_MULTI_USER = 'manage-multi-user';
+export const HIDE_COMMUNITY_ADS = 'hide-community-ads';
+export const MAP_DOMAIN = 'map-domain';
+export const CUSTOM_EMAIL_NOTIFICATION_ADDRESS =
+	'custom-email-notification-address';
+export const EXPORT_PDF = 'export-pdf';
+export const EXPORT = 'export';
+export const EXPORT_SHARED_REPORT_GDOC_PDF = 'export-shared-report-gdoc-pdf';
+export const WHITELIST_MAXIMUM_POLLS = 'whitelist-maximum-polls';
+export const SURVEY_CUSTOM_FINISH = 'survey-custom-finish';
+export const COLOR_PALETTE = 'color-palette';
+export const SSL = 'ssl';
+export const EMAIL = 'email';
+export const HIDE_BRANDING = 'hide-branding';
+export const SURVEY_CUSTOM_URL = 'survey-custom-url';
+export const SURVEY_RESPONSES = 'survey-responses';
+export const FILTER = 'filter';
+export const SHARE = 'share';
+export const POLL_REPORTS = 'poll-reports';
+export const PUBLIC_JSON_POLLS = 'public-json-polls';
+export const SURVEY_RESTRICTIONS = 'survey-restrictions';
+export const POLL_RESULTS_EMBED = 'poll-results-embed';
+export const POLL_RESTRICTIONS = 'poll-restrictions';
+export const SYNC_TO_EXTERNAL_SERVICES = 'sync-to-external-services';
+export const SURVEY_TIMEOUT = 'survey-timeout';

--- a/apps/dashboard/src/util/user/index.js
+++ b/apps/dashboard/src/util/user/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import * as AccountType from './account-types';
+
+export const isPro = ( user ) => user.account.type === AccountType.PRO;
+
+export const isJetpackPro = ( user ) =>
+	user.account.type === AccountType.JETPACK_PRO;
+
+export const isCorporate = ( user ) =>
+	includes(
+		[ AccountType.CORPORATE, AccountType.CORPORATE_6_MONTHLY ],
+		user.account.type
+	);
+
+export const isEnterprise = ( user ) =>
+	user.account.type === AccountType.ENTERPRISE;
+
+export const isVIP = ( user ) => user.account.type === AccountType.VIP;
+
+export const isPremium = ( user ) => user.account.type === AccountType.PREMIUM;
+
+export const isBusiness = ( user ) =>
+	user.account.type === AccountType.BUSINESS;
+
+export const isTeam = ( user ) => user.account.type === AccountType.TEAM;
+
+export const hasCapability = ( user, capability ) =>
+	includes( user.capabilities, capability );

--- a/apps/dashboard/webpack.config.js
+++ b/apps/dashboard/webpack.config.js
@@ -1,0 +1,40 @@
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const package = require( './package.json' );
+const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
+
+function getWebpackConfig( env, { entry, ...argv } ) {
+	const baseConfig = getBaseConfig( env, argv );
+
+	return {
+		...baseConfig,
+		output: {
+			...baseConfig.output,
+			filename: `dashboard-${ package.version }.js`,
+		},
+		externals: {
+			react: 'React',
+			'react-dom': 'ReactDOM',
+		},
+		plugins: [
+			...baseConfig.plugins.map( ( plugin ) => {
+				if ( plugin.constructor.name !== 'DefinePlugin' ) {
+					return plugin;
+				}
+
+				return new webpack.DefinePlugin( {
+					...plugin.definitions,
+					'process.env.GUTENBERG_PHASE': JSON.stringify(
+						parseInt(
+							process.env.npm_package_config_GUTENBERG_PHASE,
+							10
+						) || 1
+					),
+					'process.env.COMPONENT_SYSTEM_PHASE': JSON.stringify( 1 ),
+				} );
+			} ),
+		],
+	};
+}
+
+module.exports = getWebpackConfig;


### PR DESCRIPTION
This patch adds a new *dashboard* app, which is a single page application we will use to implement the new block editor and will ultimately take over from the current Crowdsignal dashboard.

As it stands, the app contains the main layout and two views : poll editor and poll results.  
Note, since we're not fetching any data yet, the header is currently stuck in the not-logged-in state.

This patch depends on: #11, #12, #13, #14, #15, #16 and #17.

![Screen Shot 2021-07-08 at 10 26 17 AM](https://user-images.githubusercontent.com/8056203/124889064-fcab1d00-dfd6-11eb-9387-677cef6a6800.png)

# Testing

Testing instructions can be found in d63837-code.