### PR TITLE
Audo-add submit buttons when form blocks are first added

### DIFF
--- a/apps/dashboard/src/components/editor/auto-submit-button.js
+++ b/apps/dashboard/src/components/editor/auto-submit-button.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { filter, includes, map, size } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	multipleChoiceAnswerBlock,
+	multipleChoiceQuestionBlock,
+	textQuestionBlock,
+	submitButtonBlock,
+} from '@crowdsignal/block-editor';
+
+const FORM_BLOCKS = map(
+	[
+		multipleChoiceAnswerBlock,
+		multipleChoiceQuestionBlock,
+		textQuestionBlock,
+	],
+	'name'
+);
+
+const AutoSubmitButton = () => {
+	const [ currentFormBlocksCount, setCurrentFormBlocksCount ] = useState( 0 );
+
+	const { insertBlock } = useDispatch( 'core/block-editor' );
+	const { formBlocksCount, lastBlockIndex, submitButtonCount } = useSelect(
+		( select ) => {
+			const blockEditorData = select( 'core/block-editor' );
+
+			return {
+				formBlocksCount: size(
+					filter(
+						map(
+							blockEditorData.getClientIdsWithDescendants(),
+							blockEditorData.getBlockName
+						),
+						( blockName ) => includes( FORM_BLOCKS, blockName )
+					)
+				),
+				lastBlockIndex: blockEditorData.getBlocks().length - 1,
+				submitButtonCount: blockEditorData.getGlobalBlockCount(
+					submitButtonBlock.name
+				),
+			};
+		}
+	);
+
+	useEffect( () => {
+		if (
+			currentFormBlocksCount === 0 &&
+			formBlocksCount !== 0 &&
+			submitButtonCount === 0
+		) {
+			insertBlock(
+				createBlock( submitButtonBlock.name ),
+				lastBlockIndex + 1,
+				'',
+				false
+			);
+		}
+
+		if ( currentFormBlocksCount !== formBlocksCount ) {
+			setCurrentFormBlocksCount( formBlocksCount );
+		}
+	}, [ currentFormBlocksCount, formBlocksCount, submitButtonCount ] );
+
+	return null;
+};
+
+export default AutoSubmitButton;

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -15,8 +15,10 @@ import { useStylesheet } from '@crowdsignal/hooks';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
+import AutoSubmitButton from './auto-submit-button';
 import EditorLoadingPlaceholder from './loading-placeholder';
 import DocumentSettings from './document-settings';
+import EditorLoadingPlaceholder from './loading-placeholder';
 import Toolbar from './toolbar';
 
 /**
@@ -125,6 +127,8 @@ const Editor = ( { projectId } ) => {
 			>
 				<Toolbar projectId={ projectId } />
 				<DocumentSettings />
+
+				<AutoSubmitButton />
 			</IsolatedBlockEditor>
 		</div>
 	);


### PR DESCRIPTION
This patch will automatically append a Submit Button Block to the end of the page when you first insert a form block (currently: text question, multiple choice question/answer) and the page doesn't already contain a submit button.  
It will not be appended when any form blocks are present on the page already - even if the submit button is missing.
The same should work when copy&pasting blocks in the editor.

_Note: Because of current loading behavior of [Automattic/isolated-block-editor](https://github.com/Automattic/isolated-block-editor), the submit button will also be appended when the editor is loaded and the page contains form blocks but not a submit button._

Part of c/aev5y2xb-tr.

# Testing

- Create a project and proceed add core blocks. Expect nothing out of the ordinary.
- Add a Text or Multiple Choice question.
- A Submit Button should automatically be appended at the end of the page.
- Remove the submit button and add another question block.
- The submit button should no longer be appended automatically.
- Save the project and refresh the page.
- You'll see the submit button back at the bottom when the editor loads.