### PR TITLE
Offer to restore unpublished changes (onload)

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -19,6 +19,7 @@ import AutoSubmitButton from './auto-submit-button';
 import DocumentSettings from './document-settings';
 import EditorLoadingPlaceholder from './loading-placeholder';
 import Toolbar from './toolbar';
+import { hasUnpublishedChanges } from '../../util/project';
 
 /**
  * Style dependencies
@@ -88,9 +89,18 @@ const Editor = ( { projectId } ) => {
 		[ projectId, project ]
 	);
 
-	const loadEditorContent = useCallback( () => displayedBlocks, [
-		displayedBlocks,
-	] );
+	const loadEditorContent = useCallback( () => {
+		if ( hasUnpublishedChanges( project ) ) {
+			// eslint-disable-next-line
+			const restore = window.confirm(
+				'You have unpublished changes for this project, do you want to restore the draft version?'
+			);
+			if ( restore ) {
+				return draftedBlocks;
+			}
+		}
+		return displayedBlocks;
+	}, [ displayedBlocks ] );
 
 	useStylesheet(
 		'https://app.crowdsignal.com/themes/leven/style-editor.css'


### PR DESCRIPTION
This PR adds a blunt window.confirm to restore unpublished changes upon loading a project.

The solution is a rough one, albeit effective, but it will serve until we put in place some more fancy prompt.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`. Visit http://crowdsignal.localhost:9000/project and add some content. Publish it.
Make some more changes, let it autosave or hit "Save draft" so you now have a newer draft version.
Reload the page. When the page loads, it will prompt you to restore the unpublished changes.
Hit "Ok" to restore. Hit "Cancel" to load the published version on the editor.
Reload as many times to check what happens by clicking "Ok"/"Cancel". Finally, hit "Update" button and reload again, the prompt should not show