### PR TITLE
Implement form state

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -22,6 +22,7 @@
     "@crowdsignal/block-editor": "^0.1.0",
     "@crowdsignal/blocks": "^0.1.0",
     "@crowdsignal/components": "^0.1.0",
+    "@crowdsignal/form": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
     "@wordpress/blocks": "^11.0.0",

--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -8,12 +8,15 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import {
+	Answer,
 	FreeText,
 	MultipleChoice,
 	Poll,
 	PollAnswer,
+	SubmitButton,
 	renderBlocks,
 } from '@crowdsignal/blocks';
+import { Form } from '@crowdsignal/form';
 import { STORE_NAME } from '../../data';
 
 const ContentWrapper = styled.div`
@@ -33,12 +36,16 @@ const FormPreview = ( { projectId } ) => {
 
 	return (
 		<ContentWrapper>
-			{ renderBlocks( project.content.draft.pages[ 0 ], {
-				'crowdsignal-forms/poll': Poll,
-				'crowdsignal-forms/poll-answer': PollAnswer,
-				'crowdsignal-forms/free-text': FreeText,
-				'crowdsignal-forms/multiple-choice': MultipleChoice,
-			} ) }
+			<Form name={ `f-${ projectId }` }>
+				{ renderBlocks( project.content.draft.pages[ 0 ], {
+					'crowdsignal-forms/answer': Answer,
+					'crowdsignal-forms/free-text': FreeText,
+					'crowdsignal-forms/multiple-choice': MultipleChoice,
+					'crowdsignal-forms/poll': Poll,
+					'crowdsignal-forms/poll-answer': PollAnswer,
+					'crowdsignal-forms/submit-button': SubmitButton,
+				} ) }
+			</Form>
 		</ContentWrapper>
 	);
 };

--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -34,9 +34,12 @@ const FormPreview = ( { projectId } ) => {
 		return null;
 	}
 
+	// eslint-disable-next-line no-console
+	const handleSubmit = ( data ) => console.log( data );
+
 	return (
 		<ContentWrapper>
-			<Form name={ `f-${ projectId }` }>
+			<Form name={ `f-${ projectId }` } onSubmit={ handleSubmit }>
 				{ renderBlocks( project.content.draft.pages[ 0 ], {
 					'crowdsignal-forms/answer': Answer,
 					'crowdsignal-forms/free-text': FreeText,

--- a/packages/block-editor/src/answer/attributes.js
+++ b/packages/block-editor/src/answer/attributes.js
@@ -1,0 +1,23 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	label: {
+		type: 'string',
+		default: null,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+	},
+};

--- a/packages/block-editor/src/answer/edit.js
+++ b/packages/block-editor/src/answer/edit.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@crowdsignal/blocks';
+import { useClientId } from '@crowdsignal/hooks';
+import Sidebar from './sidebar';
+
+const EditAnswer = ( props ) => {
+	const { attributes, className, onReplace, setAttributes } = props;
+
+	useClientId( { attributes, setAttributes } );
+
+	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	const handleSplit = ( label ) =>
+		createBlock( 'crowdsignal-forms/answer', {
+			...attributes,
+			clientId:
+				label && attributes.label.indexOf( label ) === 0
+					? attributes.clientId
+					: undefined,
+			label,
+		} );
+
+	const width = attributes.width ? `${ attributes.width }%` : null;
+
+	return (
+		<>
+			<Sidebar { ...props } />
+
+			<Button
+				attributes={ attributes }
+				as={ RichText }
+				className={ className }
+				style={ {
+					width,
+				} }
+				placeholder={ __( 'Enter an answer', 'blocks' ) }
+				multiline={ false }
+				preserveWhiteSpace={ false }
+				onChange={ handleChangeLabel }
+				onReplace={ onReplace }
+				onSplit={ handleSplit }
+				value={ attributes.label }
+				allowedFormats={ [] }
+				withoutInteractiveFormatting
+			/>
+		</>
+	);
+};
+
+export default EditAnswer;

--- a/packages/block-editor/src/answer/index.js
+++ b/packages/block-editor/src/answer/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import EditAnswer from './edit';
+
+const name = 'crowdsignal-forms/answer';
+
+const settings = {
+	title: __( 'Answer', 'blocks' ),
+	description: __( 'Add more answer options to your question', 'blocks' ),
+	category: 'crowdsignal-forms',
+	parent: [ 'crowdsignal-forms/multiple-choice' ],
+	edit: EditAnswer,
+	attributes,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/packages/block-editor/src/answer/sidebar.js
+++ b/packages/block-editor/src/answer/sidebar.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
+import {
+	ContrastChecker,
+	InspectorControls,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	const handleChangeWidth = ( value ) =>
+		setAttributes( {
+			width: attributes.width === value ? undefined : value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelColorGradientSettings
+				title={ __( 'Color', 'blocks' ) }
+				disableCustomGradients={ false }
+				settings={ [
+					{
+						label: __( 'Text color', 'blocks' ),
+						colorValue: attributes.textColor,
+						onColorChange: handleChangeAttribute( 'textColor' ),
+					},
+					{
+						label: __( 'Background color', 'blocks' ),
+						colorValue: attributes.backgroundColor,
+						gradientValue: attributes.gradient,
+						onColorChange: handleChangeAttribute(
+							'backgroundColor'
+						),
+						onGradientChange: handleChangeAttribute( 'gradient' ),
+					},
+				] }
+			>
+				<ContrastChecker
+					backgroundColor={ attributes.backgroundColor }
+					color={ attributes.textColor }
+				/>
+			</PanelColorGradientSettings>
+
+			<PanelBody title={ __( 'Width settings', 'blocks' ) }>
+				<ButtonGroup aria-label={ __( 'Button width' ) }>
+					{ [ 25, 50, 75, 100 ].map( ( width ) => (
+						<Button
+							isSmall
+							key={ width }
+							variant={
+								width === attributes.width
+									? 'primary'
+									: undefined
+							}
+							onClick={ () => handleChangeWidth( width ) }
+						>
+							{ width }%
+						</Button>
+					) ) }
+				</ButtonGroup>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,4 +1,6 @@
-export { default as pollBlock } from './poll';
-export { default as pollAnswerBlock } from './poll-answer';
+export { default as answerBlock } from './answer';
 export { default as freeTextQuestionBlock } from './free-text';
 export { default as multipleChoiceQuestionBlock } from './multiple-choice';
+export { default as pollBlock } from './poll';
+export { default as pollAnswerBlock } from './poll-answer';
+export { default as submitButtonBlock } from './submit-button';

--- a/packages/block-editor/src/multiple-choice/edit.js
+++ b/packages/block-editor/src/multiple-choice/edit.js
@@ -17,7 +17,7 @@ import { MultipleChoiceWrapper } from './styles/multiple-choice';
 const ALLOWED_ANSWER_BLOCKS = [
 	'core/image',
 	'core/paragraph',
-	'crowdsignal-forms/poll-answer',
+	'crowdsignal-forms/answer',
 ];
 
 const MultipleChoice = ( props ) => {
@@ -45,9 +45,9 @@ const MultipleChoice = ( props ) => {
 			/>
 			<InnerBlocks
 				template={ [
-					[ 'crowdsignal-forms/poll-answer', {} ],
-					[ 'crowdsignal-forms/poll-answer', {} ],
-					[ 'crowdsignal-forms/poll-answer', {} ],
+					[ 'crowdsignal-forms/answer', {} ],
+					[ 'crowdsignal-forms/answer', {} ],
+					[ 'crowdsignal-forms/answer', {} ],
 				] }
 				templateLock={ false }
 				allowedBlocks={ ALLOWED_ANSWER_BLOCKS }

--- a/packages/block-editor/src/submit-button/attributes.js
+++ b/packages/block-editor/src/submit-button/attributes.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	label: {
+		type: 'string',
+		default: __( 'Submit', 'block-editor' ),
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+};

--- a/packages/block-editor/src/submit-button/edit.js
+++ b/packages/block-editor/src/submit-button/edit.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@crowdsignal/blocks';
+import Sidebar from './sidebar';
+
+const SubmitButton = ( props ) => {
+	const { attributes, className, onReplace, setAttributes } = props;
+
+	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	return (
+		<>
+			<Sidebar { ...props } />
+
+			<Button
+				attributes={ attributes }
+				as={ RichText }
+				className={ className }
+				placeholder={ __( 'Submit', 'blocks' ) }
+				multiline={ false }
+				preserveWhiteSpace={ false }
+				onChange={ handleChangeLabel }
+				onReplace={ onReplace }
+				value={ attributes.label }
+				allowedFormats={ [] }
+				withoutInteractiveFormatting
+			/>
+		</>
+	);
+};
+
+export default SubmitButton;

--- a/packages/block-editor/src/submit-button/index.js
+++ b/packages/block-editor/src/submit-button/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import EditSubmitButton from './edit';
+
+const name = 'crowdsignal-forms/submit-button';
+
+const settings = {
+	title: __( 'Submit Button', 'blocks' ),
+	description: __( 'Submit the form', 'blocks' ),
+	category: 'crowdsignal-forms',
+	edit: EditSubmitButton,
+	attributes,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/packages/block-editor/src/submit-button/sidebar.js
+++ b/packages/block-editor/src/submit-button/sidebar.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import {
+	ContrastChecker,
+	InspectorControls,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelColorGradientSettings
+				title={ __( 'Color', 'blocks' ) }
+				disableCustomGradients={ false }
+				settings={ [
+					{
+						label: __( 'Text color', 'blocks' ),
+						colorValue: attributes.textColor,
+						onColorChange: handleChangeAttribute( 'textColor' ),
+					},
+					{
+						label: __( 'Background color', 'blocks' ),
+						colorValue: attributes.backgroundColor,
+						gradientValue: attributes.gradient,
+						onColorChange: handleChangeAttribute(
+							'backgroundColor'
+						),
+						onGradientChange: handleChangeAttribute( 'gradient' ),
+					},
+				] }
+			>
+				<ContrastChecker
+					backgroundColor={ attributes.backgroundColor }
+					color={ attributes.textColor }
+				/>
+			</PanelColorGradientSettings>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -17,6 +17,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
+    "@crowdsignal/form": "^0.1.0",
     "@crowdsignal/styles": "^0.1.0",
     "@wordpress/block-editor": "^7.0.0",
     "@wordpress/element": "^4.0.0",

--- a/packages/blocks/src/answer/index.js
+++ b/packages/blocks/src/answer/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { useField } from '@crowdsignal/form';
+import { Button } from '../components';
+
+const Input = styled.input`
+	height: 1px;
+	position: absolute;
+	top: -20px;
+	width: 1px;
+`;
+
+const Answer = ( { attributes, className } ) => {
+	const width = attributes.width ? `${ attributes.width }%` : null;
+
+	const { inputProps } = useField( {
+		name: `q_${ 'test' }[choice]`,
+		type: 'checkbox',
+		value: attributes.clientId,
+	} );
+
+	const classes = classnames( className, {
+		'is-selected': inputProps.checked,
+	} );
+
+	return (
+		<Button
+			as="label"
+			attributes={ attributes }
+			className={ classes }
+			style={ {
+				width,
+			} }
+		>
+			{ attributes.label }
+
+			<Input { ...inputProps } />
+		</Button>
+	);
+};
+
+export default Answer;

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -9,9 +9,17 @@ import classnames from 'classnames';
  */
 import { useColorStyles } from '@crowdsignal/styles';
 
+const StyledButtonWrapper = styled.div`
+	&.is-selected {
+		filter: invert( 1 );
+	}
+`;
+
 const StyledButton = styled.button`
 	border: 0;
 	cursor: pointer;
+	overflow: hidden;
+	position: relative;
 
 	&.rich-text {
 		cursor: text;
@@ -25,7 +33,9 @@ const Button = ( {
 	style = {},
 	...props
 } ) => (
-	<div className={ classnames( className, 'wp-block-button' ) }>
+	<StyledButtonWrapper
+		className={ classnames( className, 'wp-block-button' ) }
+	>
 		<StyledButton
 			className="wp-block-button__link"
 			style={ {
@@ -36,7 +46,7 @@ const Button = ( {
 		>
 			{ children }
 		</StyledButton>
-	</div>
+	</StyledButtonWrapper>
 );
 
 export default Button;

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -1,0 +1,9 @@
+const FormTextInput = ( { className, ...props } ) => {
+	return (
+		<div className={ className }>
+			<input type="text" { ...props } />
+		</div>
+	);
+};
+
+export default FormTextInput;

--- a/packages/blocks/src/components/form-textarea/index.js
+++ b/packages/blocks/src/components/form-textarea/index.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+const FormTextarea = styled.textarea`
+	border-style: solid;
+	box-sizing: border-box;
+	width: 100%;
+`;
+
+export default FormTextarea;

--- a/packages/blocks/src/components/index.js
+++ b/packages/blocks/src/components/index.js
@@ -1,2 +1,3 @@
 export { default as Button } from './button';
+export { default as FormTextarea } from './form-textarea';
 export { default as QuestionWrapper } from './question-wrapper';

--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -6,14 +6,19 @@ import { RichText } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { QuestionWrapper } from '../components';
+import { useField } from '@crowdsignal/form';
+import { FormTextarea, QuestionWrapper } from '../components';
 
 const FreeText = ( { attributes, className } ) => {
+	const { inputProps } = useField( {
+		name: `q_${ attributes.id }`,
+	} );
+
 	return (
 		<QuestionWrapper attributes={ attributes } className={ className }>
 			<RichText.Content tagName="h3" value={ attributes.question } />
 
-			<textarea rows={ 6 } />
+			<FormTextarea { ...inputProps } rows={ 6 } />
 		</QuestionWrapper>
 	);
 };

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,8 +1,10 @@
 export * from './components';
 
+export { default as Answer } from './answer';
 export { default as FreeText } from './free-text';
 export { default as MultipleChoice } from './multiple-choice';
 export { default as Poll } from './poll';
 export { default as PollAnswer } from './poll-answer';
+export { default as SubmitButton } from './submit-button';
 
 export { renderBlocks } from './render-blocks';

--- a/packages/blocks/src/poll/index.js
+++ b/packages/blocks/src/poll/index.js
@@ -15,7 +15,6 @@ const Poll = ( { attributes, className, children } ) => {
 	return (
 		<QuestionWrapper
 			attributes={ attributes }
-			as={ 'form' }
 			className={ className }
 			style={ { width } }
 		>

--- a/packages/blocks/src/submit-button/index.js
+++ b/packages/blocks/src/submit-button/index.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { Button } from '../components';
+
+const SubmitButton = ( { attributes, className } ) => {
+	return (
+		<Button attributes={ attributes } className={ className } type="submit">
+			{ attributes.label }
+		</Button>
+	);
+};
+
+export default SubmitButton;

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,0 +1,46 @@
+# @crowdsignal/form
+
+Form handling library loosely based on [React Final Form](https://github.com/final-form/react-final-form), powered by [@wordpress/data]https://github.com/WordPress/gutenberg/tree/trunk/packages/data).
+
+### Form
+
+The form wrapper component to trigger the library for your form.
+
+```javascript
+import { Form } from '@crowdsignal/form';
+
+const MyForm = () => {
+	const handleSubmit = ( data ) => {
+		// Add code to subbmit form data here
+	};
+
+	return (
+		<Form name="my-form" onSubmit={ handleSubmit }>
+
+			// Form contents
+			...
+		</Form>
+	);
+};
+```
+
+### useField
+
+`useField` hook can be used to link traditional inputs into the `@wordpress/data` form state.
+
+```javascript
+import { useField } from '@crowdsignal/form';
+
+const TextInput = () => {
+	const { error, inputProps } = useField( {
+		name: 'example',
+	} );
+
+	return (
+		<div className="text-input">
+			<input className="text-input__input" { ...inputProps } />
+			{ error && ( <span className="text-input__error">{ error }</span> ) }
+		</div>
+	);
+};
+```

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@crowdsignal/form",
+  "version": "0.1.0",
+  "description": "Form handling powered by @wordpress/data.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal",
+    "form"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/form/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@wordpress/data": "^6.0.0",
+    "@wordpress/element": "^4.0.0",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/form/src/components/form/index.js
+++ b/packages/form/src/components/form/index.js
@@ -12,7 +12,7 @@ import { STORE_NAME } from '../../data';
 const Context = createContext( 'form' );
 
 const Form = ( { children, name, onSubmit, ...props } ) => {
-	const { data } = useSelect(
+	const data = useSelect(
 		( select ) => select( STORE_NAME ).getFormData( name ),
 		[ name ]
 	);

--- a/packages/form/src/components/form/index.js
+++ b/packages/form/src/components/form/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../../data';
+
+const Context = createContext( 'form' );
+
+const Form = ( { children, name, onSubmit, ...props } ) => {
+	const { data } = useSelect(
+		( select ) => select( STORE_NAME ).getFormData( name ),
+		[ name ]
+	);
+
+	const handleSubmit = ( event ) => {
+		event.preventDefault();
+
+		onSubmit( data );
+	};
+
+	return (
+		<Context.Provider value={ name }>
+			<form onSubmit={ handleSubmit } { ...props }>
+				{ children }
+			</form>
+		</Context.Provider>
+	);
+};
+
+Form.Context = Context;
+
+export default Form;

--- a/packages/form/src/components/index.js
+++ b/packages/form/src/components/index.js
@@ -1,0 +1,1 @@
+export { default as Form } from './form';

--- a/packages/form/src/data/action-types.js
+++ b/packages/form/src/data/action-types.js
@@ -1,0 +1,14 @@
+/**
+ * Any new action type should be added to the set of exports below, with the
+ * value mirroring its exported name.
+ *
+ * Please keep this list alphabetized!
+ *
+ * Unsure how to name an action type?
+ * Start by naming the resoure the action affects followed by the intent.
+ */
+
+export const FIELD_VALUE_SET = 'FIELD_VALUE_SET';
+export const FORM_INIT = 'FORM_INIT';
+export const FORM_SUBMIT_START = 'FORM_SUBMIT_START';
+export const FORM_SUBMIT_STOP = 'FORM_SUBMIT_STOP';

--- a/packages/form/src/data/actions.js
+++ b/packages/form/src/data/actions.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { FIELD_VALUE_SET } from './action-types';
+
+export const setFieldValue = ( form, field, value ) => ( {
+	type: FIELD_VALUE_SET,
+	form,
+	field,
+	value,
+} );

--- a/packages/form/src/data/index.js
+++ b/packages/form/src/data/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import * as actions from './actions';
+import reducer from './reducer';
+import * as selectors from './selectors';
+
+export const STORE_NAME = 'crowdsignal/form';
+
+const config = {
+	actions,
+	reducer,
+	selectors,
+};
+
+export const store = createReduxStore( STORE_NAME, config );
+
+register( store );

--- a/packages/form/src/data/reducer.js
+++ b/packages/form/src/data/reducer.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FIELD_VALUE_SET,
+	FORM_INIT,
+	FORM_SUBMIT_START,
+	FORM_SUBMIT_STOP,
+} from './action-types';
+import { keyedReducer } from './util';
+
+const error = ( state = {}, action ) => {
+	if ( action.type === FORM_INIT ) {
+		return {};
+	}
+
+	if ( action.type === FIELD_VALUE_SET ) {
+		return {
+			...state,
+			[ action.field ]: null,
+		};
+	}
+
+	return state;
+};
+
+const submitting = ( state = false, action ) => {
+	if ( action.type === FORM_SUBMIT_START ) {
+		return true;
+	}
+
+	if ( action.type === FORM_SUBMIT_STOP ) {
+		return false;
+	}
+
+	return state;
+};
+
+const value = ( state, action ) => {
+	if ( action.type === FORM_INIT ) {
+		return action.values;
+	}
+
+	if ( action.type === FIELD_VALUE_SET ) {
+		return {
+			...state,
+			[ action.field ]: action.value,
+		};
+	}
+
+	return state;
+};
+
+export default combineReducers( {
+	error: keyedReducer( 'form', error ),
+	submitting: keyedReducer( 'form', submitting ),
+	value: keyedReducer( 'form', value ),
+} );

--- a/packages/form/src/data/selectors.js
+++ b/packages/form/src/data/selectors.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export const getFieldError = ( state, form, field ) =>
+	get( state, [ 'error', form, field ] );
+
+export const getFieldValue = ( state, form, field ) =>
+	get( state, [ 'value', form, field ] );
+
+export const getFieldData = ( state, form, field ) => ( {
+	error: getFieldError( state, form, field ),
+	value: getFieldValue( state, form, field ),
+} );
+
+export const getFormData = ( state, form ) =>
+	get( state, [ 'value', form ], null );
+
+export const isSubmitting = ( state, form ) =>
+	get( state, [ 'submitting', form ], false );

--- a/packages/form/src/data/util.js
+++ b/packages/form/src/data/util.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { get, isEqual, omit } from 'lodash';
+
+/**
+ * Creates a super-reducer as a map of reducers over keyed objects
+ *
+ * @param  {string}   keyPath Lodash-style path to the key in action referencing item in state map
+ * @param  {Function} reducer Reducer applied to every item in the state map
+ * @return {Function}         Super-reducer applying reducer over a map of keyed items
+ */
+export const keyedReducer = ( keyPath, reducer ) => {
+	const initialState = reducer( undefined, {} );
+
+	return ( state = {}, action ) => {
+		const itemKey = get( action, keyPath, undefined );
+
+		if ( itemKey === null || itemKey === undefined ) {
+			return state;
+		}
+
+		const newItemState = reducer( state[ itemKey ], action );
+
+		// If new state equals old state do nothing
+		if ( newItemState === state[ itemKey ] ) {
+			return state;
+		}
+
+		// Remove the key when new state is undefined or equals initial state
+		if (
+			newItemState === undefined ||
+			isEqual( newItemState, initialState )
+		) {
+			return state.hasOwnProperty( itemKey )
+				? omit( state, itemKey )
+				: state;
+		}
+
+		return {
+			...state,
+			[ itemKey ]: newItemState,
+		};
+	};
+};

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { useContext } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { filter, includes, uniq } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Form } from '../components';
+import { STORE_NAME } from '../data';
+
+export const useField = ( { name: fieldName, type, value } ) => {
+	const form = useContext( Form.Context );
+
+	const { setFieldValue } = useDispatch( STORE_NAME );
+
+	const { error, value: currentValue } = useSelect(
+		( select ) => select( STORE_NAME ).getFieldData( form, fieldName ),
+		[ form, fieldName ]
+	);
+
+	const onChange = ( event ) => {
+		if ( type === 'checkbox' ) {
+			setFieldValue(
+				form,
+				fieldName,
+				event.target.checked
+					? uniq( [ ...( currentValue || [] ), event.target.value ] )
+					: filter(
+							currentValue || [],
+							( v ) => v !== event.target.value
+					  )
+			);
+			return;
+		}
+
+		setFieldValue( form, fieldName, event.target.value );
+	};
+
+	const inputProps = {
+		name: fieldName,
+		onChange,
+		value: type === 'checkbox' || type === 'radio' ? value : currentValue,
+	};
+
+	if ( type === 'checkbox' ) {
+		inputProps.checked = includes( currentValue, value );
+		inputProps.type = type;
+	}
+
+	if ( type === 'radio' ) {
+		inputProps.checked = currentValue === value;
+		inputProps.type = type;
+	}
+
+	return {
+		error,
+		inputProps,
+	};
+};

--- a/packages/form/src/index.js
+++ b/packages/form/src/index.js
@@ -1,0 +1,3 @@
+export * from './components';
+
+export * from './hooks/use-field';


### PR DESCRIPTION
This patch adds a new `@crowdsignal/form` package which role is to manage form state when Crowdsignal projects get rendered.

The way it works is the entire form is wrapped with a single `<Form>` component, and any child components can then use `useField` hook to link up to the state.  
The package uses it's own, separate `@wordpress/data` store called `crowdsignal/form` and the form's `name` property is used to store the data separately for each `<Form>` instance.

Due to how the submit mechanics work right now, `<Form>` needs to be an actual `<form>` element but even that could be adapted if necessary - for example should we find ourselves in a scenario where we need to deal with some kind of nested forms.

Other minor changes include:

- I added a `Submit` block which is currently just a button and needs to be added somewhere on the page in order to be able to submit the form.
- I added dedicated `Answer` blocks for `MultipleChoiceQuestionBlock` to replace `PollAnswer` and implemented the correct form mechanics there. (**multi-select buttons work now**)
- I added simple `FormTextInput` and `FormTextarea` components which don't contain too much styling yet but are supposed to be used with the blocks like `FreeText` instead of their `@wordpress/components` or `@crowdsignal/components` counterparts.
- I hooked up `FormTextarea` to the `FreeText` block and linked it up with the form state as well.

# Testing

- Go to `/project` and start a new project.
- Make sure to add free text and multiple choice questions with some answers.
- Add a submit button block.
- Proceed to `/project/{projectId}/preview` using the ID of the project you just created.
- The page should render correctly.
- You should be able to select/deselect MultipleChoice answers - they should change color when you do.
- Hit submit, the current form state will be printed to the console.