### PR TITLE
Add a dropdown with preview options

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -30,6 +30,7 @@
     "@wordpress/data": "^6.0.0",
     "@wordpress/element": "^4.0.0",
     "@wordpress/i18n": "^4.2.1",
+    "@wordpress/icons": "^5.0.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.21",
 	"isolated-block-editor": "github:automattic/isolated-block-editor#2.3.0",

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -1,7 +1,17 @@
+/* eslint-disable complexity */
+
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	Icon,
+	MenuGroup,
+	MenuItem,
+	Popover,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { check, external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line import/named
 
@@ -13,6 +23,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { hasUnpublishedChanges } from '../../util/project';
 
 const Toolbar = ( { projectId } ) => {
+	const [ showPreviewDropdown, setShowPreviewDropdown ] = useState( false );
+	const [ previewDeviceType, setPreviewDeviceType ] = useState( 'Desktop' );
+
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const [ project, isSaving, isSaved, isPublic ] = useSelect( ( select ) => {
@@ -87,11 +100,53 @@ const Toolbar = ( { projectId } ) => {
 			<Button
 				className="is-crowdsignal"
 				variant="tertiary"
-				href={ `/project/${ projectId }/preview` }
-				target="_blank"
+				onClick={ () => setShowPreviewDropdown( true ) }
 				disabled={ ! projectId }
 			>
 				{ __( 'Preview', 'block-editor' ) }
+
+				{ showPreviewDropdown && (
+					<Popover onClose={ () => setShowPreviewDropdown( false ) }>
+						<MenuGroup>
+							<MenuItem
+								onClick={ () =>
+									setPreviewDeviceType( 'Desktop' )
+								}
+								icon={
+									previewDeviceType === 'Desktop' && check
+								}
+							>
+								{ __( 'Desktop', 'dashboard' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () =>
+									setPreviewDeviceType( 'Tablet' )
+								}
+								icon={ previewDeviceType === 'Tablet' && check }
+							>
+								{ __( 'Tablet', 'dashboard' ) }
+							</MenuItem>
+							<MenuItem
+								onClick={ () =>
+									setPreviewDeviceType( 'Mobile' )
+								}
+								icon={ previewDeviceType === 'Mobile' && check }
+							>
+								{ __( 'Mobile', 'dashboard' ) }
+							</MenuItem>
+						</MenuGroup>
+						<MenuGroup>
+							<Button
+								variant="tertiary"
+								href={ `/project/${ projectId }/preview` }
+								target="_blank"
+							>
+								{ __( 'Preview in a new tab', 'dashboard' ) }
+								<Icon icon={ external } />
+							</Button>
+						</MenuGroup>
+					</Popover>
+				) }
 			</Button>
 			{ ( ! isPublic || hasUnpublishedChanges( project ) ) && (
 				<Button


### PR DESCRIPTION
This patch adds more preview options to our editor: Desktop (default), Tablet and Mobile. As well as keeping the exiting ability to preview the page in a new tab.  

_Note: Because of major breaking changes in the latest Gutenberg release with regards to layout, we need to update `main` to use latest `@wordpres/...` packages before the last step can be completed._

Solves c/KTdvQrIj-tr.

To do:

- [x] Add a dropdown for selecting your preferred preview option
- [ ] Add preview state
- [ ] Update the editor content wrapper to allow for different viewport sizes and positions based on the current preview setting

# Testing

TBA