### PR TITLE
Remove left shadow used for hover/active block

### DIFF
--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -27,11 +27,6 @@
 
 		border: 0;
 		color: var( --color-text );
-
-		.wp-block.is-selected, .wp-block:hover {
-			// the color of the first shadow should be inherited from the theme background (it's only a mask to gain some margin on the block)
-			box-shadow: -10px 0px 0px white, -12px 0px 0px #c8366e;
-		}
 	}
 
 	.edit-post-header__settings > .components-button {


### PR DESCRIPTION
This PR removes the left side shadow for active and hover blocks
