### PR TITLE
Update READMEs

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -6,7 +6,7 @@ This package contains the editor interface for all of our blocks. For public fac
 
 All of our blocks are registered under `crowdsignal-forms` namespace, so the complete block name should look something like this: `crowdsignal-forms/my-block`.
 
-In general, the block registered name should match it's display name closely. If a block happens to fall within a certain category, it's good to signify that using an appropriate suffix. For example:
+In general, the block registered name should match its display name closely. If a block happens to fall within a certain category, it's good to signify that using an appropriate suffix. For example:
 
 - `-question`
 - `-answer`

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1,3 +1,21 @@
-# @crowdsignal/blocks
+# @crowdsignal/block-editor
 
-A library containing the UI for the block editor.
+This package contains the editor interface for all of our blocks. For public facing UI, see [@crowdsignal/blocks](../blocks).
+
+## Block naming
+
+All of our blocks are registered under `crowdsignal-forms` namespace, so the complete block name should look something like this: `crowdsignal-forms/my-block`.
+
+In general, the block registered name should match it's display name closely. If a block happens to fall within a certain category, it's good to signify that using an appropriate suffix. For example:
+
+- `-question`
+- `-answer`
+- `-input`
+- etc.
+
+## Block exports
+
+Each `@crowdsignal/block-editor` block must export an object with the following properties:
+
+- **name**: The name to register and reference the block with. See _Block naming_.
+- **settings**: Block settings.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -2,7 +2,7 @@
 
 Crowdsignal block library. This package contains the implementation of the user-facing interface of all our blocks. For editor interface see [@crowdsignal/block-editor](../block-editor).
 
-**Note:** `@crowdsignal/block-editor` depends on `@crowdsignal/blocks` but `@crowdsignal/blocks` **must not** depend on `@crowdsignal/block-edito`.
+**Note:** `@crowdsignal/block-editor` depends on `@crowdsignal/blocks` but `@crowdsignal/blocks` **must not** depend on `@crowdsignal/block-editor`.
 
 ## Block architecture
 
@@ -10,8 +10,8 @@ Our blocks are exclusively [dynamic](https://developer.wordpress.org/block-edito
 
 The advantages of such approach are:
 
-- It gives us maximum flexibility and consistency in terms of being able to serve the block anywhere and it working/feeling the same.
-- Minimal overhead for implementing our block inside other services or plugins.
+- Consistent look and feel for our blocks regardles of the platform.
+- All block content are easily embeddable.
 
 ## Creating new blocks
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,0 +1,31 @@
+# @crowdsignal/blocks
+
+Crowdsignal block library. This package contains the implementation of the user-facing interface of all our blocks. For editor interface see [@crowdsignal/block-editor](../block-editor).
+
+**Note:** `@crowdsignal/block-editor` depends on `@crowdsignal/blocks` but `@crowdsignal/blocks` **must not** depend on `@crowdsignal/block-edito`.
+
+## Block architecture
+
+Our blocks are exclusively [dynamic](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/creating-dynamic-blocks/) with the added caveat they're always stored on our backend and rendered as a frontend app.  
+
+The advantages of such approach are:
+
+- It gives us maximum flexibility and consistency in terms of being able to serve the block anywhere and it working/feeling the same.
+- Minimal overhead for implementing our block inside other services or plugins.
+
+## Creating new blocks
+
+Each new block goes into its own directory named after it in the package root. See [@crowdsignal/block-editor](../block-editor) for guidelines on block naming.  
+
+It's important for the user-facing block implementation to not rely on any editor dependencies - like state or components.  
+It's also a good idea to break down blocks into smaller shared block components that can then also be used to build the editor UI for the block. Take a look at [TextQuestion](./src/text-question/index.js) and [EditTextQuestion](../block-editor/src/text-question/edit.js) for a relatively simple example.
+
+## Block components
+
+Because of their unique nature, blocks **must not** be built using external component libraries such as `@crowdsignal/components` or `@wordpress/components`.  
+Specifically, some of such components might come with very explicit styles which would make it difficult for them to be styled using the block editor. We also don't want to be forced into having to provide a separate, external stylesheet for our bundles to work.
+
+That said, it's still a good idea for different blocks to share components where applicable to keep a consistent UI and our codebase concise. There are two rules to keep in mind:
+
+- All shared components used by our blocks should go into the `components/` directory of this package.
+- The package should export these shared components so they can be used to replicate the same interface in the editor version of the block.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,0 +1,3 @@
+# @crowdsignal/icons
+
+Crowdsignal's custom icons set available as React components.


### PR DESCRIPTION
This patch adds missing README files and updates the description for `@crowdsignal/blocks` and `@crowdsignal/block-editor` to hopefully give a better picture of how they're organized.

# Testing

Proof read 😄 ?