### PR TITLE
Add dashboard state

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,5 +31,12 @@
 		"@wordpress/no-unused-vars-before-return": [
 			"off"
 		],
+	},
+	"settings": {
+		"import/resolver": {
+			"node": {
+				"paths": ["apps/dashboard/src"]
+			}
+		}
 	}
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@crowdsignal/block-editor": "^0.1.0",
     "@crowdsignal/components": "^0.1.0",
+    "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
+    "@wordpress/data": "^6.0.0",
     "@wordpress/element": "^3.1.1",
     "@wordpress/i18n": "^4.1.1",
     "classnames": "^2.2.5",

--- a/apps/dashboard/src/data/action-types.js
+++ b/apps/dashboard/src/data/action-types.js
@@ -1,0 +1,7 @@
+export const NOTICE_CREATE = 'NOTICE_CREATE';
+export const NOTICE_REMOVE = 'NOTICE_REMOVE';
+export const POLL_SAVE = 'POLL_SAVE';
+export const POLL_UPDATE = 'POLL_UPDATE';
+export const PROJECT_SAVE = 'PROJECT_SAVE';
+export const PROJECT_UPDATE = 'PROJECT_UPDATE';
+export const ROUTE_UPDATE = 'ROUTE_UPDATE';

--- a/apps/dashboard/src/data/index.js
+++ b/apps/dashboard/src/data/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import * as pollActions from './polls/actions';
+import * as projectActions from './projects/actions';
+import pollControls from './polls/controls';
+import projectControls from './projects/controls';
+import * as pollSelectors from './polls/selectors';
+import * as projectSelectors from './projects/selectors';
+import reducer from './reducer';
+
+export const STORE_NAME = 'crowdsignal/dashboard';
+
+export const store = createReduxStore( STORE_NAME, {
+	actions: {
+		...pollActions,
+		...projectActions,
+	},
+	controls: {
+		...pollControls,
+		...projectControls,
+	},
+	selectors: {
+		...pollSelectors,
+		...projectSelectors,
+	},
+	reducer,
+} );
+
+register( store );

--- a/apps/dashboard/src/data/polls/actions.js
+++ b/apps/dashboard/src/data/polls/actions.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { POLL_SAVE, POLL_UPDATE } from 'data/action-types';
+
+export function savePoll( pollId, poll ) {
+	return {
+		type: POLL_SAVE,
+		pollId,
+		poll,
+	};
+}
+
+export function updatePoll( pollId, poll ) {
+	return {
+		type: POLL_UPDATE,
+		pollId,
+		poll,
+	};
+}
+
+export function* saveAndUpdatePoll( pollId, poll ) {
+	try {
+		const response = yield savePoll( pollId, poll );
+		const id = pollId || response.data.id;
+
+		return updatePoll( id, {
+			...poll,
+			id,
+		} );
+	} catch ( error ) {
+		// Save failed
+		throw error;
+	}
+}

--- a/apps/dashboard/src/data/polls/controls.js
+++ b/apps/dashboard/src/data/polls/controls.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { createPoll, updatePoll } from '@crowdsignal/rest-api';
+import { POLL_SAVE } from '../action-types';
+
+export default {
+	[ POLL_SAVE ]: ( { pollId, poll } ) => {
+		if ( ! pollId ) {
+			return createPoll( poll );
+		}
+
+		return updatePoll( poll );
+	},
+};

--- a/apps/dashboard/src/data/polls/reducer.js
+++ b/apps/dashboard/src/data/polls/reducer.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { POLL_UPDATE } from '../action-types';
+
+const items = ( state = {}, action ) => {
+	if ( action.type === POLL_UPDATE ) {
+		return {
+			...state,
+			[ action.pollId ]: action.poll,
+		};
+	}
+
+	return state;
+};
+
+export default combineReducers( {
+	items,
+} );

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { PROJECT_SAVE, PROJECT_UPDATE } from 'data/action-types';
+
+export function saveProject( projectId, project ) {
+	return {
+		type: PROJECT_SAVE,
+		projectId,
+		project,
+	};
+}
+
+export function updateProject( projectId, project ) {
+	return {
+		type: PROJECT_UPDATE,
+		projectId,
+		project,
+	};
+}
+
+export function* saveAndUpdateProject( projectId, project ) {
+	try {
+		const response = yield saveProject( projectId, project );
+		const id = projectId || response.data.id;
+
+		return updateProject( id, {
+			...project,
+			id,
+		} );
+	} catch ( error ) {
+		// Save failed
+		throw error;
+	}
+}

--- a/apps/dashboard/src/data/projects/controls.js
+++ b/apps/dashboard/src/data/projects/controls.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { createProject, updateProject } from '@crowdsignal/rest-api';
+import { PROJECT_SAVE } from 'data/action-types';
+
+export default {
+	[ PROJECT_SAVE ]: ( { projectId, project } ) => {
+		if ( ! projectId ) {
+			return createProject( project );
+		}
+
+		return updateProject( projectId );
+	},
+};

--- a/apps/dashboard/src/data/projects/reducer.js
+++ b/apps/dashboard/src/data/projects/reducer.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PROJECT_UPDATE } from 'data/action-types';
+
+const items = ( state = {}, action ) => {
+	if ( action.type === PROJECT_UPDATE ) {
+		return {
+			...state,
+			[ action.projectId ]: action.project,
+		};
+	}
+
+	return state;
+};
+
+const lastUpdatedItemId = ( state = 0, action ) => {
+	if ( action.type === PROJECT_UPDATE ) {
+		return action.projectId;
+	}
+
+	return state;
+};
+
+export default combineReducers( {
+	items,
+	lastUpdatedItemId,
+} );

--- a/apps/dashboard/src/data/projects/selectors.js
+++ b/apps/dashboard/src/data/projects/selectors.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export const getLastUpdatedProjectId = ( state ) =>
+	get( state, [ 'projects', 'lastUpdatedItemId' ], 0 );
+
+export const getProject = ( state, projectId ) =>
+	get( state, [ 'projects', 'items', projectId ], null );

--- a/apps/dashboard/src/data/reducer.js
+++ b/apps/dashboard/src/data/reducer.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import polls from './polls/reducer';
+import projects from './projects/reducer';
+import ui from './ui/reducer';
+
+export default combineReducers( {
+	polls,
+	projects,
+	ui,
+} );

--- a/apps/dashboard/src/data/ui/actions.js
+++ b/apps/dashboard/src/data/ui/actions.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { NOTICE_CREATE, NOTICE_REMOVE, ROUTE_UPDATE } from 'data/action-types';
+
+export function removeNotice( noticeId ) {
+	return {
+		type: NOTICE_REMOVE,
+		noticeId,
+	};
+}
+
+export async function* createNotice(
+	noticeId,
+	status,
+	message,
+	{ duration = 900, ...options }
+) {
+	yield {
+		type: NOTICE_CREATE,
+		noticeId,
+		message,
+		status,
+		options,
+	};
+
+	if ( ! options.duration ) {
+		return;
+	}
+
+	await new Promise( ( resolve ) => setTimeout( resolve, duration * 1000 ) );
+
+	return removeNotice( noticeId );
+}
+
+export const errorNotice = ( message, { id, ...options } ) =>
+	createNotice( id || uniqueId(), 'error', message, options );
+
+export const successNotice = ( message, { id, ...options } ) =>
+	createNotice( id || uniqueId(), 'success', message, options );
+
+export const infoNotice = ( message, { id, ...options } ) =>
+	createNotice( id || uniqueId(), 'info', message, options );
+
+export function redirect( path ) {
+	return {
+		type: ROUTE_UPDATE,
+		path,
+	};
+}

--- a/apps/dashboard/src/data/ui/controls.js
+++ b/apps/dashboard/src/data/ui/controls.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { redirect } from '@crowdsignal/router';
+import { ROUTE_UPDATE } from 'data/action-types';
+
+export default {
+	[ ROUTE_UPDATE ]: ( { path } ) => {
+		redirect( path );
+	},
+};

--- a/apps/dashboard/src/data/ui/reducer.js
+++ b/apps/dashboard/src/data/ui/reducer.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { NOTICE_CREATE, NOTICE_REMOVE } from 'data/action-types';
+
+const notices = ( state = {}, action ) => {
+	if ( action.type === NOTICE_CREATE ) {
+		return {
+			...state,
+			[ action.noticeId ]: {
+				...action.options,
+				id: action.noticeId,
+				message: action.status,
+				status: action.message,
+			},
+		};
+	}
+
+	if ( action.type === NOTICE_REMOVE ) {
+		return omit( state, action.noticeId );
+	}
+
+	return state;
+};
+
+export default combineReducers( {
+	notices,
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,6 +3563,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/markdown-to-jsx@^6.11.3":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
@@ -3593,6 +3598,11 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
+"@types/mousetrap@^1.6.8":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@types/mousetrap/-/mousetrap-1.6.8.tgz#448929e6dc21126392830465fdb9d4a2cfc16a88"
+  integrity sha512-zTqjvgCUT5EoXqbqmd8iJMb4NJqyV/V7pK7AIKq7qcaAsJIpGlTVJS1HQM6YkdHCdnkNSbhcQI7MXYxFfE3iCA==
 
 "@types/node-fetch@^2.5.7":
   version "2.5.10"
@@ -4422,6 +4432,26 @@
     react-resize-aware "^3.1.0"
     use-memo-one "^1.1.1"
 
+"@wordpress/compose@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-5.0.0.tgz#008ef94b726c9f41ec300efcfa5dc70d2f546450"
+  integrity sha512-57+3Bd8BqFwy53VLOmIyVfo6Sx0RTAd+2nzS7dOjiyeQ7NwIIN8D+NRQ4DG6A2yCrGzEf+foKiN/kQGFxMmu3g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/lodash" "4.14.149"
+    "@types/mousetrap" "^1.6.8"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/priority-queue" "^2.2.1"
+    clipboard "^2.0.1"
+    lodash "^4.17.21"
+    mousetrap "^1.6.5"
+    react-resize-aware "^3.1.0"
+    use-memo-one "^1.1.1"
+
 "@wordpress/core-data@^3.1.7", "@wordpress/core-data@^3.1.8":
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-3.1.8.tgz#d9e58ac7906f69db9cc3a8efeef14c01f148d302"
@@ -4472,6 +4502,25 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
+"@wordpress/data@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-6.0.0.tgz#c0413bd7bde3a11ac9c2b5c1afce6edbde39decd"
+  integrity sha512-fkub4wwdD2z7Ctn0syvNfDKodBeRlq/BCHObuklGAPu8hiyB7Fzel7VqHK11u77K+5fEO5UMYzqif1HDdICQOw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/priority-queue" "^2.2.1"
+    "@wordpress/redux-routine" "^4.2.1"
+    equivalent-key-map "^0.2.2"
+    is-promise "^4.0.0"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    turbo-combine-reducers "^1.0.2"
+    use-memo-one "^1.1.1"
+
 "@wordpress/date@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-4.1.1.tgz#409866d8d524a613a3c9d1f2cb9c8ebf428dc30e"
@@ -4505,6 +4554,14 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^3.1.1"
 
+"@wordpress/deprecated@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.2.1.tgz#6f8fab767308e5f9660961dcbbc9f8f3c843e01c"
+  integrity sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/hooks" "^3.2.0"
+
 "@wordpress/dom-ready@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-3.1.1.tgz#c1ec662ca12130e92e41d3d9c95041adce3dde22"
@@ -4516,6 +4573,14 @@
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.1.1.tgz#e533666db79ddc829d127fa11960726e3e22d341"
   integrity sha512-NkNkgczdQweWXXiP7uaXmuu58JsRU/WN9OTWT0pVTZumTQKsvm0Fcs55jt3NBG+X/F80DC+DPVW6+sTKv0Lqxg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    lodash "^4.17.21"
+
+"@wordpress/dom@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.2.1.tgz#8bc105537ebf05e1452a035f6e2de68a47d32723"
+  integrity sha512-sl1MzQT8nvUfmRSrZgsLyfQo7wGFxZlLOzmAGMD4bUX/x40ZYAmsGc7E9zn7jnaqOmpbXKviUy0nBZiYGpfc2w==
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
@@ -4572,10 +4637,30 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
+"@wordpress/element@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-4.0.0.tgz#ce184de100f96780196d7b08104f34bc29aaa5bf"
+  integrity sha512-jGQ+9Q/Ml36xmYMa5wqSDRNkmHL1/HqzjLIV91TkqURHSorul9o53ze5go0tYjeY6s8C97K1Alg4gi8V+Hu7hw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^2.2.1"
+    lodash "^4.17.21"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+
 "@wordpress/escape-html@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.1.1.tgz#4b9e887c2b1b06ec0d4fc691328224b4e9736c95"
   integrity sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@wordpress/escape-html@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.2.1.tgz#5fd699cffebf59b174f5043b43b6b3dd770e2755"
+  integrity sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -4629,6 +4714,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/hooks@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.2.0.tgz#84212541ec9b9834d337b233d120f3623de074c6"
+  integrity sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@wordpress/html-entities@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-3.1.1.tgz#dd396d24fada1e063792bf8b280ef46a96584e0d"
@@ -4643,6 +4735,19 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^3.1.1"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    sprintf-js "^1.1.1"
+    tannin "^1.2.0"
+
+"@wordpress/i18n@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.2.1.tgz#a6aa7ca24477faa089b53e3d362a2fea1fb8af84"
+  integrity sha512-56TW1rGRTgBZd2wZiMVxTuSi+1z5INpbQrLFjPwqhQJNiasDAUuUFzu4dRojkyBexJbB+1McYA1gv9xZlsJ8lg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/hooks" "^3.2.0"
     gettext-parser "^1.3.1"
     lodash "^4.17.21"
     memize "^1.1.0"
@@ -4680,6 +4785,13 @@
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.1.1.tgz#1e1a18ae15711f90e54e956f1d06fbb646c93e26"
   integrity sha512-Bc782s4Kte98RKLtuDXOaUBpyJWUgN4XZJevEoFasKQTpABZUDF+Y2C0/dhnlJeYF5TDEd8TQgFfpF5csxEUNw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@wordpress/is-shallow-equal@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.2.0.tgz#b334829dd0adc6942990cc35a227e6de482f3fa2"
+  integrity sha512-9Oy7f3HFLMNfry4LLwYmfx4tROmusPAOfanv9F/MgzSBfMH7eyxU2JZd4KrP7IbPb59UfoUa8GhaLsnqKm66og==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -4723,6 +4835,15 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@wordpress/i18n" "^4.1.1"
+    lodash "^4.17.21"
+
+"@wordpress/keycodes@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.2.1.tgz#107986320440e0e61ddae2c579307892a3e24f43"
+  integrity sha512-mjJu6a7bmWR4y2mrWUMIfJIkqF50u09y8seP9o1YDdecrJBon8VAOjVmfh+N4W6L/bVLHfTq4/6IZQaVKCy3xw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/i18n" "^4.2.1"
     lodash "^4.17.21"
 
 "@wordpress/list-reusable-blocks@^2.1.4":
@@ -4807,6 +4928,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/priority-queue@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.2.1.tgz#b281c2744ebf0b82e32d5d5fc950ee8b8d09d36f"
+  integrity sha512-ou3dbfnWvIsTH6fZJhveobOxO0VH09XpIoKalDPVB9TD65LP5Zuy5KTn0ASV5V/+5KEdMNRxQ1U/9uPJc6wIXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@wordpress/react-i18n@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/react-i18n/-/react-i18n-2.1.1.tgz#13b8f7195df48833ae76467956bd836fbee1b821"
@@ -4825,6 +4953,17 @@
     "@babel/runtime" "^7.13.10"
     is-promise "^4.0.0"
     lodash "^4.17.21"
+    rungen "^0.3.2"
+
+"@wordpress/redux-routine@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-4.2.1.tgz#9626b5a0b826dd6004c261900278d1aeaf4bc2f7"
+  integrity sha512-u//4vdeKzYvu4YBRmSUsIbnUazai+PybEnquLPqxQdaF4JqVN1D5OPWHSeFtmaXR1c78I+lUf40Q7dnmA2waXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    is-promise "^4.0.0"
+    lodash "^4.17.21"
+    redux "^4.1.0"
     rungen "^0.3.2"
 
 "@wordpress/reusable-blocks@^2.1.11", "@wordpress/reusable-blocks@^2.1.8":
@@ -15614,7 +15753,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@17.0.2:
+react-dom@17.0.2, react-dom@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -15829,7 +15968,7 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-react@17.0.2:
+react@17.0.2, react@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
This patch adds the initial state for the dashboard. So far I've added the following:

- Actions & controls for saving polls and projects to the Crowdsignal backend.
- A `redirect` action with a control to trigger `redirect()` from `@crowdsignal/router`.
- A complete implementation of state for notices, that will be used to display succes/info/error notices throughout the app - however we don't have a notice component just yet.

Depends on #21 and #23.

# Testing

These changes are pretty much internal and remain unconnected at this point. No tests necessary.