### PR TITLE
Implement a `redirect()` method for @crowdsignal/router

### DIFF
--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -1,3 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { history } from './context';
+
 export * from './route';
 export * from './router';
 export * from './switch';
+
+export const redirect = ( uri ) => history.push( uri );


### PR DESCRIPTION
This patch implements a simple `redirect()` method which will serve as a means to programmatically switch the user to a different route/view inside the app.

For example

```javascript
import { redirect } from '@crowdsignal/router';

redirect( '/' ); // Will redirect to the root.
```

# Testing

No tests 🤷 