### PR TITLE
Implement settings for poll and poll answer blocks

### DIFF
--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -14,7 +14,14 @@ import Toolbar from './toolbar';
  */
 import './style.scss';
 
-const settings = {};
+const settings = {
+	iso: {
+		toolbar: {
+			inspector: true,
+			toc: true,
+		},
+	},
+};
 
 export const BlockEditor = ( { onSave } ) => {
 	return (

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -4,3 +4,17 @@
 @import '~@wordpress/block-library/build-style/editor.css';
 @import '~@wordpress/block-library/build-style/theme.css';
 @import '~@wordpress/format-library/build-style/style.css';
+
+#crowdsignal-dashboard .iso-editor {
+	.wp-block {
+		max-width: 720px;
+	}
+
+	.wp-block[data-align='wide'] {
+		max-width: 1080px;
+	}
+
+	.wp-block[data-align='full'] {
+		max-width: none;
+	}
+}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -19,10 +19,15 @@
   "dependencies": {
     "@crowdsignal/hooks": "^0.1.0",
     "@wordpress/block-editor": "^7.0.0",
+    "@wordpress/blocks": "^11.0.0",
     "@wordpress/components": "^14.1.5",
     "@wordpress/element": "^4.0.0",
     "@wordpress/i18n": "^4.2.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.1.1",
+    "@emotion/styled": "^10.0.27"
   }
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -18,11 +18,13 @@
   "main": "src/index.js",
   "dependencies": {
     "@crowdsignal/hooks": "^0.1.0",
+    "@crowdsignal/styles": "^0.1.0",
     "@wordpress/block-editor": "^7.0.0",
     "@wordpress/blocks": "^11.0.0",
     "@wordpress/components": "^14.1.5",
     "@wordpress/element": "^4.0.0",
     "@wordpress/i18n": "^4.2.1",
+    "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -17,9 +17,12 @@
   },
   "main": "src/index.js",
   "dependencies": {
+    "@crowdsignal/hooks": "^0.1.0",
     "@wordpress/block-editor": "^7.0.0",
+    "@wordpress/components": "^14.1.5",
     "@wordpress/element": "^4.0.0",
     "@wordpress/i18n": "^4.2.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "^8.3.2"
   }
 }

--- a/packages/blocks/src/poll-answer/attributes.js
+++ b/packages/blocks/src/poll-answer/attributes.js
@@ -1,0 +1,10 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	label: {
+		type: 'string',
+		default: null,
+	},
+};

--- a/packages/blocks/src/poll-answer/attributes.js
+++ b/packages/blocks/src/poll-answer/attributes.js
@@ -7,4 +7,25 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+		default: null,
+	},
+	borderWidth: {
+		type: 'number',
+		default: null,
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
 };

--- a/packages/blocks/src/poll-answer/edit.js
+++ b/packages/blocks/src/poll-answer/edit.js
@@ -1,10 +1,40 @@
 /**
  * External dependencies
  */
+import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { noop } from 'lodash';
 
-const PollAnswer = () => {
-	return <p>{ __( 'Enter an answer', 'blocks' ) }</p>;
+/**
+ * Internal dependencies
+ */
+import { useClientId } from '@crowdsignal/hooks';
+
+/**
+ * Style dependencies
+ */
+
+const PollAnswer = ( { attributes, setAttributes } ) => {
+	useClientId( { attributes, setAttributes } );
+
+	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	return (
+		<div>
+			<RichText
+				placeholder={ __( 'Enter an answer', 'blocks' ) }
+				multiline={ false }
+				preserveWhiteSpace={ false }
+				onChange={ handleChangeLabel }
+				onSplit={ noop }
+				onReplace={ noop }
+				onRemove={ noop }
+				value={ attributes.label }
+				allowedFormats={ [] }
+				withoutInteractiveFormatting
+			/>
+		</div>
+	);
 };
 
 export default PollAnswer;

--- a/packages/blocks/src/poll-answer/edit.js
+++ b/packages/blocks/src/poll-answer/edit.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,10 +14,13 @@ import { useClientId } from '@crowdsignal/hooks';
  * Style dependencies
  */
 
-const PollAnswer = ( { attributes, setAttributes } ) => {
+const PollAnswer = ( { attributes, onReplace, setAttributes } ) => {
 	useClientId( { attributes, setAttributes } );
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	const handleSplit = ( label ) =>
+		createBlock( 'crowdsignal-forms/poll-answer', { label } );
 
 	return (
 		<div>
@@ -26,9 +29,8 @@ const PollAnswer = ( { attributes, setAttributes } ) => {
 				multiline={ false }
 				preserveWhiteSpace={ false }
 				onChange={ handleChangeLabel }
-				onSplit={ noop }
-				onReplace={ noop }
-				onRemove={ noop }
+				onReplace={ onReplace }
+				onSplit={ handleSplit }
 				value={ attributes.label }
 				allowedFormats={ [] }
 				withoutInteractiveFormatting

--- a/packages/blocks/src/poll-answer/edit.js
+++ b/packages/blocks/src/poll-answer/edit.js
@@ -4,38 +4,57 @@
 import { RichText } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { useClientId } from '@crowdsignal/hooks';
+import { useColorStyles } from '@crowdsignal/styles';
+import Sidebar from './sidebar';
 
-/**
- * Style dependencies
- */
+const PollAnswer = ( props ) => {
+	const { attributes, className, onReplace, setAttributes } = props;
 
-const PollAnswer = ( { attributes, onReplace, setAttributes } ) => {
 	useClientId( { attributes, setAttributes } );
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
 
 	const handleSplit = ( label ) =>
-		createBlock( 'crowdsignal-forms/poll-answer', { label } );
+		createBlock( 'crowdsignal-forms/poll-answer', {
+			...attributes,
+			clientId:
+				label && attributes.label.indexOf( label ) === 0
+					? attributes.clientId
+					: undefined,
+			label,
+		} );
+
+	const width = attributes.width ? `${ attributes.width }%` : null;
 
 	return (
-		<div>
-			<RichText
-				placeholder={ __( 'Enter an answer', 'blocks' ) }
-				multiline={ false }
-				preserveWhiteSpace={ false }
-				onChange={ handleChangeLabel }
-				onReplace={ onReplace }
-				onSplit={ handleSplit }
-				value={ attributes.label }
-				allowedFormats={ [] }
-				withoutInteractiveFormatting
-			/>
-		</div>
+		<>
+			<Sidebar { ...props } />
+
+			<div className={ classnames( className, 'wp-block-button' ) }>
+				<RichText
+					className="wp-block-button__link"
+					style={ {
+						...useColorStyles( attributes ),
+						width,
+					} }
+					placeholder={ __( 'Enter an answer', 'blocks' ) }
+					multiline={ false }
+					preserveWhiteSpace={ false }
+					onChange={ handleChangeLabel }
+					onReplace={ onReplace }
+					onSplit={ handleSplit }
+					value={ attributes.label }
+					allowedFormats={ [] }
+					withoutInteractiveFormatting
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/packages/blocks/src/poll-answer/index.js
+++ b/packages/blocks/src/poll-answer/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import attributes from './attributes';
 import EditPollAnswer from './edit';
 
 export default {
@@ -14,4 +15,5 @@ export default {
 	category: 'crowdsignal-forms',
 	parent: [ 'crowdsignal-forms/poll' ],
 	edit: EditPollAnswer,
+	attributes,
 };

--- a/packages/blocks/src/poll-answer/sidebar.js
+++ b/packages/blocks/src/poll-answer/sidebar.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
+import {
+	ContrastChecker,
+	InspectorControls,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	const handleChangeWidth = ( value ) =>
+		setAttributes( {
+			width: attributes.width === value ? undefined : value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelColorGradientSettings
+				title={ __( 'Color', 'blocks' ) }
+				disableCustomGradients={ false }
+				settings={ [
+					{
+						label: __( 'Text color', 'blocks' ),
+						colorValue: attributes.textColor,
+						onColorChange: handleChangeAttribute( 'textColor' ),
+					},
+					{
+						label: __( 'Background color', 'blocks' ),
+						colorValue: attributes.backgroundColor,
+						gradientValue: attributes.gradient,
+						onColorChange: handleChangeAttribute(
+							'backgroundColor'
+						),
+						onGradientChange: handleChangeAttribute( 'gradient' ),
+					},
+				] }
+			>
+				<ContrastChecker
+					backgroundColor={ attributes.backgroundColor }
+					color={ attributes.textColor }
+				/>
+			</PanelColorGradientSettings>
+
+			<PanelBody title={ __( 'Width settings', 'blocks' ) }>
+				<ButtonGroup aria-label={ __( 'Button width' ) }>
+					{ [ 25, 50, 75, 100 ].map( ( width ) => (
+						<Button
+							isSmall
+							key={ width }
+							variant={
+								width === attributes.width
+									? 'primary'
+									: undefined
+							}
+							onClick={ () => handleChangeWidth( width ) }
+						>
+							{ width }%
+						</Button>
+					) ) }
+				</ButtonGroup>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/blocks/src/poll-answer/styles.js
+++ b/packages/blocks/src/poll-answer/styles.js
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */

--- a/packages/blocks/src/poll-answer/styles.js
+++ b/packages/blocks/src/poll-answer/styles.js
@@ -1,7 +1,0 @@
-/**
- * External dependencies
- */
-
-/**
- * Internal dependencies
- */

--- a/packages/blocks/src/poll/attributes.js
+++ b/packages/blocks/src/poll/attributes.js
@@ -1,8 +1,4 @@
 export default {
-	buttonStyle: {
-		type: 'object',
-		default: {},
-	},
 	clientId: {
 		type: 'string',
 		default: null,
@@ -11,12 +7,36 @@ export default {
 		type: 'object',
 		default: {},
 	},
-	style: {
-		type: 'object',
-		default: {},
-	},
 	question: {
 		type: 'string',
 		default: null,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+		default: 0,
+	},
+	borderWidth: {
+		type: 'number',
+		default: 2,
+	},
+	fontFamily: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+		default: 100,
 	},
 };

--- a/packages/blocks/src/poll/attributes.js
+++ b/packages/blocks/src/poll/attributes.js
@@ -22,6 +22,10 @@ export default {
 		type: 'number',
 		default: 0,
 	},
+	boxShadow: {
+		type: 'boolean',
+		default: false,
+	},
 	borderWidth: {
 		type: 'number',
 		default: 2,

--- a/packages/blocks/src/poll/attributes.js
+++ b/packages/blocks/src/poll/attributes.js
@@ -1,0 +1,22 @@
+export default {
+	buttonStyle: {
+		type: 'object',
+		default: {},
+	},
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	restrictions: {
+		type: 'object',
+		default: {},
+	},
+	style: {
+		type: 'object',
+		default: {},
+	},
+	question: {
+		type: 'string',
+		default: null,
+	},
+};

--- a/packages/blocks/src/poll/constants.js
+++ b/packages/blocks/src/poll/constants.js
@@ -1,0 +1,91 @@
+export const AnswerStyle = Object.freeze( {
+	RADIO: 'radio',
+	BUTTON: 'button',
+} );
+
+export const ButtonAlignment = Object.freeze( {
+	LIST: 'list',
+	INLINE: 'inline',
+} );
+
+export const ClosedPollState = Object.freeze( {
+	SHOW_RESULTS: 'show-results',
+	SHOW_CLOSED_BANNER: 'show-closed-banner',
+	HIDDEN: 'hidden',
+} );
+
+export const ConfirmMessageType = Object.freeze( {
+	THANK_YOU: 'thank-you',
+	CUSTOM_TEXT: 'custom-text',
+	REDIRECT: 'redirect',
+	RESULTS: 'results',
+} );
+
+export const FontFamilyType = Object.freeze( {
+	THEME_DEFAULT: 'theme-default',
+	GEORGIA: 'georgia',
+	PALATINO: 'palatino',
+	TIMES_NEW_ROMAN: 'times-new-roman',
+	ARIAL: 'arial',
+	IMPACT: 'impact',
+	LUCIDA: 'lucida',
+	TAHOMA: 'tahoma',
+	TREBUCHET: 'trebuchet',
+	VERDANA: 'verdana',
+	COURIER: 'courier',
+	// Google fonts:  enum value = google font url slug
+	CABIN: 'Cabin',
+	CHIVO: 'Chivo',
+	OPEN_SANS: 'Open+Sans',
+	FIRA_SANS: 'Fira+Sans',
+	ROBOTO: 'Roboto',
+	NUNITO: 'Nunito',
+	OVERPASS: 'Overpass',
+	LATO: 'Lato',
+	LIBRE_FRANKLIN: 'Libre+Franklin',
+	MONTSERRAT: 'Montserrat',
+	POPPINS: 'Poppins',
+	RUBIK: 'Rubik',
+	RALEWAY: 'Raleway',
+	JOSEFIN_SANS: 'Josefin+Sans',
+	ALEGREYA_SANS: 'Alegreya+Sans',
+	OSWALD: 'Oswald',
+} );
+
+export const FontFamilyMap = Object.freeze( {
+	[ FontFamilyType.THEME_DEFAULT ]: null,
+	[ FontFamilyType.GEORGIA ]: 'Georgia, serif',
+	[ FontFamilyType.PALATINO ]:
+		'"Palatino Linotype", "Book Antiqua", Palatino, serif',
+	[ FontFamilyType.TIMES_NEW_ROMAN ]: '"Times New Roman", Times, serif',
+	[ FontFamilyType.ARIAL ]: 'Arial, Helvetica, sans-serif',
+	[ FontFamilyType.IMPACT ]: 'Impact, Charcoal, sans-serif',
+	[ FontFamilyType.LUCIDA ]:
+		'"Lucida Sans Unicode", "Lucida Grande", sans-serif',
+	[ FontFamilyType.TAHOMA ]: 'Tahoma, Geneva, sans-serif',
+	[ FontFamilyType.TREBUCHET ]: '"Trebuchet MS", Helvetica, sans-serif',
+	[ FontFamilyType.VERDANA ]: 'Verdana, Geneva, sans-serif',
+	[ FontFamilyType.COURIER ]: '"Courier New", Courier, monospace',
+	[ FontFamilyType.CABIN ]: '"Cabin", sans-serif',
+	[ FontFamilyType.CHIVO ]: '"Chivo", sans-serif',
+	[ FontFamilyType.OPEN_SANS ]: '"Open Sans", sans-serif',
+	[ FontFamilyType.FIRA_SANS ]: '"Fira Sans", sans-serif',
+	[ FontFamilyType.ROBOTO ]: '"Roboto", sans-serif',
+	[ FontFamilyType.NUNITO ]: '"Nunito", sans-serif',
+	[ FontFamilyType.OVERPASS ]: '"Overpass", sans-serif',
+	[ FontFamilyType.LATO ]: '"Lato", sans-serif',
+	[ FontFamilyType.LIBRE_FRANKLIN ]: '"Libre Franklin", sans-serif',
+	[ FontFamilyType.MONTSERRAT ]: '"Montserrat", sans-serif',
+	[ FontFamilyType.POPPINS ]: '"Poppins", sans-serif',
+	[ FontFamilyType.RUBIK ]: '"Rubik", sans-serif',
+	[ FontFamilyType.RALEWAY ]: '"Raleway", sans-serif',
+	[ FontFamilyType.JOSEFIN_SANS ]: '"Josefin Sans", sans-serif',
+	[ FontFamilyType.ALEGREYA_SANS ]: '"Alegreya Sans", sans-serif',
+	[ FontFamilyType.OSWALD ]: '"Oswald", sans-serif',
+} );
+
+export const PollStatus = Object.freeze( {
+	OPEN: 'open',
+	CLOSED: 'closed',
+	CLOSED_AFTER: 'closed-after',
+} );

--- a/packages/blocks/src/poll/edit.js
+++ b/packages/blocks/src/poll/edit.js
@@ -12,6 +12,11 @@ import { includes, round } from 'lodash';
 import { useClientId } from '@crowdsignal/hooks';
 import Sidebar from './sidebar';
 
+/**
+ * Style dependencies
+ */
+import { PollWrapper } from './styles/poll';
+
 const ALLOWED_BLOCKS = [ 'crowdsignal-forms/poll-answer', 'core/paragraph' ];
 
 const PollBlock = ( props ) => {
@@ -54,7 +59,7 @@ const PollBlock = ( props ) => {
 				showHandle={ isResizable }
 				resizeRatio={ 2 }
 			>
-				<div>
+				<PollWrapper>
 					<RichText
 						tagName="h3"
 						placeholder={ __( 'Enter your question', 'blocks' ) }
@@ -63,14 +68,16 @@ const PollBlock = ( props ) => {
 
 					<InnerBlocks
 						template={ [
-							[ 'core/paragraph', { content: 'Hello' } ],
+							[ 'crowdsignal-forms/poll-answer', {} ],
+							[ 'crowdsignal-forms/poll-answer', {} ],
+							[ 'crowdsignal-forms/poll-answer', {} ],
 						] }
 						templateLock={ false }
 						allowedBlocks={ ALLOWED_BLOCKS }
 						orientation="vertical"
 						__experimentalMoverDirection="vertical"
 					/>
-				</div>
+				</PollWrapper>
 			</ResizableBox>
 		</>
 	);

--- a/packages/blocks/src/poll/edit.js
+++ b/packages/blocks/src/poll/edit.js
@@ -1,25 +1,78 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { ResizableBox } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { includes, round } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { useClientId } from '@crowdsignal/hooks';
+import Sidebar from './sidebar';
 
 const ALLOWED_BLOCKS = [ 'crowdsignal-forms/poll-answer', 'core/paragraph' ];
 
-const PollBlock = () => {
+const PollBlock = ( props ) => {
+	const { attributes, isSelected, setAttributes } = props;
+
+	useClientId( props );
+
+	const handleChangeQuestion = ( question ) => setAttributes( { question } );
+
+	const handleResize = ( event, handle, element ) => {
+		if ( ! includes( [ 'right', 'left' ], handle ) ) {
+			return;
+		}
+
+		setAttributes( {
+			style: {
+				...attributes.style,
+				width: round(
+					( element.offsetWidth / element.parentNode.offsetWidth ) *
+						100
+				),
+			},
+		} );
+	};
+
+	const isResizable = isSelected && attributes.align !== 'full';
+	const blockWidth =
+		attributes.align !== 'full' ? `${ attributes.style.width }%` : 'auto';
+
 	return (
-		<div>
-			<InnerBlocks
-				template={ [
-					[ 'crowdsignal-forms/poll-answer', {} ],
-					[ 'crowdsignal-forms/poll-answer', {} ],
-					[ 'crowdsignal-forms/poll-answer', {} ],
-				] }
-				templateInsertUpdatesSelection={ false }
-				templateLock=""
-				allowedBlocks={ ALLOWED_BLOCKS }
-				orientation="vertical"
-			/>
-		</div>
+		<>
+			<Sidebar { ...props } />
+
+			<ResizableBox
+				size={ { height: 'auto', width: blockWidth } }
+				minWidth="25%"
+				maxWidth="100%"
+				enable={ { left: true, right: true } }
+				onResizeStop={ handleResize }
+				showHandle={ isResizable }
+				resizeRatio={ 2 }
+			>
+				<div>
+					<RichText
+						tagName="h3"
+						placeholder={ __( 'Enter your question', 'blocks' ) }
+						onChange={ handleChangeQuestion( 'question' ) }
+					/>
+
+					<InnerBlocks
+						template={ [
+							[ 'core/paragraph', { content: 'Hello' } ],
+						] }
+						templateLock={ false }
+						allowedBlocks={ ALLOWED_BLOCKS }
+						orientation="vertical"
+						__experimentalMoverDirection="vertical"
+					/>
+				</div>
+			</ResizableBox>
+		</>
 	);
 };
 

--- a/packages/blocks/src/poll/edit.js
+++ b/packages/blocks/src/poll/edit.js
@@ -10,17 +10,18 @@ import { includes, round } from 'lodash';
  * Internal dependencies
  */
 import { useClientId } from '@crowdsignal/hooks';
+import { useBorderStyles, useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
 
 /**
  * Style dependencies
  */
-import { PollWrapper } from './styles/poll';
+import { EditorWrapper, PollWrapper } from './styles/poll';
 
 const ALLOWED_BLOCKS = [ 'crowdsignal-forms/poll-answer', 'core/paragraph' ];
 
 const PollBlock = ( props ) => {
-	const { attributes, isSelected, setAttributes } = props;
+	const { attributes, className, isSelected, setAttributes } = props;
 
 	useClientId( props );
 
@@ -32,22 +33,20 @@ const PollBlock = ( props ) => {
 		}
 
 		setAttributes( {
-			style: {
-				...attributes.style,
-				width: round(
-					( element.offsetWidth / element.parentNode.offsetWidth ) *
-						100
-				),
-			},
+			width: round(
+				( element.offsetWidth /
+					element.parentNode.parentNode.offsetWidth ) *
+					100
+			),
 		} );
 	};
 
 	const isResizable = isSelected && attributes.align !== 'full';
 	const blockWidth =
-		attributes.align !== 'full' ? `${ attributes.style.width }%` : 'auto';
+		attributes.align !== 'full' ? `${ attributes.width }%` : 'auto';
 
 	return (
-		<>
+		<EditorWrapper>
 			<Sidebar { ...props } />
 
 			<ResizableBox
@@ -59,7 +58,13 @@ const PollBlock = ( props ) => {
 				showHandle={ isResizable }
 				resizeRatio={ 2 }
 			>
-				<PollWrapper>
+				<PollWrapper
+					className={ className }
+					style={ {
+						...useColorStyles( attributes ),
+						...useBorderStyles( attributes ),
+					} }
+				>
 					<RichText
 						tagName="h3"
 						placeholder={ __( 'Enter your question', 'blocks' ) }
@@ -79,7 +84,7 @@ const PollBlock = ( props ) => {
 					/>
 				</PollWrapper>
 			</ResizableBox>
-		</>
+		</EditorWrapper>
 	);
 };
 

--- a/packages/blocks/src/poll/index.js
+++ b/packages/blocks/src/poll/index.js
@@ -1,18 +1,23 @@
 /**
  * External dependencies
  */
+import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import attributes from './attributes';
 import EditPoll from './edit';
 
 export default {
+	apiVersion: 1,
 	title: __( 'Poll', 'blocks' ),
 	description: __( "Create polls and get your audience's opinion", 'blocks' ),
 	category: 'crowdsignal-forms',
 	edit: EditPoll,
+	save: () => <InnerBlocks.Content />,
+	attributes,
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 	},

--- a/packages/blocks/src/poll/index.js
+++ b/packages/blocks/src/poll/index.js
@@ -20,6 +20,8 @@ export default {
 	attributes,
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
+		html: false,
+		reusable: false,
 	},
 	getEditWrapperProps: ( { align } ) => ( {
 		'data-align': align,

--- a/packages/blocks/src/poll/sidebar.js
+++ b/packages/blocks/src/poll/sidebar.js
@@ -14,8 +14,10 @@ import {
 import {
 	ContrastChecker,
 	InspectorControls,
-	PanelColorSettings,
 	URLInput,
+	useSetting,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -23,8 +25,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
-	AnswerStyle,
-	ButtonAlignment,
 	ClosedPollState,
 	ConfirmMessageType,
 	FontFamilyType,
@@ -32,25 +32,11 @@ import {
 } from './constants';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
+	const gradients = useSetting( 'color.gradients' ) || [];
+
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
 			[ key ]: value,
-		} );
-
-	const handleChangeStyle = ( key ) => ( value ) =>
-		setAttributes( {
-			style: {
-				...attributes.style,
-				[ key ]: value,
-			},
-		} );
-
-	const handleChangeButtonStyle = ( key ) => ( value ) =>
-		setAttributes( {
-			buttonStyle: {
-				...attributes.buttonStyle,
-				[ key ]: value,
-			},
 		} );
 
 	const handleChangeRestriction = ( key ) => ( value ) =>
@@ -178,36 +164,43 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 				) }
 			</PanelBody>
 
-			<PanelColorSettings
-				title={ __( 'Block styling', 'blocks' ) }
+			<PanelColorGradientSettings
+				title={ __( 'Style', 'blocks' ) }
 				initialOpen={ false }
-				colorSettings={ [
+				gradients={ [] }
+				disableCustomGradients={ false }
+				settings={ [
 					{
 						label: __( 'Text color', 'blocks' ),
-						value: attributes.style.color,
-						onChange: handleChangeStyle( 'textColor' ),
+						colorValue: attributes.textColor,
+						onColorChange: handleChangeAttribute( 'textColor' ),
 					},
 					{
 						label: __( 'Background color', 'blocks' ),
-						value: attributes.style.backgroundColor,
-						onChange: handleChangeStyle( 'backgroundColor' ),
+						colorValue: attributes.backgroundColor,
+						gradientValue: attributes.gradient,
+						onColorChange: handleChangeAttribute(
+							'backgroundColor'
+						),
+						onGradientChange: handleChangeAttribute( 'gradient' ),
+						gradients,
 					},
 					{
 						label: __( 'Border color', 'blocks' ),
-						value: attributes.style.borderColor,
-						onChange: handleChangeStyle( 'borderColor' ),
+						colorValue: attributes.borderColor,
+						onColorChange: handleChangeAttribute( 'borderColor' ),
 					},
 				] }
 			>
 				<ContrastChecker
-					backgroundColor={ attributes.style.backgroundColor }
-					textColor={ attributes.style.color }
+					backgroundColor={ attributes.backgroundColor }
+					textColor={ attributes.textColor }
 				/>
 
 				<SelectControl
 					label={ __( 'Choose font', 'blocks' ) }
-					value={ attributes.style.fontFamily }
-					onChange={ handleChangeStyle( 'fontFamily' ) }
+					value={ attributes.fontFamily }
+					onChange={ handleChangeAttribute( 'fontFamily' ) }
 					options={ [
 						{
 							label: __( 'Default theme font', 'blocks' ),
@@ -325,8 +318,8 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 						<TextControl
 							type="number"
 							label={ __( 'Width (%)', 'blocks' ) }
-							value={ attributes.style.width }
-							onChange={ handleChangeStyle( 'width' ) }
+							value={ attributes.width }
+							onChange={ handleChangeAttribute( 'width' ) }
 						/>
 						<Button isSmall onClick={ handleResetWidth }>
 							{ __( 'Reset', 'blocks' ) }
@@ -337,62 +330,22 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 				<TextControl
 					label={ __( 'Border thickness', 'blocks' ) }
 					type="number"
-					value={ attributes.style.borderWidth }
-					onChange={ handleChangeStyle( 'borderWidth' ) }
+					value={ attributes.borderWidth }
+					onChange={ handleChangeAttribute( 'borderWidth' ) }
 				/>
 				<TextControl
 					label={ __( 'Corner radius', 'blocks' ) }
 					type="number"
-					value={ attributes.style.borderRadius }
-					onChange={ handleChangeStyle( 'borderRadius' ) }
+					value={ attributes.borderRadius }
+					onChange={ handleChangeAttribute( 'borderRadius' ) }
 				/>
 
 				<ToggleControl
 					label={ __( 'Drop shadow', 'blocks' ) }
-					checked={ attributes.style.hasBoxShadow }
-					onChange={ handleChangeStyle( 'hasBoxShadow' ) }
+					checked={ attributes.boxShadow }
+					onChange={ handleChangeAttribute( 'boxShadow' ) }
 				/>
-			</PanelColorSettings>
-
-			<PanelColorSettings
-				title={ __( 'Button styling', 'blocks' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						label: __( 'Text color', 'blocks' ),
-						value: attributes.buttonStyle.color,
-						onChange: handleChangeButtonStyle( 'color' ),
-					},
-					{
-						label: __( 'Background color', 'blocks' ),
-						value: attributes.buttonStyle.backgroundColor,
-						onChange: handleChangeButtonStyle( 'backgroundColor' ),
-					},
-				] }
-			>
-				<ContrastChecker
-					textColor={ attributes.buttonStyle.color }
-					backgroundColor={ attributes.buttonStyle.backgroundColor }
-				/>
-
-				{ AnswerStyle.BUTTON === attributes.answerStyle && (
-					<SelectControl
-						label={ __( 'Alignment', 'blocks' ) }
-						value={ attributes.buttonStyle.align }
-						onChange={ handleChangeButtonStyle( 'align' ) }
-						options={ [
-							{
-								label: __( 'List', 'blocks' ),
-								value: ButtonAlignment.LIST,
-							},
-							{
-								label: __( 'Inline', 'blocks' ),
-								value: ButtonAlignment.INLINE,
-							},
-						] }
-					/>
-				) }
-			</PanelColorSettings>
+			</PanelColorGradientSettings>
 
 			<PanelBody
 				title={ __( 'Answer settings', 'blocks' ) }

--- a/packages/blocks/src/poll/sidebar.js
+++ b/packages/blocks/src/poll/sidebar.js
@@ -1,0 +1,418 @@
+/**
+ * External dependencies
+ */
+import {
+	Button,
+	CheckboxControl,
+	PanelBody,
+	SelectControl,
+	TextareaControl,
+	TextControl,
+	TimePicker,
+	ToggleControl,
+} from '@wordpress/components';
+import {
+	ContrastChecker,
+	InspectorControls,
+	PanelColorSettings,
+	URLInput,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	AnswerStyle,
+	ButtonAlignment,
+	ClosedPollState,
+	ConfirmMessageType,
+	FontFamilyType,
+	PollStatus,
+} from './constants';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	const handleChangeStyle = ( key ) => ( value ) =>
+		setAttributes( {
+			style: {
+				...attributes.style,
+				[ key ]: value,
+			},
+		} );
+
+	const handleChangeButtonStyle = ( key ) => ( value ) =>
+		setAttributes( {
+			buttonStyle: {
+				...attributes.buttonStyle,
+				[ key ]: value,
+			},
+		} );
+
+	const handleChangeRestriction = ( key ) => ( value ) =>
+		setAttributes( {
+			restrictions: {
+				...attributes.restrictions,
+				[ key ]: value,
+			},
+		} );
+
+	const handleResetWidth = () =>
+		setAttributes( {
+			style: {
+				...attributes.style,
+				width: 100,
+			},
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Confirmation message', 'blocks' ) }
+				initialOpen={ true }
+			>
+				<SelectControl
+					label={ __( 'On submission', 'blocks' ) }
+					value={ attributes.confirmMessageType }
+					onChange={ handleChangeAttribute( 'confirmMessageType' ) }
+					options={ [
+						{
+							label: __( 'Show results', 'blocks' ),
+							value: ConfirmMessageType.RESULTS,
+						},
+						{
+							label: __( 'Show a "Thank You" message', 'blocks' ),
+							value: ConfirmMessageType.THANK_YOU,
+						},
+						{
+							label: __( 'Show a custom text message', 'blocks' ),
+							value: ConfirmMessageType.CUSTOM_TEXT,
+						},
+					] }
+				/>
+
+				{ ConfirmMessageType.CUSTOM_TEXT ===
+					attributes.confirmMessageType && (
+					<TextareaControl
+						label={ __( 'Message text', 'blocks' ) }
+						placeholder={ __( 'Thanks for voting!', 'blocks' ) }
+						value={ attributes.customConfirmMessage }
+						onChange={ handleChangeAttribute(
+							'customConfirmMessage'
+						) }
+					/>
+				) }
+
+				{ ConfirmMessageType.REDIRECT ===
+					attributes.confirmMessageType && (
+					<URLInput
+						label={ __( 'Redirect address', 'blocks' ) }
+						value={ attributes.redirectAddres }
+						onChange={ handleChangeAttribute( 'redirectAddres' ) }
+					/>
+				) }
+			</PanelBody>
+
+			<PanelBody
+				title={ __( 'Settings', 'blocks' ) }
+				initialOpen={ false }
+			>
+				<SelectControl
+					label={ __( 'Status', 'blocks' ) }
+					value={ attributes.pollStatus }
+					onChange={ handleChangeAttribute( 'pollStatus' ) }
+					options={ [
+						{
+							label: __( 'Open', 'blocks' ),
+							value: PollStatus.OPEN,
+						},
+						{
+							label: __( 'Close after', 'blocks' ),
+							value: PollStatus.CLOSED_AFTER,
+						},
+						{
+							label: __( 'Closed', 'blocks' ),
+							value: PollStatus.CLOSED,
+						},
+					] }
+				/>
+
+				{ PollStatus.CLOSED_AFTER === attributes.pollStatus && (
+					<TimePicker
+						label={ __( 'Close poll on', 'blocks' ) }
+						currentTime={ attributes.closedAfterDateTime }
+						is12Hour={ true }
+						onChange={ handleChangeAttribute(
+							'closedAfterDateTime'
+						) }
+					/>
+				) }
+
+				{ PollStatus.OPEN !== attributes.pollStatus && (
+					<SelectControl
+						label={ __( 'When the poll is closed', 'blocks' ) }
+						value={ attributes.closedPollState }
+						onChange={ handleChangeAttribute( 'closedPollState' ) }
+						options={ [
+							{
+								label: __( 'Show results', 'blocks' ),
+								value: ClosedPollState.SHOW_RESULTS,
+							},
+							{
+								label: __(
+									'Display a "Closed" banner',
+									'blocks'
+								),
+								value: ClosedPollState.SHOW_CLOSED_BANNER,
+							},
+							{
+								label: __( 'Hide poll', 'blocks' ),
+								value: ClosedPollState.HIDDEN,
+							},
+						] }
+					/>
+				) }
+			</PanelBody>
+
+			<PanelColorSettings
+				title={ __( 'Block styling', 'blocks' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Text color', 'blocks' ),
+						value: attributes.style.color,
+						onChange: handleChangeStyle( 'textColor' ),
+					},
+					{
+						label: __( 'Background color', 'blocks' ),
+						value: attributes.style.backgroundColor,
+						onChange: handleChangeStyle( 'backgroundColor' ),
+					},
+					{
+						label: __( 'Border color', 'blocks' ),
+						value: attributes.style.borderColor,
+						onChange: handleChangeStyle( 'borderColor' ),
+					},
+				] }
+			>
+				<ContrastChecker
+					backgroundColor={ attributes.style.backgroundColor }
+					textColor={ attributes.style.color }
+				/>
+
+				<SelectControl
+					label={ __( 'Choose font', 'blocks' ) }
+					value={ attributes.style.fontFamily }
+					onChange={ handleChangeStyle( 'fontFamily' ) }
+					options={ [
+						{
+							label: __( 'Default theme font', 'blocks' ),
+							value: FontFamilyType.THEME_DEFAULT,
+						},
+						{
+							label: 'Alegreya Sans',
+							value: FontFamilyType.ALEGREYA_SANS,
+						},
+						{
+							label: 'Arial',
+							value: FontFamilyType.ARIAL,
+						},
+						{
+							label: 'Cabin',
+							value: FontFamilyType.CABIN,
+						},
+						{
+							label: 'Chivo',
+							value: FontFamilyType.CHIVO,
+						},
+						{
+							label: 'Courier',
+							value: FontFamilyType.COURIER,
+						},
+						{
+							label: 'Fira Sans',
+							value: FontFamilyType.FIRA_SANS,
+						},
+						{
+							label: 'Georgia',
+							value: FontFamilyType.GEORGIA,
+						},
+						{
+							label: 'Impact',
+							value: FontFamilyType.IMPACT,
+						},
+						{
+							label: 'Josefin Sans',
+							value: FontFamilyType.JOSEFIN_SANS,
+						},
+						{
+							label: 'Lato',
+							value: FontFamilyType.LATO,
+						},
+						{
+							label: 'Libre Franklin',
+							value: FontFamilyType.LIBRE_FRANKLIN,
+						},
+						{
+							label: 'Lucida',
+							value: FontFamilyType.LUCIDA,
+						},
+						{
+							label: 'Montserrat',
+							value: FontFamilyType.MONTSERRAT,
+						},
+						{
+							label: 'Nunito',
+							value: FontFamilyType.NUNITO,
+						},
+						{
+							label: 'Open Sans',
+							value: FontFamilyType.OPEN_SANS,
+						},
+						{
+							label: 'Oswald',
+							value: FontFamilyType.OSWALD,
+						},
+						{
+							label: 'Overpass',
+							value: FontFamilyType.OVERPASS,
+						},
+						{
+							label: 'Palatino',
+							value: FontFamilyType.PALATINO,
+						},
+						{
+							label: 'Poppins',
+							value: FontFamilyType.POPPINS,
+						},
+						{
+							label: 'Raleway',
+							value: FontFamilyType.RALEWAY,
+						},
+						{
+							label: 'Roboto',
+							value: FontFamilyType.ROBOTO,
+						},
+						{
+							label: 'Rubik',
+							value: FontFamilyType.RUBIK,
+						},
+						{
+							label: 'Tahoma',
+							value: FontFamilyType.TAHOMA,
+						},
+						{
+							label: 'Times New Roman',
+							value: FontFamilyType.TIMES_NEW_ROMAN,
+						},
+						{
+							label: 'Trebuchet',
+							value: FontFamilyType.TREBUCHET,
+						},
+						{
+							label: 'Verdana',
+							value: FontFamilyType.VERDANA,
+						},
+					] }
+				/>
+
+				{ attributes.align !== 'full' && (
+					<>
+						<TextControl
+							type="number"
+							label={ __( 'Width (%)', 'blocks' ) }
+							value={ attributes.style.width }
+							onChange={ handleChangeStyle( 'width' ) }
+						/>
+						<Button isSmall onClick={ handleResetWidth }>
+							{ __( 'Reset', 'blocks' ) }
+						</Button>
+					</>
+				) }
+
+				<TextControl
+					label={ __( 'Border thickness', 'blocks' ) }
+					type="number"
+					value={ attributes.style.borderWidth }
+					onChange={ handleChangeStyle( 'borderWidth' ) }
+				/>
+				<TextControl
+					label={ __( 'Corner radius', 'blocks' ) }
+					type="number"
+					value={ attributes.style.borderRadius }
+					onChange={ handleChangeStyle( 'borderRadius' ) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Drop shadow', 'blocks' ) }
+					checked={ attributes.style.hasBoxShadow }
+					onChange={ handleChangeStyle( 'hasBoxShadow' ) }
+				/>
+			</PanelColorSettings>
+
+			<PanelColorSettings
+				title={ __( 'Button styling', 'blocks' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Text color', 'blocks' ),
+						value: attributes.buttonStyle.color,
+						onChange: handleChangeButtonStyle( 'color' ),
+					},
+					{
+						label: __( 'Background color', 'blocks' ),
+						value: attributes.buttonStyle.backgroundColor,
+						onChange: handleChangeButtonStyle( 'backgroundColor' ),
+					},
+				] }
+			>
+				<ContrastChecker
+					textColor={ attributes.buttonStyle.color }
+					backgroundColor={ attributes.buttonStyle.backgroundColor }
+				/>
+
+				{ AnswerStyle.BUTTON === attributes.answerStyle && (
+					<SelectControl
+						label={ __( 'Alignment', 'blocks' ) }
+						value={ attributes.buttonStyle.align }
+						onChange={ handleChangeButtonStyle( 'align' ) }
+						options={ [
+							{
+								label: __( 'List', 'blocks' ),
+								value: ButtonAlignment.LIST,
+							},
+							{
+								label: __( 'Inline', 'blocks' ),
+								value: ButtonAlignment.INLINE,
+							},
+						] }
+					/>
+				) }
+			</PanelColorSettings>
+
+			<PanelBody
+				title={ __( 'Answer settings', 'blocks' ) }
+				initialOpen={ true }
+			>
+				<CheckboxControl
+					checked={ attributes.restrictions.oneResponsePerComputer }
+					label={ __( 'One response per computer', 'blocks' ) }
+					onChange={ handleChangeRestriction(
+						'oneResponsePerComputer'
+					) }
+				/>
+				<CheckboxControl
+					checked={ attributes.randomizeAnswers }
+					label={ __( 'Randomize answer order', 'blocks' ) }
+					onChange={ handleChangeAttribute( 'randomizeAnswers' ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/blocks/src/poll/sidebar.js
+++ b/packages/blocks/src/poll/sidebar.js
@@ -15,7 +15,6 @@ import {
 	ContrastChecker,
 	InspectorControls,
 	URLInput,
-	useSetting,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 } from '@wordpress/block-editor';
@@ -32,8 +31,6 @@ import {
 } from './constants';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
-	const gradients = useSetting( 'color.gradients' ) || [];
-
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
 			[ key ]: value,
@@ -165,9 +162,7 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 			</PanelBody>
 
 			<PanelColorGradientSettings
-				title={ __( 'Style', 'blocks' ) }
-				initialOpen={ false }
-				gradients={ [] }
+				title={ __( 'Color', 'blocks' ) }
 				disableCustomGradients={ false }
 				settings={ [
 					{
@@ -183,12 +178,6 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 							'backgroundColor'
 						),
 						onGradientChange: handleChangeAttribute( 'gradient' ),
-						gradients,
-					},
-					{
-						label: __( 'Border color', 'blocks' ),
-						colorValue: attributes.borderColor,
-						onColorChange: handleChangeAttribute( 'borderColor' ),
 					},
 				] }
 			>
@@ -196,7 +185,39 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 					backgroundColor={ attributes.backgroundColor }
 					textColor={ attributes.textColor }
 				/>
+			</PanelColorGradientSettings>
 
+			<PanelColorGradientSettings
+				title={ __( 'Border', 'blocks' ) }
+				settings={ [
+					{
+						label: __( 'Border color', 'blocks ' ),
+						colorValue: attributes.borderColor,
+						onColorChange: handleChangeAttribute( 'borderColor' ),
+					},
+				] }
+			>
+				<TextControl
+					label={ __( 'Border thickness', 'blocks' ) }
+					type="number"
+					value={ attributes.borderWidth }
+					onChange={ handleChangeAttribute( 'borderWidth' ) }
+				/>
+				<TextControl
+					label={ __( 'Corner radius', 'blocks' ) }
+					type="number"
+					value={ attributes.borderRadius }
+					onChange={ handleChangeAttribute( 'borderRadius' ) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Drop shadow', 'blocks' ) }
+					checked={ attributes.boxShadow }
+					onChange={ handleChangeAttribute( 'boxShadow' ) }
+				/>
+			</PanelColorGradientSettings>
+
+			<PanelBody title={ __( 'Typography', 'blocks' ) }>
 				<SelectControl
 					label={ __( 'Choose font', 'blocks' ) }
 					value={ attributes.fontFamily }
@@ -312,40 +333,21 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 						},
 					] }
 				/>
+			</PanelBody>
 
-				{ attributes.align !== 'full' && (
-					<>
-						<TextControl
-							type="number"
-							label={ __( 'Width (%)', 'blocks' ) }
-							value={ attributes.width }
-							onChange={ handleChangeAttribute( 'width' ) }
-						/>
-						<Button isSmall onClick={ handleResetWidth }>
-							{ __( 'Reset', 'blocks' ) }
-						</Button>
-					</>
-				) }
-
-				<TextControl
-					label={ __( 'Border thickness', 'blocks' ) }
-					type="number"
-					value={ attributes.borderWidth }
-					onChange={ handleChangeAttribute( 'borderWidth' ) }
-				/>
-				<TextControl
-					label={ __( 'Corner radius', 'blocks' ) }
-					type="number"
-					value={ attributes.borderRadius }
-					onChange={ handleChangeAttribute( 'borderRadius' ) }
-				/>
-
-				<ToggleControl
-					label={ __( 'Drop shadow', 'blocks' ) }
-					checked={ attributes.boxShadow }
-					onChange={ handleChangeAttribute( 'boxShadow' ) }
-				/>
-			</PanelColorGradientSettings>
+			{ attributes.align !== 'full' && (
+				<PanelBody title={ __( 'Width settings', 'blocks' ) }>
+					<TextControl
+						type="number"
+						label={ __( 'Width (%)', 'blocks' ) }
+						value={ attributes.width }
+						onChange={ handleChangeAttribute( 'width' ) }
+					/>
+					<Button isSmall onClick={ handleResetWidth }>
+						{ __( 'Reset', 'blocks' ) }
+					</Button>
+				</PanelBody>
+			) }
 
 			<PanelBody
 				title={ __( 'Answer settings', 'blocks' ) }

--- a/packages/blocks/src/poll/styles/poll.js
+++ b/packages/blocks/src/poll/styles/poll.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+export const PollWrapper = styled.div( ( {} ) => {
+	return css`
+		border: 1px solid var( --color-border );
+		margin-left: auto;
+		margin-right: auto;
+		margin-top: 5px;
+		padding: 16px 24px;
+		position: relative;
+		text-align: left;
+	`;
+} );

--- a/packages/blocks/src/poll/styles/poll.js
+++ b/packages/blocks/src/poll/styles/poll.js
@@ -2,16 +2,27 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
-export const PollWrapper = styled.div( ( {} ) => {
-	return css`
-		border: 1px solid var( --color-border );
-		margin-left: auto;
-		margin-right: auto;
-		margin-top: 5px;
-		padding: 16px 24px;
-		position: relative;
-		text-align: left;
-	`;
-} );
+export const EditorWrapper = styled.div`
+	display: flex;
+	justify-content: center;
+	padding: 0;
+	width: 100%;
+`;
+
+export const PollWrapper = styled.div`
+	border-style: solid;
+	box-sizing: border-box;
+	padding: 16px 24px;
+	position: relative;
+	text-align: left;
+	width: 100%;
+
+	.block-editor-block-list__layout > * {
+		margin-bottom: 16px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+`;

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,6 +18,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@wordpress/element": "^4.0.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "^8.3.2"
   }
 }

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -1,1 +1,2 @@
 export { default as useBlur } from './use-blur';
+export { default as useClientId } from './use-client-id';

--- a/packages/hooks/src/use-client-id/index.js
+++ b/packages/hooks/src/use-client-id/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { v4 as uuid } from 'uuid';
+
+const useClientId = ( { attributes, setAttributes } ) => {
+	useEffect( () => {
+		if ( attributes.clientId ) {
+			return;
+		}
+
+		setAttributes( {
+			clientId: uuid(),
+		} );
+	}, [] );
+};
+
+export default useClientId;

--- a/packages/styles/src/helpers.js
+++ b/packages/styles/src/helpers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber } from 'lodash';
+import { isFinite } from 'lodash';
 
 export const useColorStyles = ( {
 	backgroundColor,
@@ -18,6 +18,10 @@ export const useBorderStyles = ( {
 	borderWidth,
 } ) => ( {
 	borderColor,
-	borderRadius: isNumber( borderRadius ) ? `${ borderRadius }px` : null,
-	borderWidth: isNumber( borderWidth ) ? `${ borderWidth }px` : null,
+	borderRadius: isFinite( parseInt( borderRadius, 10 ) )
+		? `${ borderRadius }px`
+		: null,
+	borderWidth: isFinite( parseInt( borderWidth, 10 ) )
+		? `${ borderWidth }px`
+		: null,
 } );

--- a/packages/styles/src/helpers.js
+++ b/packages/styles/src/helpers.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { isNumber } from 'lodash';
+
+export const useColorStyles = ( {
+	backgroundColor,
+	gradient,
+	textColor,
+} ) => ( {
+	background: gradient || backgroundColor,
+	color: textColor,
+} );
+
+export const useBorderStyles = ( {
+	borderColor,
+	borderRadius,
+	borderWidth,
+} ) => ( {
+	borderColor,
+	borderRadius: isNumber( borderRadius ) ? `${ borderRadius }px` : null,
+	borderWidth: isNumber( borderWidth ) ? `${ borderWidth }px` : null,
+} );

--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -1,3 +1,4 @@
 export * from './breakpoints';
 export * from './colors';
+export * from './helpers';
 export * from './reset';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,7 +4861,7 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
   integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
-"@wordpress/a11y@^3.2.1":
+"@wordpress/a11y@^3.2.0", "@wordpress/a11y@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-3.2.1.tgz#87cbb71228388ecf7d04d175f2990391e2882c5e"
   integrity sha512-DSKSEkRmucjjF9ORiHHcUemtmNLckuE9auEovEVKeVfOBkLpx4qS6kMaxK8CCU9PUSBU9szfwwfoAz+YMQq6dg==
@@ -5081,6 +5081,49 @@
   resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-4.0.1.tgz#dcb1b4bcef1224c5a6c814a8e8ea4be83baa7740"
   integrity sha512-mmLxc21NWxZSSPvD592tmzpBlme+nB0fbG1xO+EldS4vQkeWIQUZlNbrMijZM/hpFaBqDEJCAZFUPUpw1XwBWg==
 
+"@wordpress/components@^14.1.5":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-14.2.0.tgz#fa7c6ed96fb8ec98e05a04f8c0a7b583a84cd56f"
+  integrity sha512-a06jjuBQMcIyrfXBfk4Hyu9BLQkT1rQm3tbOIE9Ur/cV8K0os0DrMUPZlNZ37IeOORzXhz89/L5mopvRttGLJQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/css" "^11.1.3"
+    "@emotion/react" "^11.1.5"
+    "@emotion/styled" "^11.3.0"
+    "@emotion/utils" "1.0.0"
+    "@wordpress/a11y" "^3.2.0"
+    "@wordpress/compose" "^4.2.0"
+    "@wordpress/date" "^4.2.0"
+    "@wordpress/deprecated" "^3.2.0"
+    "@wordpress/dom" "^3.2.0"
+    "@wordpress/element" "^3.2.0"
+    "@wordpress/hooks" "^3.2.0"
+    "@wordpress/i18n" "^4.2.0"
+    "@wordpress/icons" "^4.1.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.0"
+    "@wordpress/primitives" "^2.2.0"
+    "@wordpress/rich-text" "^4.2.0"
+    "@wordpress/warning" "^2.2.0"
+    classnames "^2.3.1"
+    dom-scroll-into-view "^1.2.1"
+    downshift "^6.0.15"
+    gradient-parser "^0.1.5"
+    highlight-words-core "^1.2.2"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    moment "^2.22.1"
+    re-resizable "^6.4.0"
+    react-dates "^17.1.1"
+    react-resize-aware "^3.1.0"
+    react-spring "^8.0.20"
+    react-use-gesture "^9.0.0"
+    reakit "^1.3.8"
+    rememo "^3.0.0"
+    tinycolor2 "^1.4.2"
+    uuid "^8.3.0"
+
 "@wordpress/components@^15.0.0":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-15.0.0.tgz#5dac7bc2827d08363f27114d961989058783f281"
@@ -5123,6 +5166,26 @@
     rememo "^3.0.0"
     tinycolor2 "^1.4.2"
     uuid "^8.3.0"
+
+"@wordpress/compose@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-4.2.0.tgz#f9d900237cdea2e8f648438fb5b992f5d1ab7842"
+  integrity sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/lodash" "4.14.149"
+    "@types/mousetrap" "^1.6.8"
+    "@wordpress/deprecated" "^3.2.0"
+    "@wordpress/dom" "^3.2.0"
+    "@wordpress/element" "^3.2.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.0"
+    "@wordpress/priority-queue" "^2.2.0"
+    clipboard "^2.0.1"
+    lodash "^4.17.21"
+    mousetrap "^1.6.5"
+    react-resize-aware "^3.1.0"
+    use-memo-one "^1.1.1"
 
 "@wordpress/compose@^5.0.0":
   version "5.0.0"
@@ -5174,6 +5237,25 @@
     "@wordpress/data" "^6.0.0"
     "@wordpress/deprecated" "^3.2.1"
 
+"@wordpress/data@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-5.2.0.tgz#14fc63788586968f503d538a7a9fbb60838afe6f"
+  integrity sha512-NlPIC8PdKnPly9CnynQS1di59Af3eiCZrQgZm1VssfA620NDoJA5p3dlDYj/Ts4Ryzp78HCi7wjhkmbsHpnd6g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/compose" "^4.2.0"
+    "@wordpress/deprecated" "^3.2.0"
+    "@wordpress/element" "^3.2.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/priority-queue" "^2.2.0"
+    "@wordpress/redux-routine" "^4.2.0"
+    equivalent-key-map "^0.2.2"
+    is-promise "^4.0.0"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    turbo-combine-reducers "^1.0.2"
+    use-memo-one "^1.1.1"
+
 "@wordpress/data@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-6.0.0.tgz#c0413bd7bde3a11ac9c2b5c1afce6edbde39decd"
@@ -5193,7 +5275,7 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
-"@wordpress/date@^4.2.1":
+"@wordpress/date@^4.2.0", "@wordpress/date@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-4.2.1.tgz#4742e82018ec64075a9fefc795d26f3f21643ebc"
   integrity sha512-1I9B+PvtdJAt5R5ON6fq3ux76GUltk/V5dYjhsN8CYzmuSNpIY7hNFbbr9LgRswSdPH1zhR+a/mqhzdDU99PRA==
@@ -5218,7 +5300,7 @@
     json2php "^0.0.4"
     webpack-sources "^2.2.0"
 
-"@wordpress/deprecated@^3.2.1":
+"@wordpress/deprecated@^3.2.0", "@wordpress/deprecated@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.2.1.tgz#6f8fab767308e5f9660961dcbbc9f8f3c843e01c"
   integrity sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==
@@ -5233,7 +5315,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/dom@^3.2.1":
+"@wordpress/dom@^3.2.0", "@wordpress/dom@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.2.1.tgz#8bc105537ebf05e1452a035f6e2de68a47d32723"
   integrity sha512-sl1MzQT8nvUfmRSrZgsLyfQo7wGFxZlLOzmAGMD4bUX/x40ZYAmsGc7E9zn7jnaqOmpbXKviUy0nBZiYGpfc2w==
@@ -5306,6 +5388,19 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
+"@wordpress/element@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-3.2.0.tgz#531720b3a023a1509f13d2464b2e1d670153116e"
+  integrity sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^2.2.0"
+    lodash "^4.17.21"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+
 "@wordpress/escape-html@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.1.1.tgz#4b9e887c2b1b06ec0d4fc691328224b4e9736c95"
@@ -5313,7 +5408,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/escape-html@^2.2.1":
+"@wordpress/escape-html@^2.2.0", "@wordpress/escape-html@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.2.1.tgz#5fd699cffebf59b174f5043b43b6b3dd770e2755"
   integrity sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==
@@ -5377,7 +5472,7 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@wordpress/i18n@^4.2.1":
+"@wordpress/i18n@^4.2.0", "@wordpress/i18n@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.2.1.tgz#a6aa7ca24477faa089b53e3d362a2fea1fb8af84"
   integrity sha512-56TW1rGRTgBZd2wZiMVxTuSi+1z5INpbQrLFjPwqhQJNiasDAUuUFzu4dRojkyBexJbB+1McYA1gv9xZlsJ8lg==
@@ -5389,6 +5484,15 @@
     memize "^1.1.0"
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
+
+"@wordpress/icons@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-4.1.0.tgz#12e3f6e5923c7c78200d242c152db6d068dc76a5"
+  integrity sha512-1FpEjT9kJbr0cWbgdgIwd2DoeerWijcVx3qCZ/WMFKNElBH9lfZLuWPI1hpX102HGWFcEi3VlbVpdBGeCeYQWg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/element" "^3.2.0"
+    "@wordpress/primitives" "^2.2.0"
 
 "@wordpress/icons@^5.0.0":
   version "5.0.0"
@@ -5457,7 +5561,7 @@
     lodash "^4.17.21"
     rememo "^3.0.0"
 
-"@wordpress/keycodes@^3.2.1":
+"@wordpress/keycodes@^3.2.0", "@wordpress/keycodes@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.2.1.tgz#107986320440e0e61ddae2c579307892a3e24f43"
   integrity sha512-mjJu6a7bmWR4y2mrWUMIfJIkqF50u09y8seP9o1YDdecrJBon8VAOjVmfh+N4W6L/bVLHfTq4/6IZQaVKCy3xw==
@@ -5532,6 +5636,15 @@
   resolved "https://registry.yarnpkg.com/@wordpress/prettier-config/-/prettier-config-1.0.5.tgz#905aa221633f48eb3b5c3966c2169639577ad7e8"
   integrity sha512-kZ1EzXmDKOe+QxSJJSu70zx+x2g1awqYJjX7Z947K0affv4l8/oPA+k3SgNi3U9Q5Sbwtb5xLgDr9k0HGJSw7g==
 
+"@wordpress/primitives@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-2.2.0.tgz#a813c3d8a43ad1f873b8e53f0b125cb8832273b0"
+  integrity sha512-WupgR+tt6fKGZE1UKy2gz3wDdpRL9MWQbVuetXv/7TPAz2ofOS2fZIsXNrl4D0HkA82gYh8w8s2TXK0XNyAAow==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/element" "^3.2.0"
+    classnames "^2.3.1"
+
 "@wordpress/primitives@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-3.0.0.tgz#f96ea8c04edf9c5eee7f58b3f493f566557c0fca"
@@ -5541,7 +5654,7 @@
     "@wordpress/element" "^4.0.0"
     classnames "^2.3.1"
 
-"@wordpress/priority-queue@^2.2.1":
+"@wordpress/priority-queue@^2.2.0", "@wordpress/priority-queue@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.2.1.tgz#b281c2744ebf0b82e32d5d5fc950ee8b8d09d36f"
   integrity sha512-ou3dbfnWvIsTH6fZJhveobOxO0VH09XpIoKalDPVB9TD65LP5Zuy5KTn0ASV5V/+5KEdMNRxQ1U/9uPJc6wIXw==
@@ -5558,7 +5671,7 @@
     "@wordpress/i18n" "^4.2.1"
     utility-types "^3.10.0"
 
-"@wordpress/redux-routine@^4.2.1":
+"@wordpress/redux-routine@^4.2.0", "@wordpress/redux-routine@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-4.2.1.tgz#9626b5a0b826dd6004c261900278d1aeaf4bc2f7"
   integrity sha512-u//4vdeKzYvu4YBRmSUsIbnUazai+PybEnquLPqxQdaF4JqVN1D5OPWHSeFtmaXR1c78I+lUf40Q7dnmA2waXw==
@@ -5586,6 +5699,24 @@
     "@wordpress/notices" "^3.2.1"
     "@wordpress/url" "^3.2.1"
     lodash "^4.17.21"
+
+"@wordpress/rich-text@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-4.2.0.tgz#df14810323378702e257a59ef66705cfbf44450e"
+  integrity sha512-e+wfrkKtZIcFZJZLxkrikiXbxlr6nuGg+V94uKMLrzJEWdw7w/8l3dNhWHRGPkldXIEGrF/mV40ibjUa2p3Sfg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/compose" "^4.2.0"
+    "@wordpress/data" "^5.2.0"
+    "@wordpress/dom" "^3.2.0"
+    "@wordpress/element" "^3.2.0"
+    "@wordpress/escape-html" "^2.2.0"
+    "@wordpress/is-shallow-equal" "^4.2.0"
+    "@wordpress/keycodes" "^3.2.0"
+    classnames "^2.3.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    rememo "^3.0.0"
 
 "@wordpress/rich-text@^5.0.0":
   version "5.0.0"
@@ -5730,7 +5861,7 @@
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.1.1.tgz#9f7ea1b9e054b0190c3203eb596f5fd025e0577b"
   integrity sha512-EX+/6P2bWO0zRrKJYx1yck0rY2K5z5aPb67DTU+2ggcowW8JRP7hBzGdzhXqoE32oMS7RO97nG3uD9sZtn2DJA==
 
-"@wordpress/warning@^2.2.1":
+"@wordpress/warning@^2.2.0", "@wordpress/warning@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.2.1.tgz#28c30f18ed3eb9db81125aebe15202468e594c60"
   integrity sha512-IlwDEcCYCMQjrHjVxPTjqx/y+aeyg0DYpNGArt30WFY/aVfZHNu25UASYjwngEahIAUfA7b3oTQbJv2o3IghGQ==
@@ -20335,7 +20466,7 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
This patch adds settings for `Poll` and `PollAnswer` blocks based on the ones in Crowdsignal Forms albeit with some differences.

The main difference lies in `PollAnswer` now being a child block, and thus being able to contain its own settings.
This simplifies the main block itself quite a bit, with a potential downside that each answer is now managed separately.  
Now, one could just as well say it's an advantage as it gives the user more option. Pressing enter on one answer will duplicate all its attributes but `label` and `clientId` which makes it easy enough to add identically styled answers if you ask me.

Other than that, the changes are mostly internal:

- Each block generates a unique `clientId` when it's created, with the exception of `PollAnswer` when it's _split_ and already contains a value/label - it will retain its current `clientId`.
- `restrictions` are now a single `object` prop vs having all of them pollute the attributes.
- All style related props follow the naming scheme supported by core blocks and their helpers, as well as `@crowdsignal/styles`.
- I moved over the typography settings from Crowdsignal Forms as well but I believe there's something in core for that as well. I'll need to check.

![Screen Shot 2021-08-19 at 10 18 40 PM](https://user-images.githubusercontent.com/8056203/130138604-e9f87098-af8e-441c-b1a1-172c63b8970f.png)

# Testing

- Run `yarn install` and `yarn workspace @crowdsignal/dashboard start`
- Go to `https://crowdsignal.localhost:9000/edit/poll/123`
- Add a `Poll` block
- The poll block should have a border by default, and poll answers should look like regular button blocks
- Try changing some of the color or border values on either the poll block or poll answers to see if attributes are updated correctly
- Resizing the poll block should work as well