### PR TITLE
Add editor sidebars

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -30,6 +30,7 @@ export const editorSettings = {
 		},
 		sidebar: {
 			inserter: true,
+			inspector: true,
 		},
 		toolbar: {
 			documentInspector: __( 'Document', 'dashboard' ),

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -28,6 +28,9 @@ export const editorSettings = {
 		defaultPreferences: {
 			fixedToolbar: false,
 		},
+		sidebar: {
+			inserter: true,
+		},
 		toolbar: {
 			documentInspector: __( 'Document', 'dashboard' ),
 			inspector: true,


### PR DESCRIPTION
This PR enables editor sidebars for the inserter, list view, and block and document settings.  

![crowdsignal localhost_9000_project_2670174 (3)](https://user-images.githubusercontent.com/8056203/137280985-5249ef7c-560e-4fcd-bfbc-38dd550b65f1.png)

Solves c/zJuK6WL8-tr, c/gJKCWpqO-tr and c/mmjwQUjE-tr.
Depends on [Automattic/isolated-block-editor#75](https://github.com/Automattic/isolated-block-editor/pull/75/files).

To do:
- Update isolated-block-editor to the correct version once the above PR gets merged.
- It'd be great if we can manually force the inserter open, and perhaps force it to stay open even when not in focus.

Needs #94 to be merged first.

# Testing

- Go to `/project(/projectId)` to open or start a project
- Clicking on the `+` button in the upper left corner should open the inserter in a sidebar on the left.
- There should be a 'list view' icon (4th from the left). Clicking on it will display the list view of the project in a sidebar on the left.
- There shouldn't be an 'info' icon on the left side of the editor toolbar.
- Clicking the cog icon in the upper right should open the document and block settings in a sidebar on the right.