### PR TITLE
Add Free Text block with inline debugging

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -7,11 +7,12 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { pollBlock, pollAnswerBlock } from '@crowdsignal/blocks';
+import { pollBlock, pollAnswerBlock, freeText } from '@crowdsignal/blocks';
 
 const BLOCKS = {
 	'crowdsignal-forms/poll': pollBlock,
 	'crowdsignal-forms/poll-answer': pollAnswerBlock,
+	'crowdsignal-forms/free-text': freeText,
 };
 
 export const registerBlocks = () =>

--- a/packages/blocks/src/free-text/attributes.js
+++ b/packages/blocks/src/free-text/attributes.js
@@ -1,0 +1,55 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	restrictions: {
+		type: 'object',
+		default: {},
+	},
+	question: {
+		type: 'string',
+		default: null,
+	},
+	note: {
+		type: 'string',
+		default: '',
+	},
+	// should this be an entry on restrictions?
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+		default: 0,
+	},
+	boxShadow: {
+		type: 'boolean',
+		default: false,
+	},
+	borderWidth: {
+		type: 'number',
+		default: 2,
+	},
+	fontFamily: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+		default: 100,
+	},
+};

--- a/packages/blocks/src/free-text/edit.js
+++ b/packages/blocks/src/free-text/edit.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useClientId } from '@crowdsignal/hooks';
+
+const FreeText = ( props ) => {
+	const { attributes, setAttributes } = props;
+
+	useClientId( props );
+
+	const handleChangeQuestion = ( question ) => setAttributes( { question } );
+
+	const handleChangeNote = ( note ) => setAttributes( { note } );
+
+	return (
+		<>
+			<RichText
+				tagName="h3"
+				placeholder={ __( 'Enter your question', 'blocks' ) }
+				onChange={ handleChangeQuestion }
+				value={ attributes.question }
+			/>
+			<TextareaControl
+				rows={ 6 }
+				onChange={ handleChangeNote }
+				value={ attributes.note }
+			/>
+
+			<pre>{ JSON.stringify( attributes, null, 4 ) }</pre>
+		</>
+	);
+};
+
+export default FreeText;

--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import EditFreeText from './edit';
+
+export default {
+	apiVersion: 1,
+	title: __( 'Free Text', 'blocks' ),
+	description: __( 'Allows for a free text response on your form', 'blocks' ),
+	category: 'crowdsignal-forms',
+	edit: EditFreeText,
+	attributes,
+	supports: {
+		html: false,
+		reusable: false,
+	},
+};

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,3 +1,4 @@
 export { default as pollBlock } from './poll';
 export { default as pollAnswerBlock } from './poll-answer';
+export { default as freeText } from './free-text';
 export { renderBlocks } from './render-blocks';


### PR DESCRIPTION
This PR adds a new question block: Free Text

It includes a `<pre>` with all the block's structure for easy debugging while we finish this up.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`. Go to crowdsignal.localhost:9000 and add the new block by typing `/Free Text`