### PR TITLE
Remove the Poll block

### DIFF
--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -10,8 +10,6 @@ import styled from '@emotion/styled';
 import {
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
-	Poll,
-	PollAnswer,
 	SubmitButton,
 	TextQuestion,
 	renderBlocks,
@@ -50,8 +48,6 @@ const FormPreview = ( { projectId } ) => {
 				{ renderBlocks( project.content.draft.pages[ 0 ], {
 					'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
 					'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
-					'crowdsignal-forms/poll': Poll,
-					'crowdsignal-forms/poll-answer': PollAnswer,
 					'crowdsignal-forms/submit-button': SubmitButton,
 					'crowdsignal-forms/text-question': TextQuestion,
 				} ) }

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -11,8 +11,6 @@ import styled from '@emotion/styled';
 import {
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
-	Poll,
-	PollAnswer,
 	SubmitButton,
 	TextQuestion,
 	renderBlocks,
@@ -107,8 +105,6 @@ const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
 						{ renderBlocks( content, {
 							'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
 							'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
-							'crowdsignal-forms/poll': Poll,
-							'crowdsignal-forms/poll-answer': PollAnswer,
 							'crowdsignal-forms/submit-button': SubmitButton,
 							'crowdsignal-forms/text-question': TextQuestion,
 						} ) }

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,6 +1,4 @@
 export { default as multipleChoiceAnswerBlock } from './multiple-choice-answer';
 export { default as multipleChoiceQuestionBlock } from './multiple-choice-question';
-export { default as pollBlock } from './poll';
-export { default as pollAnswerBlock } from './poll-answer';
 export { default as submitButtonBlock } from './submit-button';
 export { default as textQuestionBlock } from './text-question';


### PR DESCRIPTION
This PR removes the registration and initialization of the Poll block.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`. Go to crowdsignal.localhost:9000/project and attempt to add a Poll block, you shouldn't be able to do so.

@ice9js any other cleanup we need to do here? We might do good and get rid of the whole store/data in place, but not sure if you had plans for it