### PR TITLE
Bump isolated-block-editor to version 2.3.0

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -24,8 +24,8 @@
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
     "@wordpress/data": "^6.0.0",
-    "@wordpress/element": "^3.1.1",
-    "@wordpress/i18n": "^4.1.1",
+    "@wordpress/element": "^4.0.0",
+    "@wordpress/i18n": "^4.2.1",
     "classnames": "^2.2.5",
     "lodash": "^4.17.21"
   },

--- a/apps/feedback-widget/package.json
+++ b/apps/feedback-widget/package.json
@@ -25,9 +25,9 @@
     "@crowdsignal/components": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/styles": "^0.1.0",
-    "@wordpress/components": "^14.1.1",
-    "@wordpress/element": "^3.1.1",
-    "@wordpress/i18n": "^4.1.1",
+    "@wordpress/components": "^15.0.0",
+    "@wordpress/element": "^4.0.0",
+    "@wordpress/i18n": "^4.2.1",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -2,24 +2,24 @@
   "name": "@crowdsignal/block-editor",
   "version": "0.1.0",
   "description": "Crowdsignal Block Editor",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
   "keywords": [
     "crowdsignal"
   ],
-  "author": "Automattic Inc.",
   "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/block-editor/README.md",
-  "license": "GPL-2.0-or-later",
-  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
   },
-  "scripts": {
-  },
   "bugs": {
     "url": "https://github.com/Automattic/crowdsignal-ui/issues"
   },
+  "main": "src/index.js",
   "dependencies": {
-    "isolated-block-editor": "github:automattic/isolated-block-editor#1.2.2",
+    "isolated-block-editor": "github:automattic/isolated-block-editor#2.3.0",
     "lodash": "^4.17.21"
+  },
+  "scripts": {
   }
 }

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -4,6 +4,11 @@
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
 import { noop } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const settings = {};
 
 export const BlockEditor = ( { onSave } ) => {

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -1,0 +1,6 @@
+@import '~@wordpress/components/build-style/style.css';
+@import '~@wordpress/block-editor/build-style/style.css';
+@import '~@wordpress/block-library/build-style/style.css';
+@import '~@wordpress/block-library/build-style/editor.css';
+@import '~@wordpress/block-library/build-style/theme.css';
+@import '~@wordpress/format-library/build-style/style.css';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@crowdsignal/hooks": "^0.1.0",
     "@crowdsignal/styles": "^0.1.0",
-    "@wordpress/element": "^3.1.1",
-    "@wordpress/i18n": "^4.1.1",
+    "@wordpress/element": "^4.0.0",
+    "@wordpress/i18n": "^4.2.1",
     "classnames": "^2.2.5",
     "lodash": "^4.17.21"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,7 +17,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@wordpress/element": "^3.1.1",
+    "@wordpress/element": "^4.0.0",
     "lodash": "^4.17.21"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -18,7 +18,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@wordpress/element": "^3.1.1",
+    "@wordpress/element": "4.0.0",
     "history": "^5.0.0",
     "lodash": "^4.17.21",
     "route-parser": "^0.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,7 +634,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-jsx@^7.14.5":
+"@babel/plugin-syntax-jsx@^7.12.13", "@babel/plugin-syntax-jsx@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz#000e2e25d8673cce49300517a3eda44c263e4201"
   integrity sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==
@@ -1224,6 +1224,24 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
+"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz#3a16850ba04d8d9651f07f3fb674b3436a4fb9d7"
+  integrity sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "^4.0.3"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.29":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -1233,6 +1251,17 @@
     "@emotion/stylis" "0.8.5"
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/cache@^11.1.3", "@emotion/cache@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
+  integrity sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
 
 "@emotion/core@^10.1.1":
   version "10.1.1"
@@ -1255,7 +1284,18 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.8.0":
+"@emotion/css@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.1.3.tgz#9ed44478b19e5d281ccbbd46d74d123d59be793f"
+  integrity sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==
+  dependencies:
+    "@emotion/babel-plugin" "^11.0.0"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+
+"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -1267,10 +1307,35 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz#29ef6be1e946fb4739f9707def860f316f668cde"
+  integrity sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.5":
+  version "11.4.1"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.4.1.tgz#a1b0b767b5bad57515ffb0cad9349614d27f4d57"
+  integrity sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.0.2"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
 
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
@@ -1283,10 +1348,26 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
+"@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
 "@emotion/sheet@0.9.4":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.2.tgz#1d9ffde531714ba28e62dac6a996a8b1089719d0"
+  integrity sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw==
 
 "@emotion/styled-base@^10.0.27":
   version "10.0.31"
@@ -1306,12 +1387,23 @@
     "@emotion/styled-base" "^10.0.27"
     babel-plugin-emotion "^10.0.27"
 
+"@emotion/styled@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
+  integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.3.0"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/utils" "^1.0.0"
+
 "@emotion/stylis@0.8.5":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -1321,7 +1413,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
 
-"@emotion/weak-memoize@0.2.5":
+"@emotion/utils@1.0.0", "@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -4161,33 +4258,42 @@
     "@wordpress/dom-ready" "^3.1.1"
     "@wordpress/i18n" "^4.1.1"
 
-"@wordpress/annotations@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/annotations/-/annotations-2.1.2.tgz#f7d7f54c179c3cd2d2a34b8065feeb7435222080"
-  integrity sha512-VFbBu7IczGzUy3oEMrFjXwdhkR0IV79ItiXM1z2qnTLm6GoC+Fgi/l5CtexErZINQauHTFWuSuHEuedWHNRCwA==
+"@wordpress/a11y@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-3.2.1.tgz#87cbb71228388ecf7d04d175f2990391e2882c5e"
+  integrity sha512-DSKSEkRmucjjF9ORiHHcUemtmNLckuE9auEovEVKeVfOBkLpx4qS6kMaxK8CCU9PUSBU9szfwwfoAz+YMQq6dg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/rich-text" "^4.1.2"
+    "@wordpress/dom-ready" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+
+"@wordpress/annotations@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/annotations/-/annotations-2.2.1.tgz#399fe39968afaefc2a60e6df4a92fba10d788c99"
+  integrity sha512-sH2TG4hmHmM0pipZHU6rnJo5ZV29XMT+rE3jBjT1fk5zO/QoA7o5xfx9dpACmUR6HfdvlEyLO2VpKChdHFw9uA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/rich-text" "^5.0.0"
     lodash "^4.17.21"
     rememo "^3.0.0"
     uuid "^8.3.0"
 
-"@wordpress/api-fetch@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-5.1.1.tgz#6f5b9bdaf34c5b25335b1d6f5a381accc186646c"
-  integrity sha512-pThYQhoKiePeGgb5aZnc4A9YT5WktfZkejSk4JIfFxdzXF7YXunyMoA9Aib2YvY94IkItLzBeTl/jDk9yYL2hw==
+"@wordpress/api-fetch@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-5.2.1.tgz#6c3c9895a931c4c28b5280550e8dbb601097dd54"
+  integrity sha512-hmZnll1Z4u9A1vS3hHf9epzTvK+oIWkASLPO+Yq1BK1SwDiNGcZxwWMr+kDSEWd0ProccTsgo4EAbIS9vnhoUQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/url" "^3.1.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/url" "^3.2.1"
 
-"@wordpress/autop@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-3.1.1.tgz#e28a0c1921b7db65875abd9204c2e5f2e7f8e1ff"
-  integrity sha512-ZwZy1DNyXQWX1k4cN3lAzVgcAii6bzFXUS08Zj8kaQf+hNE+BwX5cNb/TK98QQQYNAoiCnt4DiWiD1nxwM+EdA==
+"@wordpress/autop@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-3.2.1.tgz#8676ec896796fc9f938a068e4c298d2dac65c414"
+  integrity sha512-dp5jm72v53ygEHiPp6CTyE8AzLEZ/YpW7kRKJGQwYz4U7wwkkfpsoattc/9uaQsv06AP6rEzT/ioGFOVZRuv9g==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -4224,44 +4330,45 @@
   resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-3.5.4.tgz#e5769ff2c87183aa245454d2411f61f3bd97db60"
   integrity sha512-5JfLnkQMqaefuoMkqUJMBC8m9RpXJqaaOykxuy9y3uk+s2ENbMGXSUjbzw+anO3SIRORKnHmRkgofcSoqvWV5w==
 
-"@wordpress/blob@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-3.1.1.tgz#47d1b6097744dfdc86a06427f5938f6fa9f8a520"
-  integrity sha512-yuT184YYi690FgsV7+1PgWPV7t6eQFhi/sAkzQ6cc+iZFaIELvX5gBcqomB3tc3GuXnhwmKTjQDzuzaepX4BoQ==
+"@wordpress/blob@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-3.2.1.tgz#f8056ac4ca027440ad2fe73bd7e4dad40b85d3cc"
+  integrity sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/block-editor@^6.1.5", "@wordpress/block-editor@^6.1.8":
-  version "6.1.8"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-editor/-/block-editor-6.1.8.tgz#6742679fc9131181d63c63b0c25f039170d1c4e3"
-  integrity sha512-kYQo8jydLzO5/4QNLoM1KfEFHCEVPOYxFg7VU84lWIlhupQDn/6fNtxTlZdJixNjLfbiV1lnHbroxqtbvh+KWA==
+"@wordpress/block-editor@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-editor/-/block-editor-7.0.0.tgz#0f316478ea6cfbac5918aaeed3726cbd868af480"
+  integrity sha512-j8GjUD4UdxiKE2vSg0cGObZrwf9RfwlG8wWhbia4mvyIFX5u90Y+CLj0lSZ2XfZe+ZgEx7XIqU34P0vu8xY6Yg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/block-serialization-default-parser" "^4.1.1"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/data-controls" "^2.1.2"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keyboard-shortcuts" "^2.1.2"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/notices" "^3.1.2"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/shortcode" "^3.1.1"
-    "@wordpress/token-list" "^2.1.1"
-    "@wordpress/url" "^3.1.1"
-    "@wordpress/wordcount" "^3.1.1"
-    classnames "^2.2.5"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/block-serialization-default-parser" "^4.2.1"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/data-controls" "^2.2.1"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keyboard-shortcuts" "^3.0.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/notices" "^3.2.1"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/shortcode" "^3.2.1"
+    "@wordpress/token-list" "^2.2.0"
+    "@wordpress/url" "^3.2.1"
+    "@wordpress/warning" "^2.2.1"
+    "@wordpress/wordcount" "^3.2.1"
+    classnames "^2.3.1"
     css-mediaquery "^0.1.2"
     diff "^4.0.2"
     dom-scroll-into-view "^1.2.1"
@@ -4275,40 +4382,41 @@
     tinycolor2 "^1.4.2"
     traverse "^0.6.6"
 
-"@wordpress/block-library@^3.2.8":
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-library/-/block-library-3.2.12.tgz#4a354fdbe854300e151ce60dc7e4a670e67766fb"
-  integrity sha512-WQn6mcNDlMfIdy/TSz9Ih1s2DStHRKvBrHyR8YAYHRyRF254HBGDvz4ehTG5PGu5qqcE7phdzAH0g/Ca7XSq6w==
+"@wordpress/block-library@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-library/-/block-library-5.0.0.tgz#dd47e33fd0da4c2c6bbd22df015c07b2b3cae07e"
+  integrity sha512-J2RbVmFcrLMa5LJ0emgrc6OsEP2DQaDSIkbSKaxNll5vt9GYAMV3SjgT2O8VEE/nfiFgTbfoX9ANho1pdvNRmA==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/autop" "^3.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/block-editor" "^6.1.8"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/core-data" "^3.1.8"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/date" "^4.1.1"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/escape-html" "^2.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/notices" "^3.1.2"
-    "@wordpress/primitives" "^2.1.1"
-    "@wordpress/reusable-blocks" "^2.1.11"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/server-side-render" "^2.1.6"
-    "@wordpress/url" "^3.1.1"
-    "@wordpress/viewport" "^3.1.2"
-    classnames "^2.2.5"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/autop" "^3.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/block-editor" "^7.0.0"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/core-data" "^4.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/date" "^4.2.1"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/escape-html" "^2.2.1"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/notices" "^3.2.1"
+    "@wordpress/primitives" "^3.0.0"
+    "@wordpress/reusable-blocks" "^3.0.0"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/server-side-render" "^3.0.0"
+    "@wordpress/url" "^3.2.1"
+    "@wordpress/viewport" "^4.0.0"
+    classnames "^2.3.1"
     fast-average-color "4.3.0"
     lodash "^4.17.21"
     memize "^1.1.0"
@@ -4317,41 +4425,41 @@
     react-easy-crop "^3.0.0"
     tinycolor2 "^1.4.2"
 
-"@wordpress/block-serialization-default-parser@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.1.1.tgz#169562114ee81b58e96599c969b71a390019b4e3"
-  integrity sha512-WBpsFmXy9JK0Jx3CyAe4GFFdIqt7ZRcCD88Wrhf4oJrPbJutdsGMjaSpP3SOwWTh+xeJGiyePjwa3+1Zw0KHcw==
+"@wordpress/block-serialization-default-parser@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.1.tgz#a9b70b5eaae746727d851420a224ece23eb2fa57"
+  integrity sha512-TKLGqFiysDKtLnc0pjPD1AOU5fg0LX12XfrK9Ke6QmCP2q7e57+9ZM9SRzXQ2U8GRgsIiwhjzi31R2HQGXqYng==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/block-serialization-spec-parser@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-4.1.1.tgz#22e72d86a8d7ec95d7cfc0e0b7911aef541e582e"
-  integrity sha512-T9bEw6zJmp6u0Yiqe+ZKfkgSyWug1kafnkbRN82cX8GVLVGC9uqT1XYriGJREGFS1jN5kNhvo6tDHkb/gsenBw==
+"@wordpress/block-serialization-spec-parser@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-4.2.0.tgz#af525df2e21826ee7772f3690489ff98d12ae2d8"
+  integrity sha512-QPu0jdZXXYYQ5N/UFHIM1Zbk+0faGMj4bh9c7UOIjmk5Vm3CSncd7mB6IvxzB9xrFVx++vmyBceNnZjlplOWpA==
   dependencies:
     pegjs "^0.10.0"
     phpegjs "^1.0.0-beta7"
 
-"@wordpress/blocks@^9.1.4":
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-9.1.4.tgz#4c8354603d31be061cdc8205d1dcdb0f5b64ee96"
-  integrity sha512-t822wnj+mueRvGoxlLywKeEXDeyiNNBghCMg8g7hCFhV9/0aBHJSolia3FFXLcVWYH9V8cMI1jUgGUdvVxnbuQ==
+"@wordpress/blocks@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-11.0.0.tgz#f3356637d0c2cef66d2eee3d4994a2b1bc6e9947"
+  integrity sha512-r6xvEkj9VTqNYD2HgPwQQze5MwvhNJoqi7tCMv90fm8iDmHP5IumB5DEpfZLVegLXBVkliWxK87stIOQnkoOGQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/autop" "^3.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/block-serialization-default-parser" "^4.1.1"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/shortcode" "^3.1.1"
+    "@wordpress/autop" "^3.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/block-serialization-default-parser" "^4.2.1"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/shortcode" "^3.2.1"
     hpq "^1.3.0"
     lodash "^4.17.21"
     rememo "^3.0.0"
@@ -4370,7 +4478,7 @@
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-4.0.1.tgz#dcb1b4bcef1224c5a6c814a8e8ea4be83baa7740"
   integrity sha512-mmLxc21NWxZSSPvD592tmzpBlme+nB0fbG1xO+EldS4vQkeWIQUZlNbrMijZM/hpFaBqDEJCAZFUPUpw1XwBWg==
 
-"@wordpress/components@^14.1.1", "@wordpress/components@^14.1.4", "@wordpress/components@^14.1.5":
+"@wordpress/components@^14.1.1":
   version "14.1.5"
   resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-14.1.5.tgz#7d5773d9ca10b1e8d53324e487f725d6a04cb452"
   integrity sha512-WFCbwILD7+wOjXJEfy0sBrBX7iLd6lkNmotvOnsJBCFbL4qIKe1eyLsieewJhHUVuprJ3SilblvV6sO7qM0Wcg==
@@ -4409,6 +4517,49 @@
     react-spring "^8.0.20"
     react-use-gesture "^9.0.0"
     reakit "^1.3.5"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.2"
+    uuid "^8.3.0"
+
+"@wordpress/components@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-15.0.0.tgz#5dac7bc2827d08363f27114d961989058783f281"
+  integrity sha512-jcsWPAwPIGz8Bu6LuO0fP0G3O8+5LrSZRmIYF+L/LEYeBWTaRJsIM/GBf4y6tWm8FJMOYfhbokPXzRTcB/qobg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/css" "^11.1.3"
+    "@emotion/react" "^11.1.5"
+    "@emotion/styled" "^11.3.0"
+    "@emotion/utils" "1.0.0"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/date" "^4.2.1"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/primitives" "^3.0.0"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/warning" "^2.2.1"
+    classnames "^2.3.1"
+    dom-scroll-into-view "^1.2.1"
+    downshift "^6.0.15"
+    gradient-parser "^0.1.5"
+    highlight-words-core "^1.2.2"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    moment "^2.22.1"
+    re-resizable "^6.4.0"
+    react-dates "^17.1.1"
+    react-resize-aware "^3.1.0"
+    react-spring "^8.0.20"
+    react-use-gesture "^9.0.0"
+    reakit "^1.3.8"
     rememo "^3.0.0"
     tinycolor2 "^1.4.2"
     uuid "^8.3.0"
@@ -4452,35 +4603,35 @@
     react-resize-aware "^3.1.0"
     use-memo-one "^1.1.1"
 
-"@wordpress/core-data@^3.1.7", "@wordpress/core-data@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-3.1.8.tgz#d9e58ac7906f69db9cc3a8efeef14c01f148d302"
-  integrity sha512-ZQBADH5EooVDg5KMnt1fcWq87EtotPDlAiqN8/hwBy7KavkOKZVH7pAlBcoY6CSlNxm5X808XiDW1LObcqwDkw==
+"@wordpress/core-data@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-4.0.0.tgz#c5d51d329d3df414b0435d8b3c2bb99cdc1e3ba1"
+  integrity sha512-VLA2IzI4DnVVRlHLuqHEXGRM6GRSrZWILTPiA2p2ttmaD73N+MB3rLzvJVl6WpOpnDfdquOFVFMLTEZBIpLt9g==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/data-controls" "^2.1.2"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/url" "^3.1.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/data-controls" "^2.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/url" "^3.2.1"
     equivalent-key-map "^0.2.2"
     lodash "^4.17.21"
     rememo "^3.0.0"
     uuid "^8.3.0"
 
-"@wordpress/data-controls@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/data-controls/-/data-controls-2.1.2.tgz#567deef0947dd64e63d3698e7209bb3fac1990a4"
-  integrity sha512-tWj27FsRCZbLh0EZCOAFq4bNuZx7mWNcY/kX5aiXrUx8H9OX4W/nqc2oe70Dfzlmu5+rVl+Vs30L1pdKWpycIg==
+"@wordpress/data-controls@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/data-controls/-/data-controls-2.2.1.tgz#cb2933acb835f3f9c2b6b4375dd3e552af9d85e5"
+  integrity sha512-w4LScjPn7i4IBUlnsucXkOFqIKOVQu+7MZaL82JbYPro0t5tMtnlq0ZUtWXuZcvUOtOyw8XH8jEnluzqJWVM8Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/deprecated" "^3.1.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/deprecated" "^3.2.1"
 
 "@wordpress/data@^5.1.2":
   version "5.1.2"
@@ -4530,6 +4681,15 @@
     moment "^2.22.1"
     moment-timezone "^0.5.31"
 
+"@wordpress/date@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-4.2.1.tgz#4742e82018ec64075a9fefc795d26f3f21643ebc"
+  integrity sha512-1I9B+PvtdJAt5R5ON6fq3ux76GUltk/V5dYjhsN8CYzmuSNpIY7hNFbbr9LgRswSdPH1zhR+a/mqhzdDU99PRA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    moment "^2.22.1"
+    moment-timezone "^0.5.31"
+
 "@wordpress/dependency-extraction-webpack-plugin@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.9.0.tgz#0b38278afc0429506a1ae6b82a2fc8a88bc25f58"
@@ -4569,6 +4729,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/dom-ready@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-3.2.1.tgz#827b61e5e764e2a302c9664609f567266b2954b6"
+  integrity sha512-2Tsc/SyqZMzLhJffkmgz0j9ziJKFkCpMELba9PPp8HaYYWWY67G9XxKarRbS6TSrpwpa4YI+KLc/LStDP0wpMQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@wordpress/dom@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.1.1.tgz#e533666db79ddc829d127fa11960726e3e22d341"
@@ -4585,40 +4752,40 @@
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
 
-"@wordpress/editor@^10.1.8":
-  version "10.1.11"
-  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-10.1.11.tgz#239358b793ffa1f971499e3d508bebcc4d3259eb"
-  integrity sha512-IpWo4oNfTRvMdHGiLmgE8smja3SFXVa7ei+9JuQ2eyxh1Em04tbV7wh8BGk36VqOsBTQE7sIziGJI+BdLl5LlQ==
+"@wordpress/editor@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-11.0.0.tgz#5bde129fc4576970e5a4628e0ce6a02d0ef11e6f"
+  integrity sha512-/LNtzn/OWfKV1xyFoWdOIC7cMPFyxIUYgH/AbuLrknwJhwPqPTDYxuuXuBRFrJEbYnQar+Phf8cG/xTRfKlcrA==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/autop" "^3.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/block-editor" "^6.1.8"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/core-data" "^3.1.8"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/data-controls" "^2.1.2"
-    "@wordpress/date" "^4.1.1"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keyboard-shortcuts" "^2.1.2"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/media-utils" "^2.1.1"
-    "@wordpress/notices" "^3.1.2"
-    "@wordpress/reusable-blocks" "^2.1.11"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/server-side-render" "^2.1.6"
-    "@wordpress/url" "^3.1.1"
-    "@wordpress/wordcount" "^3.1.1"
-    classnames "^2.2.5"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/autop" "^3.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/block-editor" "^7.0.0"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/core-data" "^4.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/data-controls" "^2.2.1"
+    "@wordpress/date" "^4.2.1"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keyboard-shortcuts" "^3.0.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/media-utils" "^3.0.0"
+    "@wordpress/notices" "^3.2.1"
+    "@wordpress/reusable-blocks" "^3.0.0"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/server-side-render" "^3.0.0"
+    "@wordpress/url" "^3.2.1"
+    "@wordpress/wordcount" "^3.2.1"
+    classnames "^2.3.1"
     lodash "^4.17.21"
     memize "^1.1.0"
     react-autosize-textarea "^7.1.0"
@@ -4686,25 +4853,25 @@
     prettier "npm:wp-prettier@2.2.1-beta-1"
     requireindex "^1.2.0"
 
-"@wordpress/format-library@^2.1.5":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@wordpress/format-library/-/format-library-2.1.8.tgz#966a5f1a71a45f2ea68e6967fafb253ceb112635"
-  integrity sha512-MFikZJtFLX/NUrLSIC8+uZu4KX5T3wEPQVygKyV9bFc7xoMGPwoxv8FmSGSYjCtTTxCVLs9EJmv01swGPlvsGg==
+"@wordpress/format-library@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/format-library/-/format-library-3.0.0.tgz#c511e66a108ce72e266e2e1f0e3f34cb0c7ab902"
+  integrity sha512-kAk0oS3CVHVn9pSauxhMHp4WKjB5LK+vcx5RMF4E/UJUar4wTPpD1HFP5CnVSqcwec7AgPnV1bnmvCWZyLYsaQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/block-editor" "^6.1.8"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/url" "^3.1.1"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/block-editor" "^7.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
 
 "@wordpress/hooks@^3.1.1":
@@ -4721,10 +4888,10 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/html-entities@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-3.1.1.tgz#dd396d24fada1e063792bf8b280ef46a96584e0d"
-  integrity sha512-LDeSO//QV0rm7u4SoYz2wa9fM0VhvInwWI8+mT+7jPubkgC+2DfaPte7ahofPz4/lQd9MAQ9NgvGXWTw2x0/vw==
+"@wordpress/html-entities@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-3.2.1.tgz#05345a0bd8752fbfc321b8b5e8f528e79acda81f"
+  integrity sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -4763,22 +4930,31 @@
     "@wordpress/element" "^3.1.1"
     "@wordpress/primitives" "^2.1.1"
 
-"@wordpress/interface@^3.1.5":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@wordpress/interface/-/interface-3.1.6.tgz#2643a510a8936359e1beea9322515338b2bfb203"
-  integrity sha512-H7vTqxmTkpRq8v2aS+KgDHoxL5O6zf3AgM/sHuubZ4lPen22of2iRcCjKI627S3fwVZYOVVHQduboOHP4rUrlg==
+"@wordpress/icons@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-5.0.0.tgz#9d57a70c413fbd5876756d5f07781fd0c31b1e14"
+  integrity sha512-FSt/uSBfB12h7Vu62/jy45TZp5ay95OKeuJjquGs+TU6JcoRdH8BxFvmy+7QIlVJyczToM2aP+KY1Bofb136Eg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/plugins" "^3.1.2"
-    "@wordpress/viewport" "^3.1.2"
-    classnames "^2.2.5"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/primitives" "^3.0.0"
+
+"@wordpress/interface@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/interface/-/interface-4.0.0.tgz#6a676eff998643c982988dcf41140d71d54890c3"
+  integrity sha512-lCP+Ro7bbZVGNlaqrgeJBaxzhnqIMjCWik/18i8YJSQQNqJUnrrn8uEe96A8oaD69ERWGIQ7BGYBrP7fQtXHdA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/plugins" "^4.0.0"
+    "@wordpress/viewport" "^4.0.0"
+    classnames "^2.3.1"
     lodash "^4.17.21"
 
 "@wordpress/is-shallow-equal@^4.1.1":
@@ -4815,16 +4991,16 @@
     enzyme-adapter-react-16 "^1.15.2"
     enzyme-to-json "^3.4.4"
 
-"@wordpress/keyboard-shortcuts@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-2.1.2.tgz#d4d5a0f5f8c92d42e8307da5b27c554602154098"
-  integrity sha512-3GfvtwwI00zZszSDcMAKoJXDB2FxUgcZrZeqjniBs9OOaHYcfdvgZGZZbl27JdgR0XFYKZwvVbC9o14BKsPeRA==
+"@wordpress/keyboard-shortcuts@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.0.tgz#f8f42445aa2f2456f5f58d1afd89fde436951682"
+  integrity sha512-C25tPSTYhbM5ImnQyS0FvGlOnS2R4yJov0bs7RSJeg7M7xqJtqBN3AEWq1iXkomeL+1z7jmV2N9gsHCoyxo1Wg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/keycodes" "^3.1.1"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/keycodes" "^3.2.1"
     lodash "^4.17.21"
     rememo "^3.0.0"
 
@@ -4846,39 +5022,39 @@
     "@wordpress/i18n" "^4.2.1"
     lodash "^4.17.21"
 
-"@wordpress/list-reusable-blocks@^2.1.4":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@wordpress/list-reusable-blocks/-/list-reusable-blocks-2.1.5.tgz#b611c48cbce29bc6433b81aca728cebcbc0d5701"
-  integrity sha512-piSydIjVtWs79CwVlj8WfbsYjGZgeGvBU0Igs48Cbn/iLQ6laxD+VRH+vMQBhOKY7H3Jd/+kFx2vINbnFNytDw==
+"@wordpress/list-reusable-blocks@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/list-reusable-blocks/-/list-reusable-blocks-3.0.0.tgz#ffb16b2552a95dd796c145cff84b9499b61f8da5"
+  integrity sha512-OkWOx9F5LFhiK5WCmQbBjAC9HKPz92RV29QK4xvN3dU0UTwRC0eDJ8XnJaVLS3baJk2xuNS+o6ZoJ5IuqCGoyw==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
     lodash "^4.17.21"
 
-"@wordpress/media-utils@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/media-utils/-/media-utils-2.1.1.tgz#1529fe1dec49eb6ba3a78c88c1993925a8a5120d"
-  integrity sha512-pp39/OYrr9yhvpgPfRk/ZCNE3kCZ3L9NC9fvwnNiMR5BjfkWPseezXRknnWpAdHccELAcu6WBxzXAZLoGH1/vQ==
+"@wordpress/media-utils@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/media-utils/-/media-utils-3.0.0.tgz#d2cdcbe53d5fcbf74d0814174807ab68c3776802"
+  integrity sha512-oMs71qObEAFyYjBo8DDRrVf0+v8B4y1lNGWTb4FfXTx6e1tX12hi0tR0sKvRZJR/zmmpCMkJrAeWy3u3n7Cokw==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
     lodash "^4.17.21"
 
-"@wordpress/notices@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/notices/-/notices-3.1.2.tgz#89bb832cbd660ad287bb35ff88ecb0d2d48eab14"
-  integrity sha512-cz6w0CmWYqkyyMzZYRCMFbm5Eagd/vE/I3i0zgAHwaCy56ubZwte8ges32BGAl0AeH0XbxXEF8AcOjjb5Dwqtw==
+"@wordpress/notices@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/notices/-/notices-3.2.1.tgz#0ce6a4332b2b394905646610fe709b941961b4e4"
+  integrity sha512-BQHbaswaVEozE2qcIemauX9tnOdxhfDkQuP318zImAlwIHRF5ZGpAsx+ETBjlMrwDJufAm8+xHRmjk1lyesdUw==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/data" "^5.1.2"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/data" "^6.0.0"
     lodash "^4.17.21"
 
 "@wordpress/npm-package-json-lint-config@^4.0.5":
@@ -4886,16 +5062,16 @@
   resolved "https://registry.yarnpkg.com/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.5.tgz#68033f730c06ba0f0e2f7e68ef9deeeef56a6ac8"
   integrity sha512-kckj06QsUe7fSGYWiOhsXbAgU2sL9s/gy7GynvQCqOPPiLGpJ8PvCx8OLMaT0T75CXFqieGvfS8Dtf+d84mFvg==
 
-"@wordpress/plugins@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-3.1.2.tgz#17df984d879153982d3125358f947cc0d44d6628"
-  integrity sha512-Ws+ZIpcNRRGubF11u0xvtznfNFzGBVv4Qc4+4iDNln7wIjCSVRdpyZQTpvcgjMYNqFj1LPb0f3jrKeHnRp0P9g==
+"@wordpress/plugins@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-4.0.0.tgz#ed202ffbb63f516f6457670634ed180a2d4ab836"
+  integrity sha512-vDddiBwoyj1oTGKb4A0aA7sF7SrTM2tIZu4YJ717nL45Ec+uhPkw8XxM3plsED2OZJwlhvuHuXLaUsJVQvoC1Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/icons" "^4.0.1"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/icons" "^5.0.0"
     lodash "^4.17.21"
     memize "^1.1.0"
 
@@ -4921,6 +5097,15 @@
     "@wordpress/element" "^3.1.1"
     classnames "^2.2.5"
 
+"@wordpress/primitives@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-3.0.0.tgz#f96ea8c04edf9c5eee7f58b3f493f566557c0fca"
+  integrity sha512-GwBlY4Bb5yBoEpjzBvs65lfaI9+hYWByW8FmgvibdGZt1/BjKLIStifwMxOOdwhMis0AwtNxiwDLEScmy/nLBQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/element" "^4.0.0"
+    classnames "^2.3.1"
+
 "@wordpress/priority-queue@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.1.1.tgz#c22fc152c426181fecb0ca1397daff27a6ff2918"
@@ -4935,14 +5120,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/react-i18n@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/react-i18n/-/react-i18n-2.1.1.tgz#13b8f7195df48833ae76467956bd836fbee1b821"
-  integrity sha512-BY7abOvTGVkbiLR7N2l4wSNfrMAv9wS0GO8VEaHKDFQ+Dz4jLgJySvDnvftDfYIZ+cVgDkGCmbLkxkXwzqStWA==
+"@wordpress/react-i18n@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/react-i18n/-/react-i18n-3.0.0.tgz#275b9377d58abd8277421efe816ba832e44f53c4"
+  integrity sha512-c9WSCCd1SltmmqZHrZy7ZmQJKZlgZKFjBwHZIWNvdHv+v8djiWaXewJv3X/vM7yG2zmMenn7gKq3jGGu3LI/gA==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
     utility-types "^3.10.0"
 
 "@wordpress/redux-routine@^4.1.1":
@@ -4966,22 +5151,22 @@
     redux "^4.1.0"
     rungen "^0.3.2"
 
-"@wordpress/reusable-blocks@^2.1.11", "@wordpress/reusable-blocks@^2.1.8":
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/@wordpress/reusable-blocks/-/reusable-blocks-2.1.11.tgz#281e10b1278a87f2449cd4df56960029d8c6d934"
-  integrity sha512-pgAG0Zxr5Vh6/o2zniAxQf1Sncl8PogjCUYi5bjMY5FtPC+Ifi1V+fnjQR/1yoyjULZJFj2iFMykhYEkkcwrbg==
+"@wordpress/reusable-blocks@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/reusable-blocks/-/reusable-blocks-3.0.0.tgz#fb1c505528aaa94c7817fdb77eeed982b1dcc7bb"
+  integrity sha512-UNhh9rfqWzX0OHtCzzOv9K49UwNVJ/MyUHxg42X7zEAGRo/CxSNRaxiV5IE0YDvFpqIY+PouPsOV89L2Ez32bQ==
   dependencies:
-    "@wordpress/block-editor" "^6.1.8"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/core-data" "^3.1.8"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/notices" "^3.1.2"
-    "@wordpress/url" "^3.1.1"
+    "@wordpress/block-editor" "^7.0.0"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/core-data" "^4.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/notices" "^3.2.1"
+    "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
 
 "@wordpress/rich-text@^4.1.2":
@@ -4998,6 +5183,24 @@
     "@wordpress/is-shallow-equal" "^4.1.1"
     "@wordpress/keycodes" "^3.1.1"
     classnames "^2.2.5"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    rememo "^3.0.0"
+
+"@wordpress/rich-text@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-5.0.0.tgz#9784dc8b6014bf1544eb12b3b7be620ef72379bb"
+  integrity sha512-v+QQ10aW3z9MFyW2YaC2LyomVFf6IJXMqZSsUyxuQBrM5HvXvr2Wl0u2vIbv0ZsJZUYtWU0BjNJzHI1vD8/D6w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/escape-html" "^2.2.1"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.1"
+    classnames "^2.3.1"
     lodash "^4.17.21"
     memize "^1.1.0"
     rememo "^3.0.0"
@@ -5060,27 +5263,27 @@
     webpack-livereload-plugin "^2.3.0"
     webpack-sources "^2.2.0"
 
-"@wordpress/server-side-render@^2.1.5", "@wordpress/server-side-render@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@wordpress/server-side-render/-/server-side-render-2.1.6.tgz#197afc019ef143ddbc0c0aa23390c405151c293c"
-  integrity sha512-zhSMuxJgdTSk4g/kvcOi5tqzWUaO2WQrd2qQmiMHRlDycqpC4oxqP0QtDfWV0AO5SFsBvMO0jo3ADV8qxPdQMA==
+"@wordpress/server-side-render@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/server-side-render/-/server-side-render-3.0.0.tgz#e119c8d61dc715a5dcbab3bf5c4db01b6efffff4"
+  integrity sha512-SFe9Tej1QbCuS7AyXUhGO27HyFUzlaA+6kXvyaovi7+2l03UrwX1+RpWknC3eiCqiBZKpxjSTLLFoEu/7hvs9Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.5"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/url" "^3.1.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
 
-"@wordpress/shortcode@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-3.1.1.tgz#da9b6e50c55b3aab58a12bf20cdd2ef57e909a0d"
-  integrity sha512-NiYTV42zkav0XUbRKAzoPcN3+GlwNlSXYZFLoNz+WInamTcXR5ZxQr4TE7F3DuoDNgyjwpE7vXbDJ0HFWRkgWw==
+"@wordpress/shortcode@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-3.2.1.tgz#1961fe329758a97cfad9003f7d4328ce74ee8a4b"
+  integrity sha512-nVELegRjoy/ShrKx2julCSCHiXlp8NTPfxYQCqNomUJzosdqVg7hj/LGt1STu7vZIqPayS8iVG3V7d0s2kGAkg==
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
@@ -5095,31 +5298,31 @@
     stylelint-config-recommended-scss "^4.2.0"
     stylelint-scss "^3.17.2"
 
-"@wordpress/token-list@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-2.1.1.tgz#ccd01bfa87d8c9e63c95de78f8526b9d74679780"
-  integrity sha512-haBjgsroaRjNBZ/wHd6nZamYL3Yfrt0s13Py+aR1ZKtYv+/Rmwu9VB45iB6Xb/G+v3xexopEM8uA8Zks5PNxbQ==
+"@wordpress/token-list@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-2.2.0.tgz#1b5b832155c482a930e7a8ef6325bea17bc0e989"
+  integrity sha512-0z6MhRv/pqxQcvTSeMAL69vcaxJ2J8U1Q5VeavHWnhtZ+nRglYNoE0yMLrEaeutoHeXOfWpY6baC91AgLDKE8A==
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
 
-"@wordpress/url@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-3.1.1.tgz#2b1b89858d3f4eec91d9d0c3e72f53c70d2ff2d5"
-  integrity sha512-I+yEw+a66wZ+FrpYU1F78/3c5p7/323UIrfnPUN51hIJcatsqJyQZW9Z1CNZeN5SuCobha0GPq4lw8517+VUMw==
+"@wordpress/url@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-3.2.1.tgz#2b813231c04cbfbaebf3c3beba62cc543231f32a"
+  integrity sha512-+AJt74qWz+iXkT05sBUBjx5EF3niFkvr1CqaIbWCew9/j47de6r0AHjaFhaiCCsq5fg1eqRe74sZKHrMmIWKQQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
     react-native-url-polyfill "^1.1.2"
 
-"@wordpress/viewport@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/viewport/-/viewport-3.1.2.tgz#3a49cce1031201a4d20ac2246c000a29ed3b85d9"
-  integrity sha512-cREUKffEZ4b9e5rHEbKUfT4FGoKwn4PZnSlcWQ2A0nXp5J6njziUnwrhk4/5GrNEP2/heJNUGSChOjwMsASK2Q==
+"@wordpress/viewport@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/viewport/-/viewport-4.0.0.tgz#febcb750b2304a211a6d4a3b31fc1952c1d1f839"
+  integrity sha512-68+mx34ZVi+eUQDdNVID2sAKv0HRCN6hGEwl6cGxcrSnS62AOL/Nc75TxE38Dsv6q5kWNZo4E+7fdE+B6CLbkA==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/data" "^6.0.0"
     lodash "^4.17.21"
 
 "@wordpress/warning@^2.1.1":
@@ -5127,10 +5330,15 @@
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.1.1.tgz#9f7ea1b9e054b0190c3203eb596f5fd025e0577b"
   integrity sha512-EX+/6P2bWO0zRrKJYx1yck0rY2K5z5aPb67DTU+2ggcowW8JRP7hBzGdzhXqoE32oMS7RO97nG3uD9sZtn2DJA==
 
-"@wordpress/wordcount@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/wordcount/-/wordcount-3.1.1.tgz#7548cf59638d4e42185a0d675f9725739d6c4171"
-  integrity sha512-O7T3lONKZYlPxkvIhZp5wEDl61yJs1h87VrDSkv3ZdOtEgpRF1La6pA/GN/BvBOUQL9ZAbqXUmQgUZ8hHd31eA==
+"@wordpress/warning@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.2.1.tgz#28c30f18ed3eb9db81125aebe15202468e594c60"
+  integrity sha512-IlwDEcCYCMQjrHjVxPTjqx/y+aeyg0DYpNGArt30WFY/aVfZHNu25UASYjwngEahIAUfA7b3oTQbJv2o3IghGQ==
+
+"@wordpress/wordcount@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/wordcount/-/wordcount-3.2.1.tgz#3a86d5a30491d41055e44f2e856dc8d4b8869859"
+  integrity sha512-OBHR1QIuNC8RNrFJ1EnqWAJmaFCK71JDw8WvQWy2ZN7tAlzvKGofpmCWdOrP/JXGRhVpNzLGlyMoiGB0QmvYdw==
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.21"
@@ -5864,7 +6072,7 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.0:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.6.1, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -7765,6 +7973,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -10444,7 +10659,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11518,65 +11733,72 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-"isolated-block-editor@github:automattic/isolated-block-editor#1.2.2":
-  version "1.2.2"
-  resolved "https://codeload.github.com/automattic/isolated-block-editor/tar.gz/85181aa6721082a5603c395a45d6340e5fbefec9"
+"isolated-block-editor@github:automattic/isolated-block-editor#2.3.0":
+  version "2.3.0"
+  resolved "https://codeload.github.com/automattic/isolated-block-editor/tar.gz/c7ed26fcdf3ac55e32d7b24fa76efa202f4bf571"
   dependencies:
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/annotations" "^2.1.2"
-    "@wordpress/api-fetch" "^5.1.1"
-    "@wordpress/autop" "^3.1.1"
-    "@wordpress/blob" "^3.1.1"
-    "@wordpress/block-editor" "^6.1.5"
-    "@wordpress/block-library" "^3.2.8"
-    "@wordpress/block-serialization-default-parser" "^4.1.1"
-    "@wordpress/block-serialization-spec-parser" "^4.1.1"
-    "@wordpress/blocks" "^9.1.4"
-    "@wordpress/components" "^14.1.4"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/core-data" "^3.1.7"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/data-controls" "^2.1.2"
-    "@wordpress/date" "^4.1.1"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/dom-ready" "^3.1.1"
-    "@wordpress/editor" "^10.1.8"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/escape-html" "^2.1.1"
-    "@wordpress/format-library" "^2.1.5"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/html-entities" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/interface" "^3.1.5"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keyboard-shortcuts" "^2.1.2"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/list-reusable-blocks" "^2.1.4"
-    "@wordpress/media-utils" "^2.1.1"
-    "@wordpress/notices" "^3.1.2"
-    "@wordpress/plugins" "^3.1.2"
-    "@wordpress/primitives" "^2.1.1"
-    "@wordpress/priority-queue" "^2.1.1"
-    "@wordpress/react-i18n" "^2.1.1"
-    "@wordpress/redux-routine" "^4.1.1"
-    "@wordpress/reusable-blocks" "^2.1.8"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/server-side-render" "^2.1.5"
-    "@wordpress/shortcode" "^3.1.1"
-    "@wordpress/token-list" "^2.1.1"
-    "@wordpress/url" "^3.1.1"
-    "@wordpress/viewport" "^3.1.2"
-    "@wordpress/warning" "^2.1.1"
-    "@wordpress/wordcount" "^3.1.1"
+    "@wordpress/a11y" "^3.2.1"
+    "@wordpress/annotations" "^2.2.1"
+    "@wordpress/api-fetch" "^5.2.1"
+    "@wordpress/autop" "^3.2.1"
+    "@wordpress/blob" "^3.2.1"
+    "@wordpress/block-editor" "^7.0.0"
+    "@wordpress/block-library" "^5.0.0"
+    "@wordpress/block-serialization-default-parser" "^4.2.1"
+    "@wordpress/block-serialization-spec-parser" "^4.2.0"
+    "@wordpress/blocks" "^11.0.0"
+    "@wordpress/components" "^15.0.0"
+    "@wordpress/compose" "^5.0.0"
+    "@wordpress/core-data" "^4.0.0"
+    "@wordpress/data" "^6.0.0"
+    "@wordpress/data-controls" "^2.2.1"
+    "@wordpress/date" "^4.2.1"
+    "@wordpress/deprecated" "^3.2.1"
+    "@wordpress/dom" "^3.2.1"
+    "@wordpress/dom-ready" "^3.2.1"
+    "@wordpress/editor" "^11.0.0"
+    "@wordpress/element" "^4.0.0"
+    "@wordpress/escape-html" "^2.2.1"
+    "@wordpress/format-library" "^3.0.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/html-entities" "^3.2.1"
+    "@wordpress/i18n" "^4.2.1"
+    "@wordpress/icons" "^5.0.0"
+    "@wordpress/interface" "^4.0.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keyboard-shortcuts" "^3.0.0"
+    "@wordpress/keycodes" "^3.2.1"
+    "@wordpress/list-reusable-blocks" "^3.0.0"
+    "@wordpress/media-utils" "^3.0.0"
+    "@wordpress/notices" "^3.2.1"
+    "@wordpress/plugins" "^4.0.0"
+    "@wordpress/primitives" "^3.0.0"
+    "@wordpress/priority-queue" "^2.2.1"
+    "@wordpress/react-i18n" "^3.0.0"
+    "@wordpress/redux-routine" "^4.2.1"
+    "@wordpress/reusable-blocks" "^3.0.0"
+    "@wordpress/rich-text" "^5.0.0"
+    "@wordpress/server-side-render" "^3.0.0"
+    "@wordpress/shortcode" "^3.2.1"
+    "@wordpress/token-list" "^2.2.0"
+    "@wordpress/url" "^3.2.1"
+    "@wordpress/viewport" "^4.0.0"
+    "@wordpress/warning" "^2.2.1"
+    "@wordpress/wordcount" "^3.2.1"
     classnames "^2.3.1"
+    debug "^4.3.2"
     react "17.0.2"
     react-autosize-textarea "^7.1.0"
     react-dom "17.0.2"
     reakit-utils "^0.15.1"
     redux-undo "^1.0.1"
     refx "^3.1.1"
+    yjs "^13.5.12"
+
+isomorphic.js@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.4.tgz#24ca374163ae54a7ce3b86ce63b701b91aa84969"
+  integrity sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -12565,6 +12787,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lib0@^0.2.41:
+  version "0.2.42"
+  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.42.tgz#6d8bf1fb8205dec37a953c521c5ee403fd8769b0"
+  integrity sha512-8BNM4MiokEKzMvSxTOC3gnCBisJH+jL67CnSnqzHv3jli3pUvGC8wz+0DQ2YvGr4wVQdb2R2uNNPw9LEpVvJ4Q==
+  dependencies:
+    isomorphic.js "^0.2.4"
 
 libnpmaccess@^4.0.1:
   version "4.0.3"
@@ -16389,7 +16618,7 @@ reakit-warning@^0.6.1:
   dependencies:
     reakit-utils "^0.15.1"
 
-reakit@^1.3.5:
+reakit@^1.3.5, reakit@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.8.tgz#717e1a3b7cc6da803362a0edc2c55d2b6a001baf"
   integrity sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==
@@ -18165,6 +18394,11 @@ stylelint@^13.8.0:
     table "^6.6.0"
     v8-compile-cache "^2.3.0"
     write-file-atomic "^3.0.3"
+
+stylis@^4.0.3:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 sugarss@^2.0.0:
   version "2.0.0"
@@ -20184,6 +20418,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yjs@^13.5.12:
+  version "13.5.12"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.12.tgz#7a0cf3119fb368c07243825e989a55de164b3f9c"
+  integrity sha512-/buy1kh8Ls+t733Lgov9hiNxCsjHSCymTuZNahj2hsPNoGbvnSdDmCz9Z4F19Yr1eUAAXQLJF3q7fiBcvPC6Qg==
+  dependencies:
+    lib0 "^0.2.41"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,7 +1275,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.22", "@emotion/css@^10.0.27":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1379,7 +1379,7 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
-"@emotion/styled@^10.0.23", "@emotion/styled@^10.0.27":
+"@emotion/styled@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
   integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
@@ -4249,15 +4249,6 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
   integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
 
-"@wordpress/a11y@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-3.1.1.tgz#2d8b322b2fdf5953232f17c36583271f152d71e6"
-  integrity sha512-IA5z5LAgYYYTJpKM4c/yuYcaKT3aZOHFmEKOyNsUwZfU1OKYbSaytVCY0SqxiV+S4/kYUaCWyw+e8Ujx4IKaNA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/dom-ready" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-
 "@wordpress/a11y@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-3.2.1.tgz#87cbb71228388ecf7d04d175f2990391e2882c5e"
@@ -4478,49 +4469,6 @@
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-4.0.1.tgz#dcb1b4bcef1224c5a6c814a8e8ea4be83baa7740"
   integrity sha512-mmLxc21NWxZSSPvD592tmzpBlme+nB0fbG1xO+EldS4vQkeWIQUZlNbrMijZM/hpFaBqDEJCAZFUPUpw1XwBWg==
 
-"@wordpress/components@^14.1.1":
-  version "14.1.5"
-  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-14.1.5.tgz#7d5773d9ca10b1e8d53324e487f725d6a04cb452"
-  integrity sha512-WFCbwILD7+wOjXJEfy0sBrBX7iLd6lkNmotvOnsJBCFbL4qIKe1eyLsieewJhHUVuprJ3SilblvV6sO7qM0Wcg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/core" "^10.1.1"
-    "@emotion/css" "^10.0.22"
-    "@emotion/styled" "^10.0.23"
-    "@wordpress/a11y" "^3.1.1"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/date" "^4.1.1"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/hooks" "^3.1.1"
-    "@wordpress/i18n" "^4.1.1"
-    "@wordpress/icons" "^4.0.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/primitives" "^2.1.1"
-    "@wordpress/rich-text" "^4.1.2"
-    "@wordpress/warning" "^2.1.1"
-    classnames "^2.2.5"
-    dom-scroll-into-view "^1.2.1"
-    downshift "^6.0.15"
-    emotion "^10.0.23"
-    gradient-parser "^0.1.5"
-    highlight-words-core "^1.2.2"
-    lodash "^4.17.21"
-    memize "^1.1.0"
-    moment "^2.22.1"
-    re-resizable "^6.4.0"
-    react-dates "^17.1.1"
-    react-resize-aware "^3.1.0"
-    react-spring "^8.0.20"
-    react-use-gesture "^9.0.0"
-    reakit "^1.3.5"
-    rememo "^3.0.0"
-    tinycolor2 "^1.4.2"
-    uuid "^8.3.0"
-
 "@wordpress/components@^15.0.0":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-15.0.0.tgz#5dac7bc2827d08363f27114d961989058783f281"
@@ -4563,25 +4511,6 @@
     rememo "^3.0.0"
     tinycolor2 "^1.4.2"
     uuid "^8.3.0"
-
-"@wordpress/compose@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-4.1.2.tgz#af8a0fee25ca8fff8405e3ac8e3e16aeed8feb89"
-  integrity sha512-9QdldUzcsmBPB9hj3tzPMdjHktM8FNvRqXIW2Ese0MFLV8gvrRP1JQ6tstxW59AtuRgVw0nWz2fSt0nmsjnN8Q==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keycodes" "^3.1.1"
-    "@wordpress/priority-queue" "^2.1.1"
-    clipboard "^2.0.1"
-    lodash "^4.17.21"
-    memize "^1.1.0"
-    mousetrap "^1.6.5"
-    react-resize-aware "^3.1.0"
-    use-memo-one "^1.1.1"
 
 "@wordpress/compose@^5.0.0":
   version "5.0.0"
@@ -4633,26 +4562,6 @@
     "@wordpress/data" "^6.0.0"
     "@wordpress/deprecated" "^3.2.1"
 
-"@wordpress/data@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-5.1.2.tgz#cf19428006a54ab214945cf44c2d0a86420a73f3"
-  integrity sha512-QtDlGaa6SvQmll24DDvQ0CvbtD70u0XEFPfSC7gWGFO0/mpBkrmZLUCth17cC3kfdjn+5BgefKGV3/uvHjJFqA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/deprecated" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/priority-queue" "^2.1.1"
-    "@wordpress/redux-routine" "^4.1.1"
-    equivalent-key-map "^0.2.2"
-    is-promise "^4.0.0"
-    lodash "^4.17.21"
-    memize "^1.1.0"
-    redux "^4.1.0"
-    turbo-combine-reducers "^1.0.2"
-    use-memo-one "^1.1.1"
-
 "@wordpress/data@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-6.0.0.tgz#c0413bd7bde3a11ac9c2b5c1afce6edbde39decd"
@@ -4671,15 +4580,6 @@
     memize "^1.1.0"
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
-
-"@wordpress/date@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-4.1.1.tgz#409866d8d524a613a3c9d1f2cb9c8ebf428dc30e"
-  integrity sha512-TA452SZO6Z35c7HLEmSLT0xb/zbUraKHCmkzgkZbhTRVPnZ824VCTb3ebWko9hoNZ0n6bxDE+ntMwM/YKfzDhw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    moment "^2.22.1"
-    moment-timezone "^0.5.31"
 
 "@wordpress/date@^4.2.1":
   version "4.2.1"
@@ -4706,14 +4606,6 @@
     json2php "^0.0.4"
     webpack-sources "^2.2.0"
 
-"@wordpress/deprecated@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.1.1.tgz#af644af63c28f913a321465c6df1e57284800290"
-  integrity sha512-0hILlCNhf0DukFo3hMWybf9q507cxnIHhC1GQ1crZtTqzKS2QY2C1/77V4YGPdBShUj5j1dPriYCzfB5jFFgqQ==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/hooks" "^3.1.1"
-
 "@wordpress/deprecated@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.2.1.tgz#6f8fab767308e5f9660961dcbbc9f8f3c843e01c"
@@ -4722,27 +4614,12 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^3.2.0"
 
-"@wordpress/dom-ready@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-3.1.1.tgz#c1ec662ca12130e92e41d3d9c95041adce3dde22"
-  integrity sha512-Kc0jxOgOBKDdJ5OOA1iNHXog5D3QzNrv4IBt4UYYDy59XnuzJEwDSeWQE9gP6ssRx4/qzJxi5KGr3pNZzDwqTg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-
 "@wordpress/dom-ready@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-3.2.1.tgz#827b61e5e764e2a302c9664609f567266b2954b6"
   integrity sha512-2Tsc/SyqZMzLhJffkmgz0j9ziJKFkCpMELba9PPp8HaYYWWY67G9XxKarRbS6TSrpwpa4YI+KLc/LStDP0wpMQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
-
-"@wordpress/dom@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.1.1.tgz#e533666db79ddc829d127fa11960726e3e22d341"
-  integrity sha512-NkNkgczdQweWXXiP7uaXmuu58JsRU/WN9OTWT0pVTZumTQKsvm0Fcs55jt3NBG+X/F80DC+DPVW6+sTKv0Lqxg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    lodash "^4.17.21"
 
 "@wordpress/dom@^3.2.1":
   version "3.2.1"
@@ -4791,6 +4668,19 @@
     react-autosize-textarea "^7.1.0"
     rememo "^3.0.0"
 
+"@wordpress/element@4.0.0", "@wordpress/element@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-4.0.0.tgz#ce184de100f96780196d7b08104f34bc29aaa5bf"
+  integrity sha512-jGQ+9Q/Ml36xmYMa5wqSDRNkmHL1/HqzjLIV91TkqURHSorul9o53ze5go0tYjeY6s8C97K1Alg4gi8V+Hu7hw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^2.2.1"
+    lodash "^4.17.21"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+
 "@wordpress/element@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-3.1.1.tgz#a1f33ddf54902c671d7a3426bae9731287a80f05"
@@ -4803,19 +4693,6 @@
     lodash "^4.17.21"
     react "^16.13.1"
     react-dom "^16.13.1"
-
-"@wordpress/element@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-4.0.0.tgz#ce184de100f96780196d7b08104f34bc29aaa5bf"
-  integrity sha512-jGQ+9Q/Ml36xmYMa5wqSDRNkmHL1/HqzjLIV91TkqURHSorul9o53ze5go0tYjeY6s8C97K1Alg4gi8V+Hu7hw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@types/react" "^16.9.0"
-    "@types/react-dom" "^16.9.0"
-    "@wordpress/escape-html" "^2.2.1"
-    lodash "^4.17.21"
-    react "^17.0.1"
-    react-dom "^17.0.1"
 
 "@wordpress/escape-html@^2.1.1":
   version "2.1.1"
@@ -4874,13 +4751,6 @@
     "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
 
-"@wordpress/hooks@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.1.1.tgz#be9be2abbe97ad8c0bee52c96381e5a46e559963"
-  integrity sha512-9f6H9WBwu6x/MM4ZCVLGGBuMiBcyaLapmAku5IwcWaeB2PtPduwjmk2NfGx35TuhBQD554DUg8WtTjIS019UAg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-
 "@wordpress/hooks@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.2.0.tgz#84212541ec9b9834d337b233d120f3623de074c6"
@@ -4895,19 +4765,6 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/i18n@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.1.1.tgz#3e7efe97dfa22aefa5e1989e5ee30cc6601b7b40"
-  integrity sha512-Ra/hxR8WCLqDp2P49Ibr9ANhZZZ8WHnsO+4WG3XDarJ3lmzux0TcRThDKRCcYHsW3pzieARmrEa/BOlYD7ZEjQ==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/hooks" "^3.1.1"
-    gettext-parser "^1.3.1"
-    lodash "^4.17.21"
-    memize "^1.1.0"
-    sprintf-js "^1.1.1"
-    tannin "^1.2.0"
-
 "@wordpress/i18n@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.2.1.tgz#a6aa7ca24477faa089b53e3d362a2fea1fb8af84"
@@ -4920,15 +4777,6 @@
     memize "^1.1.0"
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
-
-"@wordpress/icons@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-4.0.1.tgz#6759b8bd0e47af9a6557d3cc8aa69893191e3a83"
-  integrity sha512-dYv2GsQ1o2a775mS7gVWNfZOK8S9PCZ/kdc8nz9lApebFFfUu1M0+eTWPvhs109P9yKQ2s1ZZGWGomP/WUwWOQ==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/primitives" "^2.1.1"
 
 "@wordpress/icons@^5.0.0":
   version "5.0.0"
@@ -4956,13 +4804,6 @@
     "@wordpress/viewport" "^4.0.0"
     classnames "^2.3.1"
     lodash "^4.17.21"
-
-"@wordpress/is-shallow-equal@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.1.1.tgz#1e1a18ae15711f90e54e956f1d06fbb646c93e26"
-  integrity sha512-Bc782s4Kte98RKLtuDXOaUBpyJWUgN4XZJevEoFasKQTpABZUDF+Y2C0/dhnlJeYF5TDEd8TQgFfpF5csxEUNw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
 
 "@wordpress/is-shallow-equal@^4.2.0":
   version "4.2.0"
@@ -5003,15 +4844,6 @@
     "@wordpress/keycodes" "^3.2.1"
     lodash "^4.17.21"
     rememo "^3.0.0"
-
-"@wordpress/keycodes@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.1.1.tgz#d842167401967908713d2f43b3ff9f53cbef2bf8"
-  integrity sha512-lLJTl/PJv0F5c02YfFdzS/sspmMM3kWYcix8sXsAQgjzLkOMizSQySBa3bpT2t5auN0YQ34YVyeupVfoY+evOQ==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/i18n" "^4.1.1"
-    lodash "^4.17.21"
 
 "@wordpress/keycodes@^3.2.1":
   version "3.2.1"
@@ -5088,15 +4920,6 @@
   resolved "https://registry.yarnpkg.com/@wordpress/prettier-config/-/prettier-config-1.0.5.tgz#905aa221633f48eb3b5c3966c2169639577ad7e8"
   integrity sha512-kZ1EzXmDKOe+QxSJJSu70zx+x2g1awqYJjX7Z947K0affv4l8/oPA+k3SgNi3U9Q5Sbwtb5xLgDr9k0HGJSw7g==
 
-"@wordpress/primitives@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-2.1.1.tgz#62a8a901f56f7efe4f2d6e17383da2e9abdd5d3f"
-  integrity sha512-iX31v/302zOrxEVwFUbbwr4BKZcxR+XQ53wuShc8CzcydAYj5JUFdEuwG6Z9jRGJAX2AgizSP6Fex4ercgFLXA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/element" "^3.1.1"
-    classnames "^2.2.5"
-
 "@wordpress/primitives@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-3.0.0.tgz#f96ea8c04edf9c5eee7f58b3f493f566557c0fca"
@@ -5105,13 +4928,6 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/element" "^4.0.0"
     classnames "^2.3.1"
-
-"@wordpress/priority-queue@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.1.1.tgz#c22fc152c426181fecb0ca1397daff27a6ff2918"
-  integrity sha512-e4x4B+1F2wXejqjNr6L3LTf5aO7gzy/9MWy5pUgg1rlo8z+B73OyOUmK39WOnzFtzmwTbFqgzzCwY5JqIaZe2g==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
 
 "@wordpress/priority-queue@^2.2.1":
   version "2.2.1"
@@ -5129,16 +4945,6 @@
     "@wordpress/element" "^4.0.0"
     "@wordpress/i18n" "^4.2.1"
     utility-types "^3.10.0"
-
-"@wordpress/redux-routine@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-4.1.1.tgz#2b1ff3886725011c5e7ef41d1a4b237171cf368c"
-  integrity sha512-wjHASkmDPiOhnTZGn43kBj5RDVnSTRpj3EHL8boUGmOMiEFm/bUAfefhyvlo9ksBF4ZQm2pJjJTWtp5zE1drgg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    is-promise "^4.0.0"
-    lodash "^4.17.21"
-    rungen "^0.3.2"
 
 "@wordpress/redux-routine@^4.2.1":
   version "4.2.1"
@@ -5168,24 +4974,6 @@
     "@wordpress/notices" "^3.2.1"
     "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
-
-"@wordpress/rich-text@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-4.1.2.tgz#305a399f9a1836262eb8ea7cc2a2991130373ad2"
-  integrity sha512-63eHpiTxdVLWcnHR2hwGH0mKOF/AGfHsoDUH/p6Tp/m1ybGbLh8rMiWEeG10u9hg9+Yya2yS5wDj0pgbiUSlaA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@wordpress/compose" "^4.1.2"
-    "@wordpress/data" "^5.1.2"
-    "@wordpress/dom" "^3.1.1"
-    "@wordpress/element" "^3.1.1"
-    "@wordpress/escape-html" "^2.1.1"
-    "@wordpress/is-shallow-equal" "^4.1.1"
-    "@wordpress/keycodes" "^3.1.1"
-    classnames "^2.2.5"
-    lodash "^4.17.21"
-    memize "^1.1.0"
-    rememo "^3.0.0"
 
 "@wordpress/rich-text@^5.0.0":
   version "5.0.0"
@@ -7569,16 +7357,6 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.5.3"
 
-create-emotion@^10.0.27:
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.27.tgz#cb4fa2db750f6ca6f9a001a33fbf1f6c46789503"
-  integrity sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==
-  dependencies:
-    "@emotion/cache" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -8581,14 +8359,6 @@ emotion-theming@^10.0.27:
     "@babel/runtime" "^7.5.5"
     "@emotion/weak-memoize" "0.2.5"
     hoist-non-react-statics "^3.3.0"
-
-emotion@^10.0.23:
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.27.tgz#f9ca5df98630980a23c819a56262560562e5d75e"
-  integrity sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==
-  dependencies:
-    babel-plugin-emotion "^10.0.27"
-    create-emotion "^10.0.27"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -16618,7 +16388,7 @@ reakit-warning@^0.6.1:
   dependencies:
     reakit-utils "^0.15.1"
 
-reakit@^1.3.5, reakit@^1.3.8:
+reakit@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.8.tgz#717e1a3b7cc6da803362a0edc2c55d2b6a001baf"
   integrity sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==


### PR DESCRIPTION
This patch bumps the version of `isolated-block-editor` to `2.3.0` which adds a `<ToolbarSlot />` component that allows for inserting items into the editor toolbar.

As part of this PR, I also manually bumped all our dependencies on `@wordpress/...` libraries to match the ones used in `isolated-block-editor`.  
This solves the issue with multiple versions of the same library being installed causing issues for our custom blocks (see #26). Eventually we'll want to make them external altogether but for now this will do.

Another change is how now the styles need to be imported manually.

# Testing

- Run `yarn install`
- Run `yarn workspace @crowdsignal/dashboard start` and go to `https://crowdsignal.localhost:9000/edit/poll/123`
- The editor should still load normally with the correct styles.