### PR TITLE
Add toolbar buttons handler/link

### DIFF
--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -42,12 +42,48 @@ const Toolbar = ( { projectId } ) => {
 			...payload,
 		} );
 	};
+
+	const shareHandler = () => {
+		if ( project.permalink ) {
+			window.navigator.clipboard.writeText( project.permalink ).then(
+				() => {
+					// eslint-disable-next-line
+					window.alert(
+						`Project's public URL ( ${ project.permalink } ) has been copied to clipboard`
+					);
+				},
+				( err ) => {
+					// eslint-disable-next-line
+					window.alert( 'Share URL could not be copied to clipboard' );
+					// eslint-disable-next-line
+					console.error( err );
+				}
+			);
+		} else {
+			// eslint-disable-next-line
+			window.alert( 'Share URL will is only available for published projects' );
+		}
+		return false;
+	};
+
+	const isPublished = project && project.content && project.content.published;
+
 	return (
 		<ToolbarSlot className="block-editor__crowdsignal-toolbar">
-			<Button className="is-crowdsignal">
+			<Button
+				className="is-crowdsignal"
+				href={ `/project/${ projectId }/preview` }
+				target="_blank"
+				disabled={ ! projectId }
+			>
 				{ __( 'Preview', 'block-editor' ) }
 			</Button>
-			<Button className="is-crowdsignal" variant="secondary">
+			<Button
+				className="is-crowdsignal"
+				variant="secondary"
+				onClick={ shareHandler }
+				disabled={ ! isPublished }
+			>
 				{ __( 'Share', 'block-editor' ) }
 			</Button>
 			<Button


### PR DESCRIPTION
This PR implements 2 simple handlers for our current toolbar so to add functionality on preview and share

* Add a simple link for preview button
* Add a copy-to-clipboard handler for Share button

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`, visit http://crowdsignal.localhost:9000/project

See that, initially, Preview and Share buttons are disabled

  - [ ] make some changes so the autosave function triggers (or hit "Save draft"): "Preview" button should enable
  - [ ] hit "Publish": "Share" button should enable
  - [ ] hit "Share" button: you should get an `alert` modal stating that the URL has been copied to clipboard
  - [ ] confirm the copied URL corresponds to the project