### PR TITLE
Simplify selector/reducer isSaving on projects store branch

### DIFF
--- a/apps/dashboard/src/data/projects/reducer.js
+++ b/apps/dashboard/src/data/projects/reducer.js
@@ -31,7 +31,7 @@ const lastUpdatedItemId = ( state = 0, action ) => {
 	return state;
 };
 
-const isProjectSaving = ( state = false, action ) => {
+const isSaving = ( state = false, action ) => {
 	if ( action.type === PROJECT_SAVE ) {
 		return true;
 	}
@@ -49,5 +49,5 @@ const isProjectSaving = ( state = false, action ) => {
 export default combineReducers( {
 	items,
 	lastUpdatedItemId,
-	isProjectSaving,
+	isSaving,
 } );

--- a/apps/dashboard/src/data/projects/selectors.js
+++ b/apps/dashboard/src/data/projects/selectors.js
@@ -10,4 +10,4 @@ export const getProject = ( state, projectId ) =>
 	get( state, [ 'projects', 'items', projectId ], null );
 
 export const isProjectSaving = ( state ) =>
-	get( state, [ 'projects', 'isProjectSaving' ], false );
+	get( state, [ 'projects', 'isSaving' ], false );


### PR DESCRIPTION
This PR addresses the naming specificity of the reducer `isSaving` (formerly `isProjectSaving`) on the `projects` store branch.

## Test instructions
Run `yarn workspace @crowdsignal/dashboard start`. Inspect the store and verify the `projects` branch now holds a boolean `isSaving` entry. This boolean is responsible for making the "Save draft/Publish" buttons disabled (true) or not (false).

![image](https://user-images.githubusercontent.com/157240/131914575-d4d67d7c-52d3-46d3-b446-07be5d5581f8.png)
