### PR TITLE
Set toolbar to appear above the block instead of being fixed

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -25,6 +25,9 @@ import './style.scss';
 
 const editorSettings = {
 	iso: {
+		defaultPreferences: {
+			fixedToolbar: false,
+		},
 		toolbar: {
 			inspector: true,
 			toc: true,


### PR DESCRIPTION
This is a small patch to address c/tDCumeUy-tr. The toolbar will now appear above the block instead of the main editor toolbar for improved experience.

![Screen Shot 2021-09-22 at 4 19 04 PM](https://user-images.githubusercontent.com/8056203/134361710-54e2a476-61f1-42cc-8f86-b446488a19d6.png)

# Testing

- Run `yarn workspace @crowdsignal/dashboard start`.
- Check if the toolbar appears on the block instead of the editor toolbar as expected.