### PR TITLE
Add poll & project routes to @crowdsignal/rest-api

### DIFF
--- a/packages/rest-api/src/index.js
+++ b/packages/rest-api/src/index.js
@@ -1,1 +1,3 @@
 export * from './feedback';
+export * from './poll';
+export * from './project';

--- a/packages/rest-api/src/poll/README.md
+++ b/packages/rest-api/src/poll/README.md
@@ -1,0 +1,70 @@
+# Polls
+
+## fetchPoll
+
+Returns a poll.
+
+```javascript
+import { fetchPoll } from '@crowdsignal/rest-api';
+
+const poll = await fetchPoll( pollId );
+```
+
+### Params
+
+**pollId**: Poll ID.
+
+- Type: `Number`
+- Required: Yes
+
+### Return
+
+```json
+{
+	...
+}
+```
+
+## createPoll
+
+Creates a new poll.
+
+```javascript
+import { createPoll } from '@crowdsignal/rest-api';
+
+const poll = await createPoll( data );
+```
+
+### Params
+
+**data**: Poll data.
+
+- Type: `Object`
+- Required: Yes
+
+### Return
+
+```json
+{
+	...
+}
+```
+
+## updatePoll
+
+Updates an existing poll.
+
+```javascript
+import { updatePoll } from '@crowdsignal/rest-api';
+
+const result = await updatePoll( pollId, data );
+```
+
+### Params
+
+**data**: Poll data.
+
+- Type: `Object`
+- Required: Yes
+
+### Return

--- a/packages/rest-api/src/poll/index.js
+++ b/packages/rest-api/src/poll/index.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { http } from '@crowdsignal/http';
+
+export const fetchPoll = ( pollId ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: `/v4/polls/${ pollId }`,
+		method: 'GET',
+		mode: 'cors',
+		credentials: 'include',
+	} );
+
+export const createPoll = ( data ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: '/v4/polls',
+		method: 'POST',
+		mode: 'cors',
+		credentials: 'include',
+		body: JSON.stringify( data ),
+	} );
+
+export const updatePoll = ( pollId, data ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: `/v4/polls/${ pollId }`,
+		method: 'POST',
+		mode: 'cors',
+		credentials: 'include',
+		headers: {
+			'X-HTTP-Method-Override': 'PATCH',
+		},
+		body: JSON.stringify( data ),
+	} );

--- a/packages/rest-api/src/project/README.md
+++ b/packages/rest-api/src/project/README.md
@@ -1,0 +1,75 @@
+# Projects
+
+## fetchProject
+
+Returns a project.
+
+```javascript
+import { fetchProject } from '@crowdsignal/rest-api';
+
+const project = await fetchProject( projectId );
+```
+
+### Params
+
+**projectId**: Project ID.
+
+- Type: `Number`
+- Required: Yes
+
+### Return
+
+```json
+{
+	...
+}
+```
+
+## createProject
+
+Creates a new project.
+
+```javascript
+import { createProject } from '@crowdsignal/rest-api';
+
+const project = await createProject( data );
+```
+
+### Params
+
+**data**: Project data.
+
+- Type: `Object`
+- Required: Yes
+
+### Return
+
+```json
+{
+	...
+}
+```
+
+## updateProject
+
+Updates an existing project.
+
+```javascript
+import { updateProject } from '@crowdsignal/rest-api';
+
+const result = updateProject( projectId, data );
+```
+
+### Params
+
+**projectId**: Project ID.
+
+- Type: `Number`
+- Required: Yes
+
+**data**: Project data.
+
+- Type: `Object`
+- Required: Yes
+
+### Return

--- a/packages/rest-api/src/project/index.js
+++ b/packages/rest-api/src/project/index.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { http } from '@crowdsignal/http';
+
+export const fetchProject = ( projectId ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: `/v4/projects/${ projectId }`,
+		method: 'GET',
+		mode: 'cors',
+		credentials: 'include',
+	} );
+
+export const createProject = ( data ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: '/v4/projects',
+		method: 'POST',
+		mode: 'cors',
+		credentials: 'include',
+		body: JSON.stringify( data ),
+	} );
+
+export const updateProject = ( projectId, data ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: `/v4/projects/${ projectId }`,
+		method: 'POST',
+		mode: 'cors',
+		credentials: 'include',
+		headers: {
+			'X-Http-Method-Override': 'PATCH',
+		},
+		body: JSON.stringify( data ),
+	} );


### PR DESCRIPTION
This patch adds new poll and project route definitions to the `@crowdsignal/rest-api` package.  
As the payloads haven't been finalized yet, the README files will need to be updated later.

Update requests depend on d65222-code.

# Testing

Currently, it's difficult to test these changes on their own.