### PR TITLE
Add type checking capabilities to help deal with convoluted data structures

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,8 @@
 			"error",
 			10
 		],
+		"jsdoc/require-property-description": "off",
+		"jsdoc/require-returns-description": "off",
 		"jsx-a11y/anchor-has-content": [
 			"off"
 		],
@@ -37,6 +39,9 @@
 			"node": {
 				"paths": ["apps/dashboard/src"]
 			}
+		},
+		"jsdoc": {
+			"mode": "typescript"
 		}
 	}
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -26,6 +26,7 @@
     "@crowdsignal/hooks": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
+    "@crowdsignal/types": "^0.1.0",
     "@wordpress/blocks": "^11.0.0",
     "@wordpress/data": "^6.0.0",
     "@wordpress/element": "^4.0.0",

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -47,8 +47,8 @@ const editorSettings = {
 };
 
 /**
- * @param  {Object} props
- * @param  {number} props.projectId
+ * @param {Object} props
+ * @param {number} props.projectId
  */
 const Editor = ( { projectId } ) => {
 	/** @type {[Project, boolean]} */

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * External dependencies
  */
@@ -8,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { EditablePageHeader, TabNavigation } from '@crowdsignal/components';
+import { updateProjectTitle } from '@crowdsignal/types';
 import { STORE_NAME } from '../../data';
 
 /**
@@ -15,24 +18,35 @@ import { STORE_NAME } from '../../data';
  */
 import './style.scss';
 
+/**
+ * @typedef {import("../../../../../packages/types/src/project").Project} Project
+ */
+
+/**
+ * @enum {string}
+ */
 const Tab = {
 	EDITOR: 'editor',
 	RESULTS: 'results',
 };
 
+/**
+ * @param {Object} props
+ * @param {string} props.activeTab
+ * @param {number} props.projectId
+ */
 const ProjectNavigation = ( { activeTab, projectId } ) => {
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
+	/** @type {Project} */
 	const project = useSelect(
 		( select ) => select( STORE_NAME ).getProject( projectId ),
 		[ projectId ]
 	);
 
+	/** @type {(title: string) => void} */
 	const updateTitle = ( title ) =>
-		saveAndUpdateProject( projectId, {
-			name: title,
-			title,
-		} );
+		saveAndUpdateProject( projectId, updateProjectTitle( project, title ) );
 
 	return (
 		<div className="project-navigation">

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "check-licenses": "wp-scripts check-licenses --prod --gpl2",
+    "check-types": "tsc",
     "format": "wp-scripts format",
     "lint:js": "wp-scripts lint-js",
     "lint:pkg-json": "wp-scripts lint-pkg-json",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@storybook/source-loader": "^6.3.0",
     "@storybook/react": "^6.3.0",
     "@wordpress/scripts": "^16.1.0",
+    "@types/wordpress__blocks": "^9.1.1",
+    "@types/wordpress__data": "^4.6.0",
     "enzyme": "^3.11.0",
     "husky": "^6.0.0",
     "jest": "^27.0.6",

--- a/packages/components/src/tab-navigation/index.js
+++ b/packages/components/src/tab-navigation/index.js
@@ -13,6 +13,11 @@ import Tab from './tab';
  */
 import './style.scss';
 
+/**
+ * @param  {Object}  props
+ * @param  {any[]}   props.children
+ * @param  {string=} props.className
+ */
 const TabNavigation = ( { children, className } ) => {
 	const classes = classnames( 'tab-navigation', className );
 

--- a/packages/functional/README.md
+++ b/packages/functional/README.md
@@ -1,0 +1,64 @@
+# @crowdsignal/functional
+
+Functional programming helpers used throughout crowdsignal packages.
+
+_Note: This package is fully typed using typescript JSDoc notation._
+
+## curry
+
+Type-safe curry function for lazy binding of a functions first argument.
+
+
+```javascript
+import { flow } from 'lodash';
+import { curry } from '@crowdsignal/functional';
+
+const add = curry( ( a, b ) => a + b );
+const multiply = curry( ( a, b ) => a * b );
+
+
+// number === 18
+const number = flow(
+	add( 3 ),
+	multiply( 3 )
+)( 3 );
+```
+
+### Params
+
+**func**: Callback to curry.
+
+- Type: `Function`
+- Required: Yes
+
+### Return
+
+`Function`
+
+## curriedOr
+
+Logical OR function with support for currying.
+
+```javascript
+import { flow } from 'lodash';
+import { curry, curryOr } from '@crowdsignal/functional';
+
+const add = curry( ( a, b ) => a + b );
+const subtract = curry( ( a, b ) => a - b );
+
+const addOrSubtract = or( add( 3 ), subtract( 3 ) );
+
+addOrSubtract( 3 ); // 6
+addOrSubtract( -3 ); // -6
+```
+
+### Params
+
+**...expressions**: Expressions to evaluate. If an expression evaluates to a function, it's the return value of that function when invoked with the curried argument that determines if it's true or false.
+
+- Type: `Any`
+- Required: `Yes`
+
+### Return
+
+`Function`.

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@crowdsignal/functional",
+  "version": "0.1.0",
+  "description": "Functional programming helpers library.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal",
+    "functional"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/functional/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js"
+}

--- a/packages/functional/src/curry.js
+++ b/packages/functional/src/curry.js
@@ -1,0 +1,45 @@
+/* eslint-disable jsdoc/valid-types */
+// @ts-check
+
+/**
+ * @template F extends (...args: any[]) => any
+ *
+ * @typedef {F extends ((...args: infer A) => any) ? A : never} Params
+ */
+
+/**
+ * @template T extends any[]
+ *
+ * @typedef {T extends [any, ...any[]] ? T[0] : never} Head
+ */
+
+/**
+ * @template T extends any[]
+ *
+ * @typedef {T extends [_: any, ...tail: infer TT] ? TT : []} Tail
+ */
+
+/**
+ * @template F extends (...args: any[] => any)
+ *
+ * @typedef {F extends ((...args: any[]) => infer R) ? R : never} ReturnType
+ */
+
+/**
+ * Enables optional currying for the first argument of the passed function:
+ *
+ * @template F
+ *
+ * @param  {F extends (...args: any[]) => any ? F : never} func Function to curry
+ * @return {{
+ *   (...args: Params<F>): ReturnType<F>;
+ *   (...args: Tail<Params<F>>): (a: Head<Params<F>>) => ReturnType<F>;
+ * }}
+ */
+export const curry = ( func ) => ( ...args ) => {
+	if ( args.length === func.length - 1 ) {
+		return ( subject ) => func( subject, ...args );
+	}
+
+	return func( ...args );
+};

--- a/packages/functional/src/curry.js
+++ b/packages/functional/src/curry.js
@@ -2,25 +2,25 @@
 // @ts-check
 
 /**
- * @template F extends (...args: any[]) => any
+ * @template F
  *
  * @typedef {F extends ((...args: infer A) => any) ? A : never} Params
  */
 
 /**
- * @template T extends any[]
+ * @template T
  *
  * @typedef {T extends [any, ...any[]] ? T[0] : never} Head
  */
 
 /**
- * @template T extends any[]
+ * @template T
  *
  * @typedef {T extends [_: any, ...tail: infer TT] ? TT : []} Tail
  */
 
 /**
- * @template F extends (...args: any[] => any)
+ * @template F
  *
  * @typedef {F extends ((...args: any[]) => infer R) ? R : never} ReturnType
  */

--- a/packages/functional/src/curryOr.js
+++ b/packages/functional/src/curryOr.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+/**
+ * Logical OR for combining multiple curried functions or expressions:
+ *
+ * or( caseA, caseB( args ), caseC, 'default' )( a )
+ *
+ * @param  {any[]}           expressions
+ * @return {(a: any) => any}
+ */
+export const curryOr = ( ...expressions ) => ( value ) => {
+	for ( let i = 0; i < expressions.length; ++i ) {
+		const result =
+			typeof expressions[ i ] === 'function'
+				? expressions[ i ]( value )
+				: expressions[ i ];
+
+		if ( result || i === expressions.length - 1 ) {
+			return result;
+		}
+	}
+};

--- a/packages/functional/src/index.js
+++ b/packages/functional/src/index.js
@@ -1,0 +1,2 @@
+export * from './curry';
+export * from './curryOr';

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@crowdsignal/types",
+  "version": "0.1.0",
+  "description": "Crowdsignal data types.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal",
+    "types"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/types/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@crowdsignal/functional": "^0.1.0",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/types/src/README.md
+++ b/packages/types/src/README.md
@@ -1,0 +1,5 @@
+# @crowdsignal/types
+
+Type definitions for Crowdsignal data structures and their associated set of helpers. 
+
+_Note: This package is fully typed using typescript JSDoc notation._

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -1,0 +1,1 @@
+export * from './project';

--- a/packages/types/src/project/index.js
+++ b/packages/types/src/project/index.js
@@ -1,0 +1,129 @@
+// @ts-check
+
+/**
+ * External dependencies
+ */
+import { slice } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { curry } from '@crowdsignal/functional';
+
+/**
+ * @typedef {Array<Object>} Page
+ */
+
+/**
+ * @typedef {Object} ProjectContent
+ *
+ * @property {Array<Page>} pages     Page array.
+ * @property {number}      timestamp Last edit timestamp.
+ */
+
+/**
+ * @typedef {Object} Project
+ *
+ * @property {number}                created       Project creation date.
+ * @property {ProjectContent}        draftContent  Project's draft content.
+ * @property {string}                name          Project name.
+ * @property {string}                permalink     Project URL.
+ * @property {boolean}               public        True when project is public.
+ * @property {ProjectContent | null} publicContent Project's last published content.
+ * @property {string}                slug          Project slug.
+ * @property {string}                title         Project title.
+ */
+
+/**
+ * Creates a new project.
+ *
+ * @return {Project} New Project object.
+ */
+export const createProject = () => {
+	const currentTimestamp = Math.floor( Date.now() / 1000 );
+
+	return {
+		created: currentTimestamp,
+		draftContent: {
+			pages: [ [] ],
+			timestamp: currentTimestamp,
+		},
+		name: '',
+		permalink: '',
+		public: false,
+		publicContent: null,
+		slug: '',
+		title: '',
+	};
+};
+
+/**
+ * Helper for detecting whether a project contains unpublished changes.
+ *
+ * @param  {Project} project Project.
+ * @return {boolean}         True when project contains unpublished changes.
+ */
+export const hasUnpublishedChanges = ( project ) => ! project.public;
+
+/**
+ * Updates the project's public content.
+ *
+ * @param  {Project} project Project.
+ * @return {Project}         Updated project.
+ */
+export const publishProject = ( project ) => ( {
+	...project,
+	publicContent: project.draftContent,
+	public: true,
+} );
+
+/**
+ * Merges two project objects.
+ *
+ * @param  {Project} project      Projct to merge into.
+ * @param  {Project} otherProject Project to be merged.
+ * @return {Project}              Merged project.
+ */
+const __mergeProject = ( project, otherProject ) => ( {
+	...project,
+	...otherProject,
+} );
+export const mergeProject = curry( __mergeProject );
+
+/**
+ * Update a project's title.
+ *
+ * @param  {Project} project Project to update.
+ * @param  {string}  title   Project title.
+ * @return {Project}         Project with an updated title.
+ */
+const __updateProjectTitle = ( project, title ) => ( {
+	...project,
+	title,
+	name: title,
+} );
+export const updateProjectTitle = curry( __updateProjectTitle );
+
+/**
+ * Update a project's page.
+ * Any updates are saved as draft by default and require publishProject
+ * to be called separately to update the public content.
+ *
+ * @param  {Project} project   Project to update.
+ * @param  {Page}    page      The updated page.
+ * @param  {number=} pageIndex Index of the updated page. Defaults to 0.
+ * @return {Project}           Updated project.
+ */
+const __updateProjectPage = ( project, page, pageIndex = 0 ) => ( {
+	...project,
+	draftContent: {
+		pages: [
+			...slice( project.draftContent.pages || [], 0, pageIndex ),
+			page,
+			...slice( project.draftContent.pages || [], pageIndex + 1 ),
+		],
+		timestamp: Math.floor( Date.now() / 1000 ),
+	},
+	public: false,
+} );
+export const updateProjectPage = curry( __updateProjectPage );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"noEmit": true,
+		"jsx": "preserve",
+		"strict": true,
+		"target": "esnext",
+		"module": "esnext",
+		"isolatedModules": true,
+		"moduleResolution": "node",
+		"types": [],
+		"typeRoots": []
+	},
+	"include": [
+		"apps/*/src/**/*.js",
+		"packages/*/src/**/*.js",
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,32 @@
 {
 	"compilerOptions": {
 		"allowJs": true,
-		"noEmit": true,
 		"jsx": "preserve",
-		"strict": true,
+		"allowSyntheticDefaultImports": true,
 		"target": "esnext",
 		"module": "esnext",
 		"isolatedModules": true,
+		"noEmit": true,
+
+		/* Strict Type-Checking Options */
+		"strict": true,
+
+		/* Additional Checks */
+
+		/* Module Resolution Options */
 		"moduleResolution": "node",
-		"types": [],
-		"typeRoots": []
+		"esModuleInterop": false,
+		"resolveJsonModule": true,
+		"baseUrl": ".",
+		"paths": {
+			"react": ["node_modules/@types/react"]
+		}
 	},
 	"include": [
 		"apps/*/src/**/*.js",
 		"packages/*/src/**/*.js",
+	],
+	"exclude": [
+		"node_modules"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
 
 		/* Strict Type-Checking Options */
 		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
 
 		/* Additional Checks */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,6 +4312,11 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
 
+"@types/tinycolor2@*":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.3.tgz#ed4a0901f954b126e6a914b4839c77462d56e706"
+  integrity sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==
+
 "@types/uglify-js@*":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.0.tgz#1cad8df1fb0b143c5aba08de5712ea9d1ff71124"
@@ -4354,6 +4359,55 @@
     "@types/webpack-sources" "*"
     anymatch "^3.0.0"
     source-map "^0.6.0"
+
+"@types/wordpress__blocks@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__blocks/-/wordpress__blocks-9.1.1.tgz#169fc95f9e1c05863e1a3099107ae0fcc0006cef"
+  integrity sha512-E4tMCascyIeTeBn3olJXRDESXQWsRsCVSnuaeIrznIR5wjJbUDSQBZF/GeFLjfIraHLGV2I5++r11GcPcXp0Ig==
+  dependencies:
+    "@types/react" "*"
+    "@types/wordpress__components" "*"
+    "@types/wordpress__data" "*"
+    "@wordpress/element" "^3.0.0"
+
+"@types/wordpress__components@*":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__components/-/wordpress__components-14.0.4.tgz#662133dfe70bc8b1b79b41be7617ccea447dec99"
+  integrity sha512-fAscxuuplXCAbqThc+YDMuhixlT/beUbcQalBEfrmnE2rcvaDJu6rDXlZjZyMF9qJeS+UOaFdbpWf2fAG/skzQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/tinycolor2" "*"
+    "@types/wordpress__components" "*"
+    "@types/wordpress__notices" "*"
+    "@types/wordpress__rich-text" "*"
+    "@wordpress/element" "^3.0.0"
+    downshift "^6.0.15"
+    re-resizable "^6.4.0"
+
+"@types/wordpress__data@*", "@types/wordpress__data@^4.6.0":
+  version "4.6.10"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__data/-/wordpress__data-4.6.10.tgz#46007271427ccc7fe75d01d697a5c7fb43e7b8bb"
+  integrity sha512-I5p1MnQpx4MM+/nYeThuCfuWXtHPt5zTrCaNPZWVsLQCwpUNMWxddCG4iXbh1uR1teSeEi8OAH6ozNxD1mm81Q==
+  dependencies:
+    "@types/react" "*"
+    redux "^4.0.1"
+
+"@types/wordpress__notices@*":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__notices/-/wordpress__notices-1.5.4.tgz#ddcc9e4030298da0cd40a4a342c7264930460dd2"
+  integrity sha512-JkWWwukEvv2o8xzyYXi5iveMgUnPZXIgQfw0u/IQkSZE8+1XTJgokLwo3Ks5PrWHEzlPCZXWQXQsGeShdoOkyQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/wordpress__data" "*"
+
+"@types/wordpress__rich-text@*":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.6.tgz#ec925c8c5409e1c0f4ef9898e5a3b7feb56cae5f"
+  integrity sha512-MeLSATBHrcN3fp8cVylbpx+BKRJ1aootPNtbTblcUAHcuRo6avKu1kaDLxIZb/8YbsD+/3Wm8d1uldeNz9/lhw==
+  dependencies:
+    "@types/react" "*"
+    "@types/wordpress__data" "*"
+    "@types/wordpress__rich-text" "*"
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -5293,6 +5347,19 @@
     react "^17.0.1"
     react-dom "^17.0.1"
 
+"@wordpress/element@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-3.2.0.tgz#531720b3a023a1509f13d2464b2e1d670153116e"
+  integrity sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^2.2.0"
+    lodash "^4.17.21"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+
 "@wordpress/element@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-3.1.1.tgz#a1f33ddf54902c671d7a3426bae9731287a80f05"
@@ -5310,6 +5377,13 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.1.1.tgz#4b9e887c2b1b06ec0d4fc691328224b4e9736c95"
   integrity sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@wordpress/escape-html@^2.2.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.2.2.tgz#1695562f271fd4a31e2f4c2a4bb4018cb404f43e"
+  integrity sha512-NuPury2dyaqF7zpDaUOKaoM0FrEuqaDE1c3j7rM6kceJ4ZFDHnCLf5NivwchOLo7Xs0oVtqBdDza/dcSQaLFGg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -17524,6 +17598,13 @@ redux-undo@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.1.tgz#8d989d6c326e6718f4471042e90a5b8b6f3317eb"
   integrity sha512-0yFPT+FUgwxCEiS0Mg5T1S4tkgjR8h6sJRY9CW4EMsbJOf1SxO289TbJmlzhRouCHacdDF+powPjrjLHoJYxWQ==
+
+redux@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 redux@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This is an initial stab at trying to make parts of our application type-safe.

Solves c/MV5belpY-tr.

We have a few objects that can get quite large or chaotic, think of project or user state. I'd like to organize them a little better by defining them in proper types as well as provide some helpers to deal with updating any of these objects. This way we could keep all related logic in one place instead of manipulating objects manually inline - resulting in duplicated, more error prone code that quickly becomes difficult to understand as necessary context is spread all over the place.

As part of this endeavour, I also implemented a type-safe `curry()` function so our helpers are compatible with `flow`,`flowRight`,`compose` and the like, all while maintaining type safety.

That said, it's not all rainbows and butterflies so here's a quick overview of my findings so far regarding strong typing:

### The good

- Types. We now have a good reference of what data structures we're working with.
- Safety. When type checking is enabled and proper types are inferred or specified explicitly, you will get an error if you're trying to access a property that doesn't exist. Similarly we can ensure certain structures must exist in certain objects, saving us a null-check here and there.
- Syntax. With typescript's JSDoc syntax, we don't have to do much more than remember to add our regular docBlocks above our functions and it automatically picks it up.
- We don't need to update our toolchain - it's still all JS.

### The bad

- As not everything we write is fully typed, Typescript cannot fully deduce types where it otherwise should and requires explicit `@type` definitions.
- Somewhat related to the above, as our type definitions sit in their own package, importing them is quite painful. For example: `@typedef {import("../../../../../packages/types/src/project").Project} Project`. It'd be helpful if we can make them available globally across our modules.
- We can't restrict type-checking to certain types only. As such, whenever it's enabled for a file, the entire file would need to be updated to fix any errors that might pop up - including ones unrelated to the current issue.

### Possible compromise

If we forget about types for a minute, I think the helpers themselves are great. After all:

```javascript
const publicProject = publishProject( project );
```

Reads much better than:

```javascript
const publicProject = {
    ...project,
    content: {
        ...project.content,
        public: project.content.draft,
    },
    public: true,
};
```

The two new packages I added are fully strongly-typed. That already ensures some safety between the helpers themselves. Moving that logic into dedicated functions also makes them testable. I think that's definitely a part worth keeping.

As for enforcing types across the rest of our app... The main benefit would be the added safety when accessing any object properties. The overhead is not much but it's there.  
It's worth noting the same level of safety could be achieved by implementing similar helpers for accessing properties rather than just updating our big objects. This also has the added benefit of totally encapsulating the internal composition of any such object.  
This is the part I think needs some discussion.

### Todo

- [ ] Add a doc describing the overall stance on types across the entire repo.
- [ ] Convert project's returned from the API into the structure used in the app and vice-versa.

# Testing

Run `yarn check-types` to validate there aren't any type related errors.