### PR TITLE
Make the content area of the editor scrollable

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -38,6 +38,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.1.1",
     "@emotion/styled": "^10.0.27"
   },
   "scripts": {

--- a/apps/dashboard/src/components/app/index.js
+++ b/apps/dashboard/src/components/app/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Global } from '@emotion/core';
+
+/**
  * Internal dependencies
  */
 import { Route, Router, Switch } from '@crowdsignal/router';
@@ -7,36 +12,45 @@ import Editor from '../editor';
 import FormPreview from '../form-preview';
 import Results from '../results';
 
+/**
+ * Style dependencies
+ */
+import { Column, pageStyles } from './styles';
+
 const allowedRoutes = /^\/(project)\/.*/i;
 
 const NotFound = () => <div className="app__not-found">404</div>;
 
 const App = () => {
 	return (
-		<Router allowedRoutes={ allowedRoutes }>
-			<div className="app">
-				<Masterbar />
+		<>
+			<Global styles={ pageStyles } />
 
-				<main className="app__content">
-					<Switch>
-						<Route
-							path="/project(/:projectId)"
-							component={ Editor }
-						/>
-						<Route
-							path="/project/:projectId/results"
-							component={ Results }
-						/>
-						<Route
-							path="/project/:projectId/preview"
-							component={ FormPreview }
-						/>
+			<Router allowedRoutes={ allowedRoutes }>
+				<Column className="app">
+					<Masterbar />
 
-						<Route path="*any" component={ NotFound } />
-					</Switch>
-				</main>
-			</div>
-		</Router>
+					<Column as="main" className="app__content">
+						<Switch>
+							<Route
+								path="/project(/:projectId)"
+								component={ Editor }
+							/>
+							<Route
+								path="/project/:projectId/results"
+								component={ Results }
+							/>
+							<Route
+								path="/project/:projectId/preview"
+								component={ FormPreview }
+							/>
+
+							<Route path="*any" component={ NotFound } />
+						</Switch>
+					</Column>
+				</Column>
+			</Router>
+		</>
 	);
 };
 

--- a/apps/dashboard/src/components/app/styles.js
+++ b/apps/dashboard/src/components/app/styles.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+export const pageStyles = css`
+	html {
+		display: table;
+		margin: 0;
+		height: 100%;
+		padding: 0;
+		width: 100%;
+	}
+
+	body {
+		display: table-cell;
+		margin: 0;
+		padding: 0;
+		width: 100%;
+	}
+
+	#crowdsignal-dashboard {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		width: 100%;
+	}
+`;
+
+export const Column = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+`;

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -20,6 +20,9 @@
 }
 
 .editor {
+	flex: 1;
+	position: relative;
+
 	.iso-editor {
 		--wp-admin-theme-color: var( --color-neutral-80 );
 		--wp-admin-theme-color-darker-10: var( --color-neutral-90 );
@@ -27,6 +30,28 @@
 
 		border: 0;
 		color: var( --color-text );
+		flex: 1;
+		max-height: 100%;
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		top: 65px;
+
+		> div:nth-child(2) {
+			display: flex;
+			flex-direction: column;
+			max-height: 100%;
+
+			> div:nth-child(4) {
+				overflow-y: scroll;
+			}
+		}
+
+		.edit-post-visual-editor {
+			max-height: 100%;
+			position: relative;
+		}
 	}
 
 	.edit-post-header__settings > .components-button {


### PR DESCRIPTION
This patch updates our page and editor layout so that only the editor content is scrollable whenever the user is on the editor page.

Solves c/U2ostitJ-tr.

# Testing

- Go to `/project` and start a new project.
- Add a few block so they no longer fit on the screen
- The editor content should scroll but the header and editor toolbar should stay in place