### PR TITLE
Add multiple choice question block

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -11,12 +11,14 @@ import {
 	pollBlock,
 	pollAnswerBlock,
 	freeTextQuestionBlock,
+	multipleChoiceQuestionBlock,
 } from '@crowdsignal/blocks';
 
 const BLOCKS = {
 	'crowdsignal-forms/poll': pollBlock,
 	'crowdsignal-forms/poll-answer': pollAnswerBlock,
 	'crowdsignal-forms/free-text': freeTextQuestionBlock,
+	'crowdsignal-forms/multiple-choice': multipleChoiceQuestionBlock,
 };
 
 export const registerBlocks = () =>

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -6,6 +6,11 @@
 
 		border: 0;
 		color: var( --color-text );
+
+		.wp-block.is-selected, .wp-block:hover {
+			// the color of the first shadow should be inherited from the theme background (it's only a mask to gain some margin on the block)
+			box-shadow: -10px 0px 0px white, -12px 0px 0px #c8366e;
+		}
 	}
 
 	.edit-post-header__settings > .components-button {
@@ -18,7 +23,7 @@
 		&.is-crowdsignal {
 			--wp-admin-theme-color: var( --color-primary-50 );
 			--wp-admin-theme-color-darker-10: var( --color-primary-60 );
-			--wp-admin-theme-color-darker-20: var( --color-primary-70 );			
+			--wp-admin-theme-color-darker-20: var( --color-primary-70 );
 		}
 	}
 }

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,4 +1,5 @@
 export { default as pollBlock } from './poll';
 export { default as pollAnswerBlock } from './poll-answer';
 export { default as freeTextQuestionBlock } from './free-text';
+export { default as multipleChoiceQuestionBlock } from './multiple-choice';
 export { renderBlocks } from './render-blocks';

--- a/packages/blocks/src/multiple-choice/attributes.js
+++ b/packages/blocks/src/multiple-choice/attributes.js
@@ -1,0 +1,55 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	restrictions: {
+		type: 'object',
+		default: {},
+	},
+	question: {
+		type: 'string',
+		default: null,
+	},
+	note: {
+		type: 'string',
+		default: '',
+	},
+	// should this be an entry on restrictions?
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+		default: 0,
+	},
+	boxShadow: {
+		type: 'boolean',
+		default: false,
+	},
+	borderWidth: {
+		type: 'number',
+		default: 2,
+	},
+	fontFamily: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+		default: 100,
+	},
+};

--- a/packages/blocks/src/multiple-choice/attributes.js
+++ b/packages/blocks/src/multiple-choice/attributes.js
@@ -1,3 +1,5 @@
+import { ChoiceType } from './constants';
+
 export default {
 	clientId: {
 		type: 'string',
@@ -19,6 +21,22 @@ export default {
 	mandatory: {
 		type: 'boolean',
 		default: false,
+	},
+	allowOther: {
+		type: 'boolean',
+		default: false,
+	},
+	choiceType: {
+		type: 'number',
+		default: ChoiceType.SINGLE,
+	},
+	minimumChoices: {
+		type: 'number',
+		default: 0,
+	},
+	maximumChoices: {
+		type: 'number',
+		default: 0,
 	},
 	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
 	backgroundColor: {

--- a/packages/blocks/src/multiple-choice/constants.js
+++ b/packages/blocks/src/multiple-choice/constants.js
@@ -1,0 +1,11 @@
+export const AnswerStyle = Object.freeze( {
+	RADIO: 'radio',
+	BUTTON: 'button',
+} );
+
+export const ChoiceType = Object.freeze( {
+	SINGLE: 0, // radio
+	// SINGLE_LIST: 1, // dropdown
+	MULTIPLE: 2, // checkbox
+	// MULTIPLE_LIST: 3, // combobox
+} );

--- a/packages/blocks/src/multiple-choice/edit.js
+++ b/packages/blocks/src/multiple-choice/edit.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useClientId } from '@crowdsignal/hooks';
+
+/**
+ * Style dependencies
+ */
+import { MultipleChoiceWrapper } from './styles/multiple-choice';
+
+const ALLOWED_ANSWER_BLOCKS = [
+	'core/image',
+	'core/paragraph',
+	'crowdsignal-forms/poll-answer',
+];
+
+const MultipleChoice = ( props ) => {
+	const { attributes, setAttributes } = props;
+
+	useClientId( props );
+
+	const handleChangeQuestion = ( question ) => setAttributes( { question } );
+
+	const handleChangeNote = ( note ) => setAttributes( { note } );
+
+	return (
+		<MultipleChoiceWrapper>
+			<RichText
+				tagName="h3"
+				placeholder={ __( 'Enter your question', 'blocks' ) }
+				onChange={ handleChangeQuestion }
+				value={ attributes.question }
+			/>
+			<RichText
+				tagName="p"
+				placeholder={ __( 'Enter a note', 'blocks' ) }
+				onChange={ handleChangeNote }
+				value={ attributes.note }
+			/>
+			<InnerBlocks
+				template={ [
+					[ 'crowdsignal-forms/poll-answer', {} ],
+					[ 'crowdsignal-forms/poll-answer', {} ],
+					[ 'crowdsignal-forms/poll-answer', {} ],
+				] }
+				templateLock={ false }
+				allowedBlocks={ ALLOWED_ANSWER_BLOCKS }
+				orientation="vertical"
+				__experimentalMoverDirection="vertical"
+			/>
+		</MultipleChoiceWrapper>
+	);
+};
+
+export default MultipleChoice;

--- a/packages/blocks/src/multiple-choice/edit.js
+++ b/packages/blocks/src/multiple-choice/edit.js
@@ -32,7 +32,7 @@ const MultipleChoice = ( props ) => {
 	return (
 		<MultipleChoiceWrapper>
 			<RichText
-				tagName="h3"
+				tagName="p"
 				placeholder={ __( 'Enter your question', 'blocks' ) }
 				onChange={ handleChangeQuestion }
 				value={ attributes.question }

--- a/packages/blocks/src/multiple-choice/index.js
+++ b/packages/blocks/src/multiple-choice/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import EditMultipleChoice from './edit';
+
+export default {
+	apiVersion: 1,
+	title: __( 'Multiple Choice', 'blocks' ),
+	description: __(
+		'Allows for a multiple choice question on your form',
+		'blocks'
+	),
+	category: 'crowdsignal-forms',
+	edit: EditMultipleChoice,
+	save: () => <InnerBlocks.Content />,
+	attributes,
+	supports: {
+		html: false,
+		reusable: false,
+	},
+};

--- a/packages/blocks/src/multiple-choice/styles/multiple-choice.js
+++ b/packages/blocks/src/multiple-choice/styles/multiple-choice.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const MultipleChoiceWrapper = styled.div`
+	.multiple-choice__answer,
+	.wp-block-crowdsignal-forms-poll-answer {
+		margin-bottom: 8px;
+	}
+`;


### PR DESCRIPTION
This PR adds the initial skeleton for the MC Question Block.

It is based on the work for the Poll block and should suffice while the backend is set to receive and save this type of questions.


## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`, visit http://crowdsignal.localhost:9000/project and insert a MC Question Block by typing `/Multiple Choice`