### PR TITLE
Add MC context provider

### DIFF
--- a/packages/block-editor/src/free-text/edit.js
+++ b/packages/block-editor/src/free-text/edit.js
@@ -22,7 +22,7 @@ const FreeText = ( props ) => {
 	return (
 		<>
 			<RichText
-				tagName="h3"
+				tagName="p"
 				placeholder={ __( 'Enter your question', 'blocks' ) }
 				onChange={ handleChangeQuestion }
 				value={ attributes.question }

--- a/packages/blocks/src/answer/index.js
+++ b/packages/blocks/src/answer/index.js
@@ -3,12 +3,14 @@
  */
 import classnames from 'classnames';
 import styled from '@emotion/styled';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useField } from '@crowdsignal/form';
 import { Button } from '../components';
+import MultipleChoice from '../multiple-choice';
 
 const Input = styled.input`
 	height: 1px;
@@ -20,8 +22,14 @@ const Input = styled.input`
 const Answer = ( { attributes, className } ) => {
 	const width = attributes.width ? `${ attributes.width }%` : null;
 
+	const parentQuestion = useContext( MultipleChoice.Context );
+
+	// REVIEWER NOTE: choiceType value is assigned from ChoiceType constant under block-editor/multiple-choice/constants,
+	// being 0 = ChoiceType.SINGLE. Hardcoded here as I'm not sure how to import such constant values from the block-editor package.
 	const { inputProps } = useField( {
-		name: `q_${ 'test' }[choice]`,
+		name: `q_${ parentQuestion.clientId }[choice]${
+			parentQuestion.choiceType !== 0 ? '[]' : ''
+		}`,
 		type: 'checkbox',
 		value: attributes.clientId,
 	} );

--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -11,7 +11,7 @@ import { FormTextarea, QuestionWrapper } from '../components';
 
 const FreeText = ( { attributes, className } ) => {
 	const { inputProps } = useField( {
-		name: `q_${ attributes.id }`,
+		name: `q_${ attributes.clientId }`,
 	} );
 
 	return (

--- a/packages/blocks/src/multiple-choice/index.js
+++ b/packages/blocks/src/multiple-choice/index.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { createContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { QuestionWrapper } from '../components';
+
+const Context = createContext( 'multiple-choice' );
 
 const MultipleChoice = ( { attributes, children, className } ) => {
 	return (
@@ -14,9 +17,13 @@ const MultipleChoice = ( { attributes, children, className } ) => {
 			<RichText.Content tagName="h3" value={ attributes.question } />
 			<RichText.Content value={ attributes.note } />
 
-			<QuestionWrapper.Content>{ children }</QuestionWrapper.Content>
+			<Context.Provider value={ attributes }>
+				<QuestionWrapper.Content>{ children }</QuestionWrapper.Content>
+			</Context.Provider>
 		</QuestionWrapper>
 	);
 };
+
+MultipleChoice.Context = Context;
 
 export default MultipleChoice;


### PR DESCRIPTION
This PR wraps MC question block's children in a Context.Provider. The provided value is the attributes from the MC question block.

When the MC allows for multiple selections (not implemented yet) the input naming differs as they are provided in the old PHP form array syntax: `name=input-name[choice][]`. To this end we'll use the MC attributes to determine how the inputs should be named and it would be better to rely on our constants. I left a note to change the (now hardcoded as `0`)  *multiple selection setup* check.

## Test instructions
The changes are not UI noticeable, but the payload printed on the console should look different.

* Checkout and run `yarn workspace @crowdsignal/dashboard start`
* Create/edit a project with a Free Text, an MC and a Submit block
* Publish it and preview it by heading to http://crowdsignal.localhost:9000/project/[ID]/preview (or use the "Preview" button if #55 is already merged)
* Fill and submit

The console should print the values of your answers as an object which keys are strings `q_ + clientId hashed string`.
Each entry on the object would be a key/value pair, FreeText will show your answer as text value while MC will show the clientId of the selected answer.

NOTE: MC response would be an array of selected Answers' clientId hashes once the multiple selection is enabled. 

Something like this:

```
{
    "q_04dc0f6a-245c-4434-af51-83bc3a6f909d[choice]": "03f6ee14-e3b6-4fc4-a28d-51fbda620ee0",
    "q_c5007c0b-a6a4-42e4-bbdc-f1d1c96085df": "free text response"
}
```

@ice9js Let me know if this should be approached differently, for now I just need this to work on the submit payload/process.