### PR TITLE
Fix renderBlocks' parseNodes function

### DIFF
--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -9,9 +9,10 @@ import {
 	isEmpty,
 	isString,
 	keys,
-	lowerCase,
+	toLower,
 	map,
 	uniqueId,
+	zipObject,
 } from 'lodash';
 
 const KEY_PREFIX = 'crowdsignal-block-';
@@ -30,11 +31,17 @@ const parseNodes = ( nodes ) =>
 			return node.textContent;
 		}
 
+		const { class: className, ...attributes } = zipObject(
+			map( node.attributes, 'nodeName' ),
+			map( node.attributes, 'value' )
+		);
+
 		return {
-			name: lowerCase( node.tagName ),
+			name: toLower( node.tagName ),
 			children: parseNodes( node.childNodes ),
 			props: {
-				className: node.classList.value,
+				...attributes,
+				className,
 				key: uniqueId( KEY_PREFIX ),
 			},
 		};
@@ -77,8 +84,12 @@ const appendInnerBlocks = ( blockName, elements, innerBlocks ) => {
  * @param  {Object} elements
  * @return {Array}           Array of React elements.
  */
-const createElementsRecursive = ( elements ) =>
-	map( elements, ( element ) => {
+const createElementsRecursive = ( elements ) => {
+	if ( isEmpty( elements ) ) {
+		return null;
+	}
+
+	return map( elements, ( element ) => {
 		if ( isString( element ) ) {
 			return element;
 		}
@@ -92,6 +103,7 @@ const createElementsRecursive = ( elements ) =>
 			element.innerBlocks || createElementsRecursive( element.children )
 		);
 	} );
+};
 
 /**
  * Converts a HTML string into React elements


### PR DESCRIPTION
This patch fixes issues with some core blocks causing our preview/page renderer not to work correctly or crash altogether.  
The main culprits I found were:

- Usage of lodash' `lowerCase` instead of `toLower` causing tag names to be converted in a wrong way.
- We didn't support for any HTML attributes on these blocks other than `class`, thus blocks like the image block would never work.

Solves c/2OdLDU86-tr.

# Testing

- Create a new project and proceed to add core blocks to it. Header and Image blocks in particular as they've shown to be problematic in the past.
- Go to the preview.
- The page should now display correctly.