### PR TITLE
Enable block wide alignment

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -37,6 +37,10 @@ const editorSettings = {
 			toc: false,
 		},
 	},
+	editor: {
+		alignWide: true,
+		supportsLayout: false,
+	},
 };
 
 const Editor = ( { projectId } ) => {


### PR DESCRIPTION
This patch enables wide alignment inside of our editor. Part of c/QsghLr4q-tr.

# Testing

- Add a block that supports wide alignment. For example an image block.
- The alignment setting in the toolbar should now show additional "Wide" and "Full width" settings.
- Selecting the settings should be reflected in block's appearance - the image should now exceed the width of the content column.