### PR TITLE
PoC: Add view child blocks for polls

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -7,14 +7,17 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { pollBlock, pollAnswerBlock } from '@crowdsignal/blocks';
+import * as blocks from '@crowdsignal/blocks';
 
-const BLOCKS = {
-	'crowdsignal-forms/poll': pollBlock,
-	'crowdsignal-forms/poll-answer': pollAnswerBlock,
+const ENABLED_BLOCKS = {
+	'crowdsignal-forms/poll': blocks.pollBlock,
+	'crowdsignal-forms/poll-answer': blocks.pollAnswerBlock,
+	'crowdsignal-forms/poll-results-summary': blocks.pollResultsSummaryBlock,
+	'crowdsignal-forms/poll-results-view': blocks.pollResultsViewBlock,
+	'crowdsignal-forms/poll-vote-view': blocks.pollVoteViewBlock,
 };
 
 export const registerBlocks = () =>
-	forEach( BLOCKS, ( block, key ) => {
+	forEach( ENABLED_BLOCKS, ( block, key ) => {
 		registerBlockType( key, block );
 	} );

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,3 +1,6 @@
 export { default as pollBlock } from './poll';
 export { default as pollAnswerBlock } from './poll-answer';
+export { default as pollResultsSummaryBlock } from './poll-results-summary';
+export { default as pollResultsViewBlock } from './poll-results-view';
+export { default as pollVoteViewBlock } from './poll-vote-view';
 export { renderBlocks } from './render-blocks';

--- a/packages/blocks/src/poll-answer/index.js
+++ b/packages/blocks/src/poll-answer/index.js
@@ -13,7 +13,7 @@ export default {
 	title: __( 'Poll Answer', 'blocks' ),
 	description: __( 'Add more answer options to your poll', 'blocks' ),
 	category: 'crowdsignal-forms',
-	parent: [ 'crowdsignal-forms/poll' ],
+	parent: [ 'crowdsignal-forms/poll-vote-view' ],
 	edit: EditPollAnswer,
 	attributes,
 };

--- a/packages/blocks/src/poll-results-summary/edit.js
+++ b/packages/blocks/src/poll-results-summary/edit.js
@@ -1,0 +1,3 @@
+const EditPollResultsSummary = () => <div>Results</div>;
+
+export default EditPollResultsSummary;

--- a/packages/blocks/src/poll-results-summary/index.js
+++ b/packages/blocks/src/poll-results-summary/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import EditPollResultsSummary from './edit';
+
+export default {
+	title: __( 'Poll Results Summary', 'blocks' ),
+	description: __(
+		'Display an overview of the current poll results',
+		'blocks'
+	),
+	category: 'crowdsignal-forms',
+	parent: [ 'crowdsignal-forms/poll-results-view' ],
+	edit: EditPollResultsSummary,
+};

--- a/packages/blocks/src/poll-results-view/index.js
+++ b/packages/blocks/src/poll-results-view/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default {
+	title: __( 'Results View', 'blocks' ),
+	description: __(
+		'The container for all content shown to users after voting on the poll.'
+	),
+	category: 'crowdsignal-forms',
+	parent: [ 'crowdsignal-forms/poll' ],
+	edit: () => (
+		<InnerBlocks
+			templateLock="all"
+			template={ [ [ 'crowdsignal-forms/poll-results-summary', {} ] ] }
+		/>
+	),
+};

--- a/packages/blocks/src/poll-vote-view/index.js
+++ b/packages/blocks/src/poll-vote-view/index.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const ALLOWED_BLOCKS = [ 'crowdsignal-forms/poll-answer', 'core/paragraph' ];
+
+export default {
+	title: __( 'Voting View', 'blocks' ),
+	description: __(
+		'The container for all content initially shown to the users when visiting the poll.'
+	),
+	category: 'crowdsignal-forms',
+	parent: [ 'crowdsignal-forms/poll' ],
+	edit: () => (
+		<InnerBlocks
+			templateLock={ false }
+			template={ [
+				[ 'crowdsignal-forms/poll-answer', {} ],
+				[ 'crowdsignal-forms/poll-answer', {} ],
+				[ 'crowdsignal-forms/poll-answer', {} ],
+			] }
+			allowedBlocks={ ALLOWED_BLOCKS }
+		/>
+	),
+};

--- a/packages/blocks/src/poll/edit.js
+++ b/packages/blocks/src/poll/edit.js
@@ -18,8 +18,6 @@ import Sidebar from './sidebar';
  */
 import { EditorWrapper, PollWrapper } from './styles/poll';
 
-const ALLOWED_BLOCKS = [ 'crowdsignal-forms/poll-answer', 'core/paragraph' ];
-
 const PollBlock = ( props ) => {
 	const { attributes, className, isSelected, setAttributes } = props;
 
@@ -72,15 +70,11 @@ const PollBlock = ( props ) => {
 					/>
 
 					<InnerBlocks
+						templateLock="all"
 						template={ [
-							[ 'crowdsignal-forms/poll-answer', {} ],
-							[ 'crowdsignal-forms/poll-answer', {} ],
-							[ 'crowdsignal-forms/poll-answer', {} ],
+							[ 'crowdsignal-forms/poll-vote-view', {} ],
+							[ 'crowdsignal-forms/poll-results-view', {} ],
 						] }
-						templateLock={ false }
-						allowedBlocks={ ALLOWED_BLOCKS }
-						orientation="vertical"
-						__experimentalMoverDirection="vertical"
 					/>
 				</PollWrapper>
 			</ResizableBox>


### PR DESCRIPTION
This patch is an exploration of how the poll block could be implemented if we did allow for editing both voting and results tab, using child blocks for both.