### PR TITLE
Disable 'publish' button when the page doesn't contain any submit buttons

### DIFF
--- a/apps/dashboard/src/components/editor/publish-button.js
+++ b/apps/dashboard/src/components/editor/publish-button.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { isEmpty } from 'lodash';
 
@@ -10,7 +11,6 @@ import { isEmpty } from 'lodash';
  */
 import { submitButtonBlock } from '@crowdsignal/block-editor';
 import { STORE_NAME } from '../../data';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { hasUnpublishedChanges } from '../../util/project';
 
 const includesSubmitButton = ( blocks ) => {
@@ -63,11 +63,9 @@ const PublishButton = ( { projectId } ) => {
 		} );
 	};
 
-	if ( ! isPublic || hasUnpublishedChanges( project ) ) {
+	if ( isPublic && ! hasUnpublishedChanges( project ) ) {
 		return null;
 	}
-
-	// Todo: add hover popover to explain a submit button is missing
 
 	return (
 		<Button

--- a/apps/dashboard/src/components/editor/publish-button.js
+++ b/apps/dashboard/src/components/editor/publish-button.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -12,7 +13,14 @@ import { submitButtonBlock } from '@crowdsignal/block-editor';
 import { STORE_NAME } from '../../data';
 import { hasUnpublishedChanges } from '../../util/project';
 
+/**
+ * Style dependencies
+ */
+import { PublishButtonNotice, ToolbarButton } from './styles/button';
+
 const PublishButton = ( { projectId } ) => {
+	const [ displayNotice, setDisplayNotice ] = useState( false );
+
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const [
@@ -43,21 +51,40 @@ const PublishButton = ( { projectId } ) => {
 		} );
 	};
 
+	const toggleNotice = () => setDisplayNotice( ! displayNotice );
+
+	const isMissingSubmitButton = currentPageSubmitButtonCount === 0;
+	const disabled = isSaving || isMissingSubmitButton;
+
 	if ( isPublic && ! hasUnpublishedChanges( project ) ) {
 		return null;
 	}
 
 	return (
-		<Button
+		<ToolbarButton
+			as={ Button }
 			className="is-crowdsignal"
 			variant={ isPublic ? 'tertiary' : 'primary' }
+			disabled={ disabled }
 			onClick={ publishProject }
-			disabled={ isSaving || currentPageSubmitButtonCount < 1 }
+			onMouseEnter={ toggleNotice }
+			onMouseLeave={ toggleNotice }
 		>
 			{ isPublic
 				? __( 'Update', 'dashboard' )
 				: __( 'Publish', 'dashboard' ) }
-		</Button>
+
+			{ displayNotice && isMissingSubmitButton && (
+				<Popover noArrow={ false }>
+					<PublishButtonNotice>
+						{ __(
+							'Please add a Submit Button to the current page in order to publish your project.',
+							'dashboard'
+						) }
+					</PublishButtonNotice>
+				</Popover>
+			) }
+		</ToolbarButton>
 	);
 };
 

--- a/apps/dashboard/src/components/editor/publish-button.js
+++ b/apps/dashboard/src/components/editor/publish-button.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { submitButtonBlock } from '@crowdsignal/block-editor';
+import { STORE_NAME } from '../../data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { hasUnpublishedChanges } from '../../util/project';
+
+const includesSubmitButton = ( blocks ) => {
+	for ( const block of blocks ) {
+		if ( block.name === submitButtonBlock.name ) {
+			return true;
+		}
+
+		if (
+			! isEmpty( block.innerBlocks ) &&
+			includesSubmitButton( block.innerBlocks )
+		) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const hasMissingSubmitButtons = ( project ) => {
+	for ( const page of project?.content?.draft?.pages ) {
+		if ( ! includesSubmitButton( page ) ) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const PublishButton = ( { projectId } ) => {
+	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
+
+	const [ project, isSaving, isPublic ] = useSelect( ( select ) => [
+		select( STORE_NAME ).getProject( projectId ),
+		select( STORE_NAME ).isProjectSaving(),
+		select( STORE_NAME ).isProjectPublic(),
+	] );
+
+	const publishProject = () => {
+		const payload = { public: true };
+		saveAndUpdateProject( projectId, {
+			...project,
+			content: {
+				...project.content,
+				public: {
+					...project.content.draft,
+				},
+			},
+			...payload,
+		} );
+	};
+
+	if ( ! isPublic || hasUnpublishedChanges( project ) ) {
+		return null;
+	}
+
+	// Todo: add hover popover to explain a submit button is missing
+
+	return (
+		<Button
+			className="is-crowdsignal"
+			variant={ isPublic ? 'tertiary' : 'primary' }
+			onClick={ publishProject }
+			disabled={ isSaving || hasMissingSubmitButtons( project ) }
+		>
+			{ isPublic
+				? __( 'Update', 'dashboard' )
+				: __( 'Publish', 'dashboard' ) }
+		</Button>
+	);
+};
+
+export default PublishButton;

--- a/apps/dashboard/src/components/editor/publish-button.js
+++ b/apps/dashboard/src/components/editor/publish-button.js
@@ -4,7 +4,6 @@
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,40 +12,21 @@ import { submitButtonBlock } from '@crowdsignal/block-editor';
 import { STORE_NAME } from '../../data';
 import { hasUnpublishedChanges } from '../../util/project';
 
-const includesSubmitButton = ( blocks ) => {
-	for ( const block of blocks ) {
-		if ( block.name === submitButtonBlock.name ) {
-			return true;
-		}
-
-		if (
-			! isEmpty( block.innerBlocks ) &&
-			includesSubmitButton( block.innerBlocks )
-		) {
-			return true;
-		}
-	}
-
-	return false;
-};
-
-const hasMissingSubmitButtons = ( project ) => {
-	for ( const page of project?.content?.draft?.pages ) {
-		if ( ! includesSubmitButton( page ) ) {
-			return true;
-		}
-	}
-
-	return false;
-};
-
 const PublishButton = ( { projectId } ) => {
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
-	const [ project, isSaving, isPublic ] = useSelect( ( select ) => [
+	const [
+		project,
+		isSaving,
+		isPublic,
+		currentPageSubmitButtonCount,
+	] = useSelect( ( select ) => [
 		select( STORE_NAME ).getProject( projectId ),
 		select( STORE_NAME ).isProjectSaving(),
 		select( STORE_NAME ).isProjectPublic(),
+		select( 'core/block-editor' ).getGlobalBlockCount(
+			submitButtonBlock.name
+		),
 	] );
 
 	const publishProject = () => {
@@ -72,7 +52,7 @@ const PublishButton = ( { projectId } ) => {
 			className="is-crowdsignal"
 			variant={ isPublic ? 'tertiary' : 'primary' }
 			onClick={ publishProject }
-			disabled={ isSaving || hasMissingSubmitButtons( project ) }
+			disabled={ isSaving || currentPageSubmitButtonCount < 1 }
 		>
 			{ isPublic
 				? __( 'Update', 'dashboard' )

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -73,10 +73,4 @@
 	&:last-child {
 		margin-right: 0;
 	}
-
-	&.is-crowdsignal {
-		--wp-admin-theme-color: var( --color-primary-50 );
-		--wp-admin-theme-color-darker-10: var( --color-primary-60 );
-		--wp-admin-theme-color-darker-20: var( --color-primary-70 );
-	}
 }

--- a/apps/dashboard/src/components/editor/styles/button.js
+++ b/apps/dashboard/src/components/editor/styles/button.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const ToolbarButton = styled.button`
+	--wp-admin-theme-color: var( --color-primary-50 );
+	--wp-admin-theme-color-darker-10: var( --color-primary-60 );
+	--wp-admin-theme-color-darker-20: var( --color-primary-70 );
+`;
+
+export const PublishButtonNotice = styled.span`
+	display: block;
+	padding: 8px 16px;
+	width: max-content;
+`;

--- a/apps/dashboard/src/components/editor/styles/button.js
+++ b/apps/dashboard/src/components/editor/styles/button.js
@@ -7,6 +7,10 @@ export const ToolbarButton = styled.button`
 	--wp-admin-theme-color: var( --color-primary-50 );
 	--wp-admin-theme-color-darker-10: var( --color-primary-60 );
 	--wp-admin-theme-color-darker-20: var( --color-primary-70 );
+
+	&:disabled:not( .is-primary ) {
+		background-color: transparent;
+	}
 `;
 
 export const PublishButtonNotice = styled.span`

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -2,15 +2,15 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line import/named
 
 /**
  * Internal dependencies
  */
+import PublishButton from './publish-button';
 import { STORE_NAME } from '../../data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { hasUnpublishedChanges } from '../../util/project';
 
 const Toolbar = ( { projectId } ) => {
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
@@ -28,20 +28,6 @@ const Toolbar = ( { projectId } ) => {
 		saveAndUpdateProject( projectId, {
 			...project,
 			public: false,
-		} );
-	};
-
-	const publishProject = () => {
-		const payload = { public: true };
-		saveAndUpdateProject( projectId, {
-			...project,
-			content: {
-				...project.content,
-				public: {
-					...project.content.draft,
-				},
-			},
-			...payload,
 		} );
 	};
 
@@ -93,18 +79,9 @@ const Toolbar = ( { projectId } ) => {
 			>
 				{ __( 'Preview', 'block-editor' ) }
 			</Button>
-			{ ( ! isPublic || hasUnpublishedChanges( project ) ) && (
-				<Button
-					className="is-crowdsignal"
-					variant={ isPublic ? 'tertiary' : 'primary' }
-					onClick={ publishProject }
-					disabled={ isSaving }
-				>
-					{ isPublic
-						? __( 'Update', 'dashboard' )
-						: __( 'Publish', 'dashboard' ) }
-				</Button>
-			) }
+
+			<PublishButton projectId={ projectId } />
+
 			{ isPublic && (
 				<Button
 					className="is-crowdsignal"

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -12,6 +12,11 @@ import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line impo
 import PublishButton from './publish-button';
 import { STORE_NAME } from '../../data';
 
+/**
+ * Style dependencies
+ */
+import { ToolbarButton } from './styles/button';
+
 const Toolbar = ( { projectId } ) => {
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
@@ -60,8 +65,8 @@ const Toolbar = ( { projectId } ) => {
 
 	return (
 		<ToolbarSlot className="block-editor__crowdsignal-toolbar">
-			<Button
-				className="is-crowdsignal"
+			<ToolbarButton
+				as={ Button }
 				variant="tertiary"
 				onClick={ syncProject }
 				disabled={ isSaving || isSaved }
@@ -69,28 +74,28 @@ const Toolbar = ( { projectId } ) => {
 				{ isSaved
 					? __( 'Draft saved', 'dashboard' )
 					: __( 'Save draft', 'dashboard' ) }
-			</Button>
-			<Button
-				className="is-crowdsignal"
+			</ToolbarButton>
+			<ToolbarButton
+				as={ Button }
 				variant="tertiary"
 				href={ `/project/${ projectId }/preview` }
 				target="_blank"
 				disabled={ ! projectId }
 			>
 				{ __( 'Preview', 'block-editor' ) }
-			</Button>
+			</ToolbarButton>
 
 			<PublishButton projectId={ projectId } />
 
 			{ isPublic && (
-				<Button
-					className="is-crowdsignal"
+				<ToolbarButton
+					as={ Button }
 					variant="primary"
 					onClick={ shareHandler }
 					disabled={ isSaving }
 				>
 					{ __( 'Share', 'block-editor' ) }
-				</Button>
+				</ToolbarButton>
 			) }
 		</ToolbarSlot>
 	);


### PR DESCRIPTION
This patch will disable the _publish_ button if the current page doesn't contain a submit button.  
When it's disabled, users can trigger a popover giving the necessary context by hovering over the button.

Solves c/aev5y2xb-tr.