### PR TITLE
Fix z-index property on the editor component

### DIFF
--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -6,7 +6,6 @@
 
 		border: 0;
 		color: var( --color-text );
-		z-index: -1;
 	}
 
 	.edit-post-header__settings > .components-button {

--- a/packages/components/src/popover/styles.js
+++ b/packages/components/src/popover/styles.js
@@ -7,6 +7,7 @@ import { css } from '@emotion/core';
 export const Wrapper = styled.div( ( props ) => {
 	return css`
 		position: fixed;
+		z-index: 1000;
 
 		${ props.position };
 	`;


### PR DESCRIPTION
This patch fixes the `z-index` property on the editor component which made it un-selectable and thus impossible to add or edit blocks.

I removed the property from the editor and adjusted the `z-index` value on `<Popover />` so it doesn't get overlapped by the editor.

# Testing

- Go to `/edit/poll/123`.
- Check if the editor works normally and you can add blocks.
- The user menu in the top right corner shouldn't get overlapped by the edtor.