### PR TITLE
Disable non-working core blocks

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
+import { parse } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { debounce, get, noop } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
-import { getCategories, parse, setCategories } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import { registerBlocks } from './blocks';
 import AutoSubmitButton from './auto-submit-button';
 import DocumentSettings from './document-settings';
 import EditorLoadingPlaceholder from './loading-placeholder';
+import { editorSettings } from './settings';
 import Toolbar from './toolbar';
 import { hasUnpublishedChanges } from '../../util/project';
 
@@ -25,32 +25,6 @@ import { hasUnpublishedChanges } from '../../util/project';
  * Style dependencies
  */
 import './style.scss';
-
-const editorSettings = {
-	iso: {
-		defaultPreferences: {
-			fixedToolbar: false,
-		},
-		toolbar: {
-			documentInspector: __( 'Document', 'dashboard' ),
-			inspector: true,
-			navigation: true,
-			toc: false,
-		},
-	},
-	editor: {
-		alignWide: true,
-		supportsLayout: false,
-	},
-};
-
-setCategories( [
-	{
-		title: __( 'Form', 'dashboard' ),
-		slug: 'crowdsignal-forms/form',
-	},
-	...getCategories(),
-] );
 
 const Editor = ( { projectId } ) => {
 	const [ project, isSaved ] = useSelect( ( select ) => {

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { getCategories, setCategories } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+setCategories( [
+	{
+		title: __( 'Form', 'dashboard' ),
+		slug: 'crowdsignal-forms/form',
+	},
+	...getCategories(),
+] );
+
+export const editorSettings = {
+	iso: {
+		blocks: {
+			disallowBlocks: [
+				'core/audio',
+				'core/calendar',
+				'core/cover',
+				'core/embed',
+				'core/file',
+				'core/media-text',
+				'core/shortcode',
+			],
+		},
+		defaultPreferences: {
+			fixedToolbar: false,
+		},
+		toolbar: {
+			documentInspector: __( 'Document', 'dashboard' ),
+			inspector: true,
+			navigation: true,
+			toc: false,
+		},
+	},
+	editor: {
+		alignWide: true,
+		supportsLayout: false,
+	},
+};


### PR DESCRIPTION
This patch disables some core blocks that currently don't work in our editor, to the point where it doesn't make sense to even keep them as an option. The complete list:

- core/audio
- core/calendar
- core/cover
- core/embed
- core/file
- core/media-text
- core/shortcode

Part of c/QsghLr4q-tr.

# Testing

Try adding any of the above blocks. They shouldn't be available in the inserter anymore.