### PR TITLE
Fix UI glitches on the new editor view

### DIFF
--- a/apps/dashboard/public/index.html
+++ b/apps/dashboard/public/index.html
@@ -3,6 +3,7 @@
 <head>
 	<title>Crowdsignal Dashboard</title>
 
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="/main.css" />
 </head>
 

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -1,8 +1,24 @@
 .editor {
 	.iso-editor {
-		--wp-admin-theme-color: var( --color-text );
+		--wp-admin-theme-color: var( --color-neutral-80 );
+		--wp-admin-theme-color-darker-10: var( --color-neutral-90 );
+		--wp-admin-theme-color-darker-20: var( --color-neutral-100 );
 
 		border: 0;
 		color: var( --color-text );
+	}
+
+	.edit-post-header__settings > .components-button {
+		margin-right: 12px;
+
+		&:last-child {
+			margin-right: 0;
+		}
+
+		&.is-crowdsignal {
+			--wp-admin-theme-color: var( --color-primary-50 );
+			--wp-admin-theme-color-darker-10: var( --color-primary-60 );
+			--wp-admin-theme-color-darker-20: var( --color-primary-70 );			
+		}
 	}
 }

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -1,8 +1,8 @@
-.poll-editor {
+.editor {
 	.iso-editor {
 		--wp-admin-theme-color: var( --color-text );
 
-		border-top: 0;
+		border: 0;
 		color: var( --color-text );
 	}
 }

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -27,7 +27,7 @@ const ProjectNavigation = ( { activeTab, projectId } ) => (
 				isSelected={ activeTab === Tab.EDITOR }
 				href={ `/edit/poll/${ projectId }` }
 			>
-				{ __( 'Edior', 'dashboard' ) }
+				{ __( 'Editor', 'dashboard' ) }
 			</TabNavigation.Tab>
 			<TabNavigation.Tab
 				isSelected={ activeTab === Tab.RESULTS }

--- a/apps/dashboard/src/components/project-navigation/style.scss
+++ b/apps/dashboard/src/components/project-navigation/style.scss
@@ -1,6 +1,7 @@
 .project-navigation {
 	align-items: center;
 	border-bottom: 1px solid var(--color-border);
+	box-sizing: border-box;
 	display: grid;
 	grid-template-columns: 1fr auto 1fr;
 	padding: 0 32px;

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -17,6 +17,8 @@
   },
   "main": "src/index.js",
   "dependencies": {
+    "@wordpress/components": "^15.0.0",
+    "@wordpress/i18n": "^4.2.1",
     "isolated-block-editor": "github:automattic/isolated-block-editor#2.3.0",
     "lodash": "^4.17.21"
   },

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -5,6 +5,11 @@ import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line 
 import { noop } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import Toolbar from './toolbar';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -18,6 +23,8 @@ export const BlockEditor = ( { onSave } ) => {
 			onSaveBlocks={ onSave }
 			onLoad={ ( parse ) => parse( '' ) }
 			onError={ noop }
-		/>
+		>
+			<Toolbar />
+		</IsolatedBlockEditor>
 	);
 };

--- a/packages/block-editor/src/toolbar.js
+++ b/packages/block-editor/src/toolbar.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line import/named
+
+/**
+ * Internal dependencies
+ */
+// import { Button } from '@crowdsignal/components';
+
+const Toolbar = () => {
+	return (
+		<ToolbarSlot className="block-editor__crowdsignal-toolbar">
+			<Button className="is-crowdsignal" variant="tertiary">
+				{ __( 'Preview', 'block-editor' ) }
+			</Button>
+			<Button className="is-crowdsignal" variant="primary">
+				{ __( 'Share', 'block-editor' ) }
+			</Button>
+		</ToolbarSlot>
+	);
+};
+
+export default Toolbar;


### PR DESCRIPTION
This patch contains some small fixes for visual glitches on the editor page:

- The app is now responsive. (Albeit still with limited support from some components).
- Removed the extra border around isolated block editor.
- Fixed the typo in `ProjectNavigation` and prevented it from breaking the layout.
- Added a `<ToolbarSlot />` in the editor to display share and preview buttons.

Before:

![Screen Shot 2021-08-20 at 11 47 42 AM](https://user-images.githubusercontent.com/8056203/130215080-38bf40ac-b6fc-4521-a511-c06425fcc18d.png)

After:

![Screen Shot 2021-08-20 at 11 47 16 AM](https://user-images.githubusercontent.com/8056203/130215091-85a37c01-3c62-4a0e-a643-4e96378fc085.png)

# Testing

Go to `/edit/poll/123` and verify that the issues listed above have been fixed.