### PR TITLE
Remove a duplicated import from the Editor component

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -16,7 +16,6 @@ import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
 import AutoSubmitButton from './auto-submit-button';
-import EditorLoadingPlaceholder from './loading-placeholder';
 import DocumentSettings from './document-settings';
 import EditorLoadingPlaceholder from './loading-placeholder';
 import Toolbar from './toolbar';


### PR DESCRIPTION
Small patch to remove a duplicated import on our `<Editor />` component which is a result of a recent rebase and is causing `yarn lint:js` to throw errors.  

# Testing

Run `yarn lint:js` and verify it doesn't throw any errors.