### PR TITLE
Make block name part of the exported settings

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -7,21 +7,9 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	pollBlock,
-	pollAnswerBlock,
-	freeTextQuestionBlock,
-	multipleChoiceQuestionBlock,
-} from '@crowdsignal/blocks';
-
-const BLOCKS = {
-	'crowdsignal-forms/poll': pollBlock,
-	'crowdsignal-forms/poll-answer': pollAnswerBlock,
-	'crowdsignal-forms/free-text': freeTextQuestionBlock,
-	'crowdsignal-forms/multiple-choice': multipleChoiceQuestionBlock,
-};
+import * as blocks from '@crowdsignal/blocks';
 
 export const registerBlocks = () =>
-	forEach( BLOCKS, ( block, key ) => {
-		registerBlockType( key, block );
+	forEach( blocks, ( block ) => {
+		registerBlockType( block.name, block.settings );
 	} );

--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -9,7 +9,9 @@ import { __ } from '@wordpress/i18n';
 import attributes from './attributes';
 import EditFreeText from './edit';
 
-export default {
+const name = 'crowdsignal-forms/free-text';
+
+const settings = {
 	apiVersion: 1,
 	title: __( 'Free Text', 'blocks' ),
 	description: __( 'Allows for a free text response on your form', 'blocks' ),
@@ -20,4 +22,9 @@ export default {
 		html: false,
 		reusable: false,
 	},
+};
+
+export default {
+	name,
+	settings,
 };

--- a/packages/blocks/src/multiple-choice/index.js
+++ b/packages/blocks/src/multiple-choice/index.js
@@ -10,7 +10,9 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import attributes from './attributes';
 import EditMultipleChoice from './edit';
 
-export default {
+const name = 'crowdsignal-forms/multiple-choice';
+
+const settings = {
 	apiVersion: 1,
 	title: __( 'Multiple Choice', 'blocks' ),
 	description: __(
@@ -25,4 +27,9 @@ export default {
 		html: false,
 		reusable: false,
 	},
+};
+
+export default {
+	name,
+	settings,
 };

--- a/packages/blocks/src/poll-answer/index.js
+++ b/packages/blocks/src/poll-answer/index.js
@@ -9,11 +9,18 @@ import { __ } from '@wordpress/i18n';
 import attributes from './attributes';
 import EditPollAnswer from './edit';
 
-export default {
+const name = 'crowdsignal-forms/poll-answer';
+
+const settings = {
 	title: __( 'Poll Answer', 'blocks' ),
 	description: __( 'Add more answer options to your poll', 'blocks' ),
 	category: 'crowdsignal-forms',
 	parent: [ 'crowdsignal-forms/poll' ],
 	edit: EditPollAnswer,
 	attributes,
+};
+
+export default {
+	name,
+	settings,
 };

--- a/packages/blocks/src/poll/index.js
+++ b/packages/blocks/src/poll/index.js
@@ -10,7 +10,9 @@ import { __ } from '@wordpress/i18n';
 import attributes from './attributes';
 import EditPoll from './edit';
 
-export default {
+const name = 'crowdsignal-forms/poll';
+
+const settings = {
 	apiVersion: 1,
 	title: __( 'Poll', 'blocks' ),
 	description: __( "Create polls and get your audience's opinion", 'blocks' ),
@@ -26,4 +28,9 @@ export default {
 	getEditWrapperProps: ( { align } ) => ( {
 		'data-align': align,
 	} ),
+};
+
+export default {
+	name,
+	settings,
 };


### PR DESCRIPTION
This patch updates the blocks' default exports to include the block name as well.  
Reason being, since they need to be 'hardcoded' because of how child-blocks mechanics work, it makes more sense to keep that in one place.

The updated structure also allows for adding any additional metadata to the block if we ever want that.

# Testing

- Run `yarn workspace @crowdsignal/dashboard start`.
- Verify all Crowdsignal blocks still work like they used to.