### PR TITLE
Make project title editable

### DIFF
--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -22,15 +22,13 @@ const Toolbar = ( { projectId } ) => {
 	} );
 
 	const syncProject = () => {
-		const payload = { title: 'Drafted!' };
 		saveAndUpdateProject( projectId, {
 			...project,
-			...payload,
 		} );
 	};
 
 	const publishProject = () => {
-		const payload = { title: 'Published!', publish: true };
+		const payload = { publish: true };
 		saveAndUpdateProject( projectId, {
 			...project,
 			content: {

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { PageHeader, TabNavigation } from '@crowdsignal/components';
+import { EditablePageHeader, TabNavigation } from '@crowdsignal/components';
+import { STORE_NAME } from '../../data';
 
 /**
  * Style dependencies
@@ -19,9 +21,25 @@ const Tab = {
 };
 
 const ProjectNavigation = ( { activeTab, projectId } ) => {
+	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
+
+	const project = useSelect(
+		( select ) => select( STORE_NAME ).getProject( projectId ),
+		[ projectId ]
+	);
+
+	const updateTitle = ( title ) =>
+		saveAndUpdateProject( projectId, {
+			name: title,
+			title,
+		} );
+
 	return (
 		<div className="project-navigation">
-			<PageHeader>My Great New Poll</PageHeader>
+			<EditablePageHeader
+				onChange={ updateTitle }
+				text={ project.title }
+			/>
 			<TabNavigation>
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.EDITOR }

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -38,7 +38,7 @@ const ProjectNavigation = ( { activeTab, projectId } ) => {
 		<div className="project-navigation">
 			<EditablePageHeader
 				onChange={ updateTitle }
-				text={ project.title }
+				text={ project?.title || __( 'Untitled Project', 'dashboard' ) }
 			/>
 			<TabNavigation>
 				<TabNavigation.Tab


### PR DESCRIPTION
This patch solves c/NXdi1uep-tr and enables editing of the project title.

While working for this I had a few concerns due to how we currently implement the project state:

- As or right now, we have no complete reference for the `project` object anywhere in our codebase which makes it slightly difficult to work with. At least it'd be nice to explicitly list all the properties inside the reducer by using something like `pick` or even implement some proper validation for it.
- Because of how `project` is stored, and especially because of how `saveAndUpdateProject` works, any component that updates any of its properties is now closely coupled to the actual `project` structure. To remedy this we can either update our project state setup and provide more granular control for the saving side-effect, or at the very least, we should provide a set of helper functions for working with a `project` so you'd call stuff like `project = updateProjectTitle( project, title );` instead of modifying it directly.

# Testing

- Go to `/project` and create a project, it'll have `Drafted!` as the default title.
- Click on the title to edit it.
- After making the changes, click anywhere outside of the title to stop editing.
- The changes should be saved immediately afterwards.
- Reload the page and verify the changes have been saved.