### PR TITLE
Add a setting for synchronizing attributes between sibling blocks

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -24,6 +24,7 @@
     "@wordpress/block-editor": "^7.0.0",
     "@wordpress/blocks": "^11.0.0",
     "@wordpress/components": "^15.0.0",
+    "@wordpress/compose": "^5.0.0",
     "@wordpress/data": "^6.0.0",
     "@wordpress/element": "^4.0.0",
     "@wordpress/i18n": "^4.2.1",

--- a/packages/block-editor/src/multiple-choice-answer/attributes.js
+++ b/packages/block-editor/src/multiple-choice-answer/attributes.js
@@ -7,6 +7,10 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	shareSiblingAttributes: {
+		type: 'boolean',
+		default: true,
+	},
 	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
 	backgroundColor: {
 		type: 'string',

--- a/packages/block-editor/src/multiple-choice-answer/edit.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -9,6 +10,7 @@ import { createBlock } from '@wordpress/blocks';
 import { MultipleChoiceQuestion, getBlockStyle } from '@crowdsignal/blocks';
 import { useClientId } from '@crowdsignal/hooks';
 import { useParentAttributes } from '../util/use-parent-attributes';
+import { withSharedSiblingAttributes } from '../util/with-shared-sibling-attributes';
 import EditButtonAnswer from './edit-button';
 import EditCheckboxAnswer from './edit-checkbox';
 import Sidebar from './sidebar';
@@ -63,4 +65,11 @@ const EditMultipleChoiceAnswer = ( props ) => {
 	);
 };
 
-export default EditMultipleChoiceAnswer;
+export default compose(
+	withSharedSiblingAttributes( [
+		'backgroundColor',
+		'gradient',
+		'textColor',
+		'width',
+	] )
+)( EditMultipleChoiceAnswer );

--- a/packages/block-editor/src/multiple-choice-answer/sidebar.js
+++ b/packages/block-editor/src/multiple-choice-answer/sidebar.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { Button, ButtonGroup, PanelBody } from '@wordpress/components';
+import {
+	Button,
+	ButtonGroup,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -12,6 +17,11 @@ import { MultipleChoiceQuestion } from '@crowdsignal/blocks';
 import ColorSettings from '../components/color-settings';
 
 const Sidebar = ( { attributes, blockStyle, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
 	const handleChangeWidth = ( value ) =>
 		setAttributes( {
 			width: attributes.width === value ? undefined : value,
@@ -19,13 +29,26 @@ const Sidebar = ( { attributes, blockStyle, setAttributes } ) => {
 
 	return (
 		<InspectorControls>
+			<PanelBody title={ __( 'Answer settings' ) }>
+				<ToggleControl
+					label={ __(
+						'Sync style settings for all answers',
+						'block-editor'
+					) }
+					checked={ attributes.shareSiblingAttributes }
+					onChange={ handleChangeAttribute(
+						'shareSiblingAttributes'
+					) }
+				/>
+			</PanelBody>
+
 			<ColorSettings
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>
 
 			{ blockStyle === MultipleChoiceQuestion.Style.BUTTON && (
-				<PanelBody title={ __( 'Width settings', 'blocks' ) }>
+				<PanelBody title={ __( 'Width settings', 'block-editor' ) }>
 					<ButtonGroup aria-label={ __( 'Button width' ) }>
 						{ [ 25, 50, 75, 100 ].map( ( width ) => (
 							<Button

--- a/packages/block-editor/src/multiple-choice-answer/sidebar.js
+++ b/packages/block-editor/src/multiple-choice-answer/sidebar.js
@@ -29,19 +29,6 @@ const Sidebar = ( { attributes, blockStyle, setAttributes } ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Answer settings' ) }>
-				<ToggleControl
-					label={ __(
-						'Sync style settings for all answers',
-						'block-editor'
-					) }
-					checked={ attributes.shareSiblingAttributes }
-					onChange={ handleChangeAttribute(
-						'shareSiblingAttributes'
-					) }
-				/>
-			</PanelBody>
-
 			<ColorSettings
 				attributes={ attributes }
 				setAttributes={ setAttributes }
@@ -67,6 +54,19 @@ const Sidebar = ( { attributes, blockStyle, setAttributes } ) => {
 					</ButtonGroup>
 				</PanelBody>
 			) }
+
+			<PanelBody title={ __( 'Style settings' ) }>
+				<ToggleControl
+					label={ __(
+						'Sync style settings for all answers',
+						'block-editor'
+					) }
+					checked={ attributes.shareSiblingAttributes }
+					onChange={ handleChangeAttribute(
+						'shareSiblingAttributes'
+					) }
+				/>
+			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/packages/block-editor/src/util/with-shared-sibling-attributes.js
+++ b/packages/block-editor/src/util/with-shared-sibling-attributes.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { filter, first, map, pick } from 'lodash';
+
+export const useSharedSiblingAttributes = ( {
+	attributes,
+	clientId,
+	setAttributes,
+	sharedAttributes,
+} ) => {
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	const siblings = useSelect(
+		( select ) => {
+			const blockEditor = select( 'core/block-editor' );
+
+			const blockName = blockEditor.getBlockName( clientId );
+			const parentId = first(
+				blockEditor.getBlockParents( clientId, true )
+			);
+
+			return filter(
+				map(
+					blockEditor.getBlock( parentId ).innerBlocks,
+					( block ) => block.clientId
+				),
+				( childClientId ) =>
+					childClientId !== clientId &&
+					blockEditor.getBlockName( childClientId ) === blockName
+			);
+		},
+		[ clientId ]
+	);
+
+	const syncAttributes = useCallback(
+		( newAttributes ) => {
+			if (
+				attributes.shareSiblingAttributes ||
+				newAttributes.shareSiblingAttributes
+			) {
+				updateBlockAttributes(
+					siblings,
+					pick(
+						attributes.shareSiblingAttributes
+							? newAttributes
+							: { ...attributes, ...newAttributes },
+						[ ...sharedAttributes, 'shareSiblingAttributes' ]
+					)
+				);
+			}
+
+			setAttributes( newAttributes );
+		},
+		[ ...siblings, ...sharedAttributes, attributes ]
+	);
+
+	return syncAttributes;
+};
+
+export const withSharedSiblingAttributes = ( sharedAttributes ) => (
+	WrappedComponent
+) => ( { attributes, clientId, setAttributes, ...props } ) => {
+	const syncAttributes = useSharedSiblingAttributes( {
+		attributes,
+		clientId,
+		setAttributes,
+		sharedAttributes,
+	} );
+
+	return (
+		<WrappedComponent
+			attributes={ attributes }
+			clientId={ clientId }
+			setAttributes={ syncAttributes }
+			{ ...props }
+		/>
+	);
+};


### PR DESCRIPTION
This patch implements a new mechanic that allows for synchronizing given properties between multiple child blocks that are of the same type. This is so that it's easier to edit the appearance of a 'compound question block' as a whole rather than going through every child block separately.  
As of now, only `MultipleChoiceAnswer` implements a setting to take advantage of this.

_Note: For the time being I just added an 'answer settings' section to the top of Multiple Choice Answer's sidebar, but perhaps there's a better place for the toggle. That said, it should be in a common place that's not necessarily linked to any specific style settings as these may vary depending on the block._

Solves c/L9Wt6cXy-tr.

![Screen Shot 2021-10-20 at 8 32 00 PM](https://user-images.githubusercontent.com/8056203/138151601-7cf51f59-4861-4c91-889d-6e1044dadb1b.png)

# Testing

- Add a **Multiple Choice** block and select an answer block.
- There should now be a setting for syncing the style setting across all block answers at the top of the sidebar. It's selected by default.
- Proceed to make changes to the block background, text color or width. They should simultaneously be applied to all other answer blocks inside the question.
- Uncheck the sync setting.
- Proceed to make some more changes to the block, these should no longer propagate to other answers.
- Check the settings again. All other answer blocks should immediately update to reflect the appearance of your selected answer block.