### PR TITLE
Change editor route

### DIFF
--- a/apps/dashboard/src/components/app/index.js
+++ b/apps/dashboard/src/components/app/index.js
@@ -6,7 +6,7 @@ import Masterbar from '../masterbar';
 import Editor from '../editor';
 import Results from '../results';
 
-const allowedRoutes = /^\/(edit)\/.*/i;
+const allowedRoutes = /^\/(project)\/.*/i;
 
 const NotFound = () => <div className="app__not-found">404</div>;
 
@@ -18,9 +18,12 @@ const App = () => {
 
 				<main className="app__content">
 					<Switch>
-						<Route path="/edit(/:projectId)" component={ Editor } />
 						<Route
-							path="/edit/:projectId/results"
+							path="/project(/:projectId)"
+							component={ Editor }
+						/>
+						<Route
+							path="/project/:projectId/results"
 							component={ Results }
 						/>
 

--- a/apps/dashboard/src/components/app/index.js
+++ b/apps/dashboard/src/components/app/index.js
@@ -18,12 +18,9 @@ const App = () => {
 
 				<main className="app__content">
 					<Switch>
+						<Route path="/edit(/:projectId)" component={ Editor } />
 						<Route
-							path="/edit/poll(/:projectId)"
-							component={ Editor }
-						/>
-						<Route
-							path="/edit/poll/:projectId/results"
+							path="/edit/:projectId/results"
 							component={ Results }
 						/>
 

--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -7,11 +7,12 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { pollBlock, pollAnswerBlock } from '@crowdsignal/blocks';
+import { pollBlock, pollAnswerBlock, freeText } from '@crowdsignal/blocks';
 
 const BLOCKS = {
 	'crowdsignal-forms/poll': pollBlock,
 	'crowdsignal-forms/poll-answer': pollAnswerBlock,
+	'crowdsignal-forms/free-text': freeText,
 };
 
 export const registerBlocks = () =>

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -13,7 +13,7 @@ import { BlockEditor } from '@crowdsignal/block-editor';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
-import EditorLoadingPlaceholder from './loading-placeholder';
+// import EditorLoadingPlaceholder from './loading-placeholder';
 import BlockLoader from './block-loader';
 
 /**
@@ -63,10 +63,10 @@ const Editor = ( { projectId } ) => {
 		[ projectId, project ]
 	);
 
-	if ( projectId && null === project ) {
-		// project is being loaded
-		return <EditorLoadingPlaceholder />;
-	}
+	// if ( projectId && null === project ) {
+	// 	// project is being loaded
+	// 	return <EditorLoadingPlaceholder />;
+	// }
 
 	return (
 		<div className="editor">

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -13,7 +13,7 @@ import { BlockEditor } from '@crowdsignal/block-editor';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
-// import EditorLoadingPlaceholder from './loading-placeholder';
+import EditorLoadingPlaceholder from './loading-placeholder';
 import BlockLoader from './block-loader';
 
 /**
@@ -63,10 +63,10 @@ const Editor = ( { projectId } ) => {
 		[ projectId, project ]
 	);
 
-	// if ( projectId && null === project ) {
-	// 	// project is being loaded
-	// 	return <EditorLoadingPlaceholder />;
-	// }
+	if ( projectId && null === project ) {
+		// project is being loaded
+		return <EditorLoadingPlaceholder />;
+	}
 
 	return (
 		<div className="editor">

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -44,8 +44,7 @@ export function* saveAndUpdateProject( projectId, project ) {
 			: yield dispatchAsync( createProject, [ project ] );
 
 		yield updateProject( response.data.id, response.data );
-		redirect( `/project/${ response.data.id }` );
-		return;
+		return redirect( `/project/${ response.data.id }` );
 	} catch ( error ) {
 		// Request failed
 		return saveProjectError( error.message );

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -43,8 +43,9 @@ export function* saveAndUpdateProject( projectId, project ) {
 			? yield dispatchAsync( patchProject, [ projectId, project ] )
 			: yield dispatchAsync( createProject, [ project ] );
 
+		yield updateProject( response.data.id, response.data );
 		redirect( `/project/${ response.data.id }` );
-		return updateProject( response.data.id, response.data );
+		return;
 	} catch ( error ) {
 		// Request failed
 		return saveProjectError( error.message );

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -43,8 +43,7 @@ export function* saveAndUpdateProject( projectId, project ) {
 			? yield dispatchAsync( patchProject, [ projectId, project ] )
 			: yield dispatchAsync( createProject, [ project ] );
 
-		yield redirect( `/project/${ response.data.id }` );
-
+		redirect( `/project/${ response.data.id }` );
 		return updateProject( response.data.id, response.data );
 	} catch ( error ) {
 		// Request failed

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -43,7 +43,7 @@ export function* saveAndUpdateProject( projectId, project ) {
 			? yield dispatchAsync( patchProject, [ projectId, project ] )
 			: yield dispatchAsync( createProject, [ project ] );
 
-		yield redirect( `/edit/poll/${ response.data.id }` );
+		yield redirect( `/edit/${ response.data.id }` );
 
 		return updateProject( response.data.id, response.data );
 	} catch ( error ) {

--- a/apps/dashboard/src/data/projects/actions.js
+++ b/apps/dashboard/src/data/projects/actions.js
@@ -43,7 +43,7 @@ export function* saveAndUpdateProject( projectId, project ) {
 			? yield dispatchAsync( patchProject, [ projectId, project ] )
 			: yield dispatchAsync( createProject, [ project ] );
 
-		yield redirect( `/edit/${ response.data.id }` );
+		yield redirect( `/project/${ response.data.id }` );
 
 		return updateProject( response.data.id, response.data );
 	} catch ( error ) {

--- a/packages/blocks/src/free-text/attributes.js
+++ b/packages/blocks/src/free-text/attributes.js
@@ -1,0 +1,55 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	restrictions: {
+		type: 'object',
+		default: {},
+	},
+	question: {
+		type: 'string',
+		default: null,
+	},
+	note: {
+		type: 'string',
+		default: '',
+	},
+	// should this be an entry on restrictions?
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+		default: 0,
+	},
+	boxShadow: {
+		type: 'boolean',
+		default: false,
+	},
+	borderWidth: {
+		type: 'number',
+		default: 2,
+	},
+	fontFamily: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+		default: 100,
+	},
+};

--- a/packages/blocks/src/free-text/edit.js
+++ b/packages/blocks/src/free-text/edit.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useClientId } from '@crowdsignal/hooks';
+
+const FreeText = ( props ) => {
+	const { attributes, setAttributes } = props;
+
+	useClientId( props );
+
+	const handleChangeQuestion = ( question ) => setAttributes( { question } );
+
+	const handleChangeNote = ( note ) => setAttributes( { note } );
+
+	return (
+		<>
+			<RichText
+				tagName="h3"
+				placeholder={ __( 'Enter your question', 'blocks' ) }
+				onChange={ handleChangeQuestion }
+				value={ attributes.question }
+			/>
+			<TextareaControl
+				rows={ 6 }
+				onChange={ handleChangeNote }
+				value={ attributes.note }
+			/>
+
+			<pre>{ JSON.stringify( attributes, null, 4 ) }</pre>
+		</>
+	);
+};
+
+export default FreeText;

--- a/packages/blocks/src/free-text/edit.js
+++ b/packages/blocks/src/free-text/edit.js
@@ -32,8 +32,6 @@ const FreeText = ( props ) => {
 				onChange={ handleChangeNote }
 				value={ attributes.note }
 			/>
-
-			<pre>{ JSON.stringify( attributes, null, 4 ) }</pre>
 		</>
 	);
 };

--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import EditFreeText from './edit';
+
+export default {
+	apiVersion: 1,
+	title: __( 'Free Text', 'blocks' ),
+	description: __( 'Allows for a free text response on your form', 'blocks' ),
+	category: 'crowdsignal-forms',
+	edit: EditFreeText,
+	attributes,
+	supports: {
+		html: false,
+		reusable: false,
+	},
+};

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,3 +1,4 @@
 export { default as pollBlock } from './poll';
 export { default as pollAnswerBlock } from './poll-answer';
+export { default as freeText } from './free-text';
 export { renderBlocks } from './render-blocks';

--- a/packages/blocks/src/poll/edit.js
+++ b/packages/blocks/src/poll/edit.js
@@ -69,6 +69,7 @@ const PollBlock = ( props ) => {
 						tagName="h3"
 						placeholder={ __( 'Enter your question', 'blocks' ) }
 						onChange={ handleChangeQuestion }
+						value={ attributes.question || '' }
 					/>
 
 					<InnerBlocks


### PR DESCRIPTION
This PR removes the `poll` part of the editor route, becoming:

  - /edit/{id}
  - /edit/{id}/results

This PR depends on #41 