### PR TITLE
WIP: Project renderer app

### DIFF
--- a/apps/dashboard/webpack.config.js
+++ b/apps/dashboard/webpack.config.js
@@ -8,7 +8,7 @@ function getWebpackConfig( env, { entry, ...argv } ) {
 
 	return {
 		...baseConfig,
-		devtool: env === 'production' ? null : 'eval-cheap-module-source-map',
+		devtool: baseConfig.mode === 'production' ? false : 'eval-cheap-module-source-map',
 		output: {
 			...baseConfig.output,
 		},

--- a/apps/project-renderer/babel.config.js
+++ b/apps/project-renderer/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	presets: [
+		'@automattic/calypso-build/babel/wordpress-element',
+		'@automattic/calypso-build/babel/default',
+	],
+	plugins: [
+		'@babel/plugin-transform-runtime',
+		'@wordpress/babel-plugin-import-jsx-pragma',
+	],
+};

--- a/apps/project-renderer/package.json
+++ b/apps/project-renderer/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@crowdsignal/project-renderer",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Crowdsignal project renderer.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "browser": true,
+  "homepage": "https://github.com/Automattic/crowdsignal-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@crowdsignal/blocks": "^0.1.0",
+    "@crowdsignal/components": "^0.1.0",
+    "@wordpress/element": "^4.0.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "webpack-dev-server": "^3.11.2"
+  },
+  "peerDependencies": {
+    "@emotion/styled": "^10.0.27"
+  },
+  "scripts": {
+    "build": "calypso-build ./src/index.js",
+    "start": "webpack serve"
+  }
+}

--- a/apps/project-renderer/public/index.html
+++ b/apps/project-renderer/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Crowdsignal Dashboard</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/main.css" />
+</head>
+
+<body>
+	<div id="crowdsignal-project"></div>
+
+	<script>
+	window.project = {"id":2665644,"name":"Published!","created":1632406952,"title":"Published!","content":{"draft":{"pages":[[{"clientId":"e2fd5ce8-1653-4cc4-abcc-4d88269a93bc","name":"crowdsignal-forms\/multiple-choice","isValid":true,"attributes":{"clientId":"654cf46c-5b98-410f-834b-1490054cc2bc","restrictions":[],"question":"questions","note":"","mandatory":false,"allowOther":false,"choiceType":0,"minimumChoices":0,"maximumChoices":0,"borderRadius":0,"boxShadow":false,"borderWidth":2,"width":100},"innerBlocks":[{"clientId":"7a4cacf6-fbbf-414b-86c8-1bc5bfa74faf","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"224d4431-acee-4e38-b5b9-aa7e41dbb174","label":"1"},"innerBlocks":[],"validationIssues":[],"originalContent":""},{"clientId":"e4b7945e-134e-41e6-8dad-bc44cbdf5527","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"6c7934f4-51b3-4cef-88a4-dd0fa190d25d","label":"2"},"innerBlocks":[],"validationIssues":[],"originalContent":""},{"clientId":"3d89c5b5-941f-43a7-984f-b441d5e39e8c","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"7ec13604-e8bd-4fa1-b456-f3c303208cca","label":null},"innerBlocks":[],"validationIssues":[],"originalContent":""}],"validationIssues":[],"originalContent":""}]]},"published":{"pages":[[{"clientId":"e2fd5ce8-1653-4cc4-abcc-4d88269a93bc","name":"crowdsignal-forms\/multiple-choice","isValid":true,"attributes":{"clientId":"654cf46c-5b98-410f-834b-1490054cc2bc","restrictions":[],"question":"questions","note":"","mandatory":false,"allowOther":false,"choiceType":0,"minimumChoices":0,"maximumChoices":0,"borderRadius":0,"boxShadow":false,"borderWidth":2,"width":100},"innerBlocks":[{"clientId":"7a4cacf6-fbbf-414b-86c8-1bc5bfa74faf","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"224d4431-acee-4e38-b5b9-aa7e41dbb174","label":"1"},"innerBlocks":[],"validationIssues":[],"originalContent":""},{"clientId":"e4b7945e-134e-41e6-8dad-bc44cbdf5527","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"6c7934f4-51b3-4cef-88a4-dd0fa190d25d","label":"2"},"innerBlocks":[],"validationIssues":[],"originalContent":""},{"clientId":"3d89c5b5-941f-43a7-984f-b441d5e39e8c","name":"crowdsignal-forms\/poll-answer","isValid":true,"attributes":{"clientId":"7ec13604-e8bd-4fa1-b456-f3c303208cca","label":null},"innerBlocks":[],"validationIssues":[],"originalContent":""}],"validationIssues":[],"originalContent":""}]]}},"status":0,"closeDate":1632406952,"slug":"published","permalink":"https:\/\/cgastrell.survey.fm\/published","styleId":150,"folderId":30956410,"packId":0,"restrictResponses":true,"restrictQuota":false,"restrictCaptcha":false,"restrictPassword":false,"restrictIp":false,"restrictEmail":false,"header":"","footer":"","responseTimeout":24,"published":false};
+	</script>
+	<script src="https://app.crowdsignal.com/js/react/react.development.js"></script>
+	<script src="https://app.crowdsignal.com/js/react/react-dom.development.js"></script>
+	<script src="/main.js"></script>
+</body>
+</html>

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import FormPreview from '../form-preview';
+
+const App = ( { project } ) => {
+	const content = project.content.published.pages[ 0 ];
+	return (
+		<div className="app">
+			<FormPreview content={ content } />
+		</div>
+	);
+};
+
+export default App;

--- a/apps/project-renderer/src/components/form-preview/index.js
+++ b/apps/project-renderer/src/components/form-preview/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FreeText,
+	MultipleChoice,
+	Poll,
+	PollAnswer,
+	renderBlocks,
+} from '@crowdsignal/blocks';
+
+const ContentWrapper = styled.div`
+	margin: 0 auto;
+	max-width: 720px;
+	padding: 20px;
+`;
+
+const FormPreview = ( { content } ) => {
+	if ( ! content ) {
+		return null;
+	}
+
+	return (
+		<ContentWrapper>
+			{ renderBlocks( content, {
+				'crowdsignal-forms/poll': Poll,
+				'crowdsignal-forms/poll-answer': PollAnswer,
+				'crowdsignal-forms/free-text': FreeText,
+				'crowdsignal-forms/multiple-choice': MultipleChoice,
+			} ) }
+		</ContentWrapper>
+	);
+};
+
+export default FormPreview;

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { StyleProvider } from '@crowdsignal/components';
+import App from './components/app';
+
+const renderProject = () =>
+	render(
+		<StyleProvider reset>
+			<App project={ window.project } />
+		</StyleProvider>,
+		document.getElementById( 'crowdsignal-project' )
+	);
+
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'load', renderProject );

--- a/apps/project-renderer/webpack.config.js
+++ b/apps/project-renderer/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const package = require( './package.json' );
+const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
+
+function getWebpackConfig( env, { entry, ...argv } ) {
+	const baseConfig = getBaseConfig( env, argv );
+
+	return {
+		...baseConfig,
+		devtool: env === 'production' ? null : 'eval-cheap-module-source-map',
+		output: {
+			...baseConfig.output,
+		},
+		externals: {
+			react: 'React',
+			'react-dom': 'ReactDOM',
+		},
+		plugins: [
+			...baseConfig.plugins.map( ( plugin ) => {
+				if ( plugin.constructor.name !== 'DefinePlugin' ) {
+					return plugin;
+				}
+
+				return new webpack.DefinePlugin( {
+					...plugin.definitions,
+					'process.env.GUTENBERG_PHASE': JSON.stringify(
+						parseInt(
+							process.env.npm_package_config_GUTENBERG_PHASE,
+							10
+						) || 1
+					),
+					'process.env.COMPONENT_SYSTEM_PHASE': JSON.stringify( 1 ),
+				} );
+			} ),
+		],
+		devServer: {
+			contentBase: [
+				path.join(__dirname, 'dist'),
+				path.join(__dirname, 'public'),
+			],
+			compress: true,
+			host: 'crowdsignal.localhost',
+			https: true,
+			port: 9000,
+			historyApiFallback: true,
+		},
+	};
+}
+
+module.exports = getWebpackConfig;

--- a/apps/project-renderer/webpack.config.js
+++ b/apps/project-renderer/webpack.config.js
@@ -8,7 +8,7 @@ function getWebpackConfig( env, { entry, ...argv } ) {
 
 	return {
 		...baseConfig,
-		devtool: env === 'production' ? null : 'eval-cheap-module-source-map',
+		devtool: baseConfig.mode === 'production' ? false : 'eval-cheap-module-source-map',
 		output: {
 			...baseConfig.output,
 		},


### PR DESCRIPTION
This PR adds the simplest app to render a dumped project (`window.project`) with the FormPreview component.

A diff companion, not ready yet, lives at D67696-code but we still need to come up with an automated way of building these apps and make them available to consume from the platform.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/project-renderer start`, visit https://crowdsignal.localhost:9000 to see a mocked up project. No styles are included.