### PR TITLE
Make Free text question render its input as an array[text]

### DIFF
--- a/packages/blocks/src/free-text/index.js
+++ b/packages/blocks/src/free-text/index.js
@@ -11,7 +11,7 @@ import { FormTextarea, QuestionWrapper } from '../components';
 
 const FreeText = ( { attributes, className } ) => {
 	const { inputProps } = useField( {
-		name: `q_${ attributes.clientId }`,
+		name: `q_${ attributes.clientId }[text]`,
 	} );
 
 	return (


### PR DESCRIPTION
This PR adds `[text]` to the input name rendered by Free Text block. This is to preserve consistency with our backend works.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/project-renderer start`. Go to http://crowdsignal.localhost:9000/[some-project-slug-here] to see the public render of the project.

Inspect the input for the text input, the name should be `q_[some-uuid-long-string-here][text]`


NOTE: if you don't have a project, you can create one by running `yarn workspace @crowdsignal/dashboard start` and going to http://crowdsignal.localhost:9000/project. Create a Free Text block and Publish the project. You should be able to copy the project slug with the "Share" button.

