### PR TITLE
Send request with blocks

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -43,11 +43,11 @@ const Editor = ( { projectId } ) => {
 		}
 	}, [] );
 
-	const handleSaveContent = useCallback(
-		debounce( ( content ) => {
+	const handleSaveBlocks = useCallback(
+		debounce( ( blocks ) => {
 			try {
 				saveAndUpdateProject( projectId, {
-					content,
+					blocks,
 				} );
 			} catch ( error ) {
 				// console.error( error );
@@ -68,7 +68,7 @@ const Editor = ( { projectId } ) => {
 				projectId={ projectId }
 			/>
 
-			<BlockEditor onSave={ handleSaveContent } />
+			<BlockEditor onSave={ handleSaveBlocks } />
 		</div>
 	);
 };

--- a/apps/dashboard/src/data/projects/controls.js
+++ b/apps/dashboard/src/data/projects/controls.js
@@ -10,6 +10,6 @@ export default {
 			return createProject( project );
 		}
 
-		return updateProject( projectId );
+		return updateProject( projectId, project );
 	},
 };

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -10,7 +10,7 @@ export const BlockEditor = ( { onSave } ) => {
 	return (
 		<IsolatedBlockEditor
 			settings={ settings }
-			onSaveContent={ onSave }
+			onSaveBlocks={ onSave }
 			onLoad={ ( parse ) => parse( '' ) }
 			onError={ noop }
 		/>


### PR DESCRIPTION
This PR changes the save handler on the editor so the raw blocks can be sent instead of the HTML markup.

`onSaveBlocks` accepts a second argument which represents *ignoredContent*. This argument carries all things NOT to be parsed, like new lines and the kind. For now, it's just ignored (well thought argument name here, kudos).

Also added the payload on the `rest-api.updateProject`  call.

Ref: [onSaveBlocks](https://github.com/Automattic/isolated-block-editor#onsaveblocks)