### PR TITLE
Change export name for consistency

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -7,12 +7,16 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import { pollBlock, pollAnswerBlock, freeText } from '@crowdsignal/blocks';
+import {
+	pollBlock,
+	pollAnswerBlock,
+	freeTextQuestionBlock,
+} from '@crowdsignal/blocks';
 
 const BLOCKS = {
 	'crowdsignal-forms/poll': pollBlock,
 	'crowdsignal-forms/poll-answer': pollAnswerBlock,
-	'crowdsignal-forms/free-text': freeText,
+	'crowdsignal-forms/free-text': freeTextQuestionBlock,
 };
 
 export const registerBlocks = () =>

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,4 +1,4 @@
 export { default as pollBlock } from './poll';
 export { default as pollAnswerBlock } from './poll-answer';
-export { default as freeText } from './free-text';
+export { default as freeTextQuestionBlock } from './free-text';
 export { renderBlocks } from './render-blocks';


### PR DESCRIPTION
This PR is a wee change to the export name of the Free Text question block.

`freeText` -> `freeTextQuestionBlock`