### PR TITLE
Fix MC answer blocks

### DIFF
--- a/packages/blocks/src/util.js
+++ b/packages/blocks/src/util.js
@@ -5,8 +5,6 @@
  * @return {string}           Block style
  */
 export const getBlockStyle = ( className ) => {
-	const styleClass =
-		className && className.match( /is-style-([^\s]+)/i )[ 1 ];
-
+	const styleClass = className && className.match( /is-style-([^\s]+)/i );
 	return styleClass ? styleClass[ 1 ] : '';
 };


### PR DESCRIPTION
This PR addresses a glitch happening on the MultipleChoiceAnswer blocks.

The glitch was introduced due to a condition/assignment typo:

```
const styleClass = className && className.match( /is-style-([^\s]+)/i )[ 1 ];
// changed to:
const styleClass = className && className.match( /is-style-([^\s]+)/i );
```

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`, create a project at http://crowdsignal.localhost:9000/project 
Add a MultipleChoice Question block.

- [ ] see that the answer options look ok

Add a couple of answer options (MultipleChoice Answer) and publish it. Copy the public URL by clicking on the "Share". Open a new tab, paste the URL and append `?use-project` 

- [ ] you should see the public version of the project
- [ ] MC answers should look ok