### PR TITLE
Fix editor flow

### DIFF
--- a/apps/dashboard/src/components/editor/block-loader.js
+++ b/apps/dashboard/src/components/editor/block-loader.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+const BlockLoader = ( { blocks } ) => {
+	const { updateBlocksWithoutUndo } = useDispatch( 'isolated/editor' );
+
+	// mark for do the update only the first time.
+	const firstTime = useRef( true );
+
+	useEffect( () => {
+		if ( firstTime.current ) {
+			firstTime.current = false;
+			updateBlocksWithoutUndo( blocks );
+		}
+	}, [ blocks ] );
+	return null;
+};
+
+export default BlockLoader;

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -32,14 +32,22 @@ const Editor = ( { projectId } ) => {
 				const currentProject = project || {};
 				saveAndUpdateProject( projectId, {
 					...currentProject,
-					blocks,
+					content: {
+						...currentProject.content,
+						draft: {
+							pages: [ [ ...blocks ] ],
+						},
+					},
 				} );
 			} catch ( error ) {
-				// console.error( error );
-				// console.error( 'Failed to save project content.' );
+				// TODO: replace this with some nince notice or something
+				// eslint-disable-next-line
+				console.error( 'Failed to save project content.' );
+				// eslint-disable-next-line
+				console.error( error );
 			}
 		}, 1000 ),
-		[ projectId, saveAndUpdateProject ]
+		[ projectId, project ]
 	);
 
 	if ( projectId && null === project ) {

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -13,7 +13,7 @@ import { BlockEditor } from '@crowdsignal/block-editor';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
-// import EditorLoadingPlaceholder from './loading-placeholder';
+import EditorLoadingPlaceholder from './loading-placeholder';
 
 /**
  * Style dependencies
@@ -42,9 +42,10 @@ const Editor = ( { projectId } ) => {
 		[ projectId, saveAndUpdateProject ]
 	);
 
-	// if ( ! projectId ) {
-	// 	return <EditorLoadingPlaceholder />;
-	// }
+	if ( projectId && null === project ) {
+		// project is being loaded
+		return <EditorLoadingPlaceholder />;
+	}
 
 	return (
 		<div className="editor">

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -4,7 +4,7 @@
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 // import { __ } from '@wordpress/i18n';
-import { debounce } from 'lodash';
+import { debounce, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
 import EditorLoadingPlaceholder from './loading-placeholder';
+import BlockLoader from './block-loader';
 
 /**
  * Style dependencies
@@ -24,6 +25,18 @@ const Editor = ( { projectId } ) => {
 	const project = useSelect( ( select ) =>
 		select( STORE_NAME ).getProject( projectId )
 	);
+
+	const projectContent = get( project, [ 'content' ], {} );
+
+	// TODO: need to compare draft/published, offer "restore" drafted content
+	const draftedBlocks = get( projectContent, [ 'draft', 'pages', 0 ], [] );
+
+	const displayedBlocks = get(
+		projectContent,
+		[ 'published', 'pages', 0 ],
+		draftedBlocks
+	);
+
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const handleSaveBlocks = useCallback(
@@ -62,7 +75,9 @@ const Editor = ( { projectId } ) => {
 				projectId={ projectId }
 			/>
 
-			<BlockEditor onSave={ handleSaveBlocks } />
+			<BlockEditor onSave={ handleSaveBlocks }>
+				<BlockLoader blocks={ displayedBlocks } />
+			</BlockEditor>
 		</div>
 	);
 };

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useDispatch, withSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 // import { __ } from '@wordpress/i18n';
 import { debounce } from 'lodash';
 
@@ -20,7 +20,10 @@ import { registerBlocks } from './blocks';
  */
 import './style.scss';
 
-const Editor = ( { projectId, project } ) => {
+const Editor = ( { projectId } ) => {
+	const project = useSelect( ( select ) =>
+		select( STORE_NAME ).getProject( projectId )
+	);
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const handleSaveBlocks = useCallback(
@@ -57,10 +60,4 @@ const Editor = ( { projectId, project } ) => {
 
 registerBlocks();
 
-export default withSelect( ( select, ownProps ) => {
-	return {
-		project:
-			ownProps.projectId &&
-			select( STORE_NAME ).getProject( ownProps.projectId ),
-	};
-} )( Editor );
+export default Editor;

--- a/apps/dashboard/src/components/project-tools/index.js
+++ b/apps/dashboard/src/components/project-tools/index.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { Button } from '@crowdsignal/components';
 import { STORE_NAME } from '../../data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Style dependencies
  */
@@ -17,14 +17,30 @@ import './style.scss';
 const ProjectTools = ( { projectId, isSaving } ) => {
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
+	const project = useSelect( ( select ) =>
+		select( STORE_NAME ).getProject( projectId )
+	);
+
 	const syncProject = () => {
 		const payload = { title: 'Drafted!' };
-		saveAndUpdateProject( projectId, payload );
+		saveAndUpdateProject( projectId, {
+			...project,
+			...payload,
+		} );
 	};
 
 	const publishProject = () => {
 		const payload = { title: 'Published!', publish: true };
-		saveAndUpdateProject( projectId, payload );
+		saveAndUpdateProject( projectId, {
+			...project,
+			content: {
+				...project.content,
+				published: {
+					...project.content.draft,
+				},
+			},
+			...payload,
+		} );
 	};
 
 	return (

--- a/apps/dashboard/src/data/projects/resolvers.js
+++ b/apps/dashboard/src/data/projects/resolvers.js
@@ -6,6 +6,9 @@ import { dispatchAsync } from '../actions';
 import { updateProject } from '../projects/actions';
 
 function* getProject( projectId ) {
+	if ( ! projectId ) {
+		return null;
+	}
 	try {
 		const response = yield dispatchAsync( fetchProject, [ projectId ] );
 

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -25,7 +25,7 @@ const settings = {
 	},
 };
 
-export const BlockEditor = ( { onSave } ) => {
+export const BlockEditor = ( { onSave, onLoad, children } ) => {
 	const handleChangeContent = useCallback(
 		debounce( ( content ) => onSave( parse( content ) ), 1000 ),
 		[ onSave ]
@@ -35,10 +35,11 @@ export const BlockEditor = ( { onSave } ) => {
 		<IsolatedBlockEditor
 			settings={ settings }
 			onSaveContent={ handleChangeContent }
-			onLoad={ () => parse( '' ) }
+			onLoad={ onLoad || noop }
 			onError={ noop }
 		>
 			<Toolbar />
+			{ children }
 		</IsolatedBlockEditor>
 	);
 };


### PR DESCRIPTION
This PR addresses some hiccups with the load/save flow of the project. 

A new component had to be created to inject any loaded content into the editor as the Isolated Block Editor acts as a registry/store provider, hence any dispatch is only available through children components.

This PR also updates the project content payload shape:
```js
{
  ...
  content: {
    draft: {
      pages: [
        [ { block }, { block } ],
      ],
    },
    published: {
      pages: [
        [ { block }, { block } ],
      ],
    },
  }
}
```

When hitting "Publish" we assume the `draft` version is up-to-date with the editor contents and copied over the `published`. We might want to change that later (have a *volatile* state of the current content and take it from there?) but for now, with the auto-save function in place, the assumption is safe enough.

One caveat of this assumption (we can handle it better, but for now it just breaks) is publishing before any draft has been saved (no project ID on the URL).

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`, visit http://crowdsignal.localhost:9000/edit/poll

  - [ ] The editor renders empty
  - [ ] Force a draft by either making some change (add some text) or hitting "Save draft" button, see that the URL has changed to hold the project ID (numeric)
  - [ ] Check your dashboard to see the new Project (don't click it, backend not ready to deal with it) titled "Drafted!"
  - [ ] Back on the editor, hit "Publish". Check your dashboard again to see the Project is now titled "Published!"
  - [ ] Make more changes in the editor, the auto-save function should trigger but it should only update the `draft` version of the project (inspect the store to see this changes, Redux plugin might help here, store is named `crowdsignal/dashboard`)
