### PR TITLE
Create TextInput block

### DIFF
--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -11,6 +11,7 @@ import {
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	SubmitButton,
+	TextInput,
 	TextQuestion,
 	renderBlocks,
 } from '@crowdsignal/blocks';
@@ -49,6 +50,7 @@ const FormPreview = ( { projectId } ) => {
 					'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
 					'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
 					'crowdsignal-forms/submit-button': SubmitButton,
+					'crowdsignal-forms/text-input': TextInput,
 					'crowdsignal-forms/text-question': TextQuestion,
 				} ) }
 			</Form>

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -11,6 +11,7 @@ import {
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	SubmitButton,
+	TextInput,
 	TextQuestion,
 	renderBlocks,
 } from '@crowdsignal/blocks';
@@ -104,6 +105,7 @@ const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
 			'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
 			'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
 			'crowdsignal-forms/submit-button': SubmitButton,
+			'crowdsignal-forms/text-input': TextInput,
 			'crowdsignal-forms/text-question': TextQuestion,
 		} );
 

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,4 +1,5 @@
 export { default as multipleChoiceAnswerBlock } from './multiple-choice-answer';
 export { default as multipleChoiceQuestionBlock } from './multiple-choice-question';
 export { default as submitButtonBlock } from './submit-button';
+export { default as textInputBlock } from './text-input';
 export { default as textQuestionBlock } from './text-question';

--- a/packages/block-editor/src/text-input/attributes.js
+++ b/packages/block-editor/src/text-input/attributes.js
@@ -7,25 +7,11 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	labelColor: {
-		type: 'string',
-	},
 	textColor: {
 		type: 'string',
 	},
 	backgroundColor: {
 		type: 'string',
-	},
-	borderColor: {
-		type: 'string',
-	},
-	borderWidth: {
-		type: 'number',
-		default: 2,
-	},
-	borderRadius: {
-		type: 'number',
-		default: 0,
 	},
 	inputHeight: {
 		type: 'number',

--- a/packages/block-editor/src/text-input/attributes.js
+++ b/packages/block-editor/src/text-input/attributes.js
@@ -15,10 +15,10 @@ export default {
 	},
 	inputHeight: {
 		type: 'number',
-		default: 30,
+		default: 40,
 	},
-	width: {
-		type: 'number',
-		default: 100,
+	inputWidth: {
+		type: 'string',
+		default: '100%',
 	},
 };

--- a/packages/block-editor/src/text-input/attributes.js
+++ b/packages/block-editor/src/text-input/attributes.js
@@ -1,0 +1,38 @@
+export default {
+	label: {
+		type: 'string',
+		default: '',
+	},
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
+	labelColor: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderWidth: {
+		type: 'number',
+		default: 2,
+	},
+	borderRadius: {
+		type: 'number',
+		default: 0,
+	},
+	inputHeight: {
+		type: 'number',
+		default: 30,
+	},
+	width: {
+		type: 'number',
+		default: 100,
+	},
+};

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -24,7 +24,7 @@ const EditTextInput = ( props ) => {
 				onChange={ handleChangeLabel }
 				value={ attributes.label }
 			/>
-			<FormTextInput
+			<FormTextInput.Preview
 				style={ {
 					width: `${ attributes.width }%`,
 					height: `${ attributes.inputHeight }px`,

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { ResizableBox } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,9 +13,20 @@ import { useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
 
 const EditTextInput = ( props ) => {
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, isSelected } = props;
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	const handleResizeInput = ( event, handle, element ) => {
+		if ( handle !== 'bottom' && handle !== 'right' ) {
+			return;
+		}
+
+		setAttributes( {
+			inputHeight: element.offsetHeight,
+			inputWidth: `${ element.offsetWidth }px`,
+		} );
+	};
 
 	return (
 		<div style={ { ...useColorStyles( attributes ) } }>
@@ -24,12 +36,18 @@ const EditTextInput = ( props ) => {
 				onChange={ handleChangeLabel }
 				value={ attributes.label }
 			/>
-			<FormTextInput.Preview
-				style={ {
-					width: `${ attributes.width }%`,
+			<ResizableBox
+				minHeight="40px"
+				showHandle={ isSelected }
+				enable={ { bottom: true, right: true } }
+				onResizeStop={ handleResizeInput }
+				size={ {
+					width: attributes.inputWidth,
 					height: `${ attributes.inputHeight }px`,
 				} }
-			/>
+			>
+				<FormTextInput.Preview />
+			</ResizableBox>
 		</div>
 	);
 };

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -11,7 +11,7 @@ import { FormTextInput } from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
 
-const TextInput = ( props ) => {
+const EditTextInput = ( props ) => {
 	const { attributes, setAttributes } = props;
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
@@ -20,7 +20,7 @@ const TextInput = ( props ) => {
 		<div style={ { ...useColorStyles( attributes ) } }>
 			<Sidebar { ...props } />
 			<RichText
-				placeholder={ __( 'Enter form label', 'blocks' ) }
+				placeholder={ __( 'Enter form label', 'block-editor' ) }
 				onChange={ handleChangeLabel }
 				value={ attributes.label }
 			/>
@@ -34,4 +34,4 @@ const TextInput = ( props ) => {
 	);
 };
 
-export default TextInput;
+export default EditTextInput;

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { FormTextInput } from '@crowdsignal/blocks';
+import { useColorStyles } from '@crowdsignal/styles';
+import Sidebar from './sidebar';
+
+const TextInput = ( props ) => {
+	const { attributes, setAttributes } = props;
+
+	const handleChangeLabel = ( label ) => setAttributes( { label } );
+
+	return (
+		<div style={ { ...useColorStyles( attributes ) } }>
+			<Sidebar { ...props } />
+			<RichText
+				placeholder={ __( 'Enter form label', 'blocks' ) }
+				onChange={ handleChangeLabel }
+				value={ attributes.label }
+			/>
+			<FormTextInput
+				style={ {
+					width: `${ attributes.width }%`,
+					height: `${ attributes.inputHeight }px`,
+				} }
+			/>
+		</div>
+	);
+};
+
+export default TextInput;

--- a/packages/block-editor/src/text-input/index.js
+++ b/packages/block-editor/src/text-input/index.js
@@ -14,8 +14,11 @@ const name = 'crowdsignal-forms/text-input';
 
 const settings = {
 	apiVersion: 1,
-	title: __( 'Text Input Form', 'blocks' ),
-	description: __( 'An input field with a label for your form.', 'blocks' ),
+	title: __( 'Text Input Form', 'block-editor' ),
+	description: __(
+		'An input field with a label for your form.',
+		'block-editor'
+	),
 	category: 'crowdsignal-forms/form',
 	icon: <TextInputIcon />,
 	edit: Edit,

--- a/packages/block-editor/src/text-input/index.js
+++ b/packages/block-editor/src/text-input/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { TextInputIcon } from '@crowdsignal/icons';
+import attributes from './attributes';
+import Edit from './edit';
+
+const name = 'crowdsignal-forms/text-input';
+
+const settings = {
+	apiVersion: 1,
+	title: __( 'Text Input Form', 'blocks' ),
+	description: __( 'An input field with a label for your form.', 'blocks' ),
+	category: 'crowdsignal-forms/form',
+	icon: <TextInputIcon />,
+	edit: Edit,
+	attributes,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/packages/block-editor/src/text-input/sidebar.js
+++ b/packages/block-editor/src/text-input/sidebar.js
@@ -19,7 +19,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import ColorSettings from '../components/color-settings';
 
 export default ( { attributes, setAttributes } ) => {
-	const widthOptions = [ 25, 50, 75, 100 ];
+	const widthOptions = [ '25%', '50%', '75%', '100%' ];
 
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
@@ -48,14 +48,14 @@ export default ( { attributes, setAttributes } ) => {
 				/>
 				<ToggleGroupControl
 					label={ __( 'Field Width', 'block-editor' ) }
-					value={ attributes.width }
-					onChange={ handleChangeAttribute( 'width' ) }
+					value={ attributes.inputWidth }
+					onChange={ handleChangeAttribute( 'inputWidth' ) }
 				>
 					{ widthOptions.map( ( option ) => (
 						<ToggleGroupControlOption
 							key={ option }
 							value={ option }
-							label={ `${ option }%` }
+							label={ option }
 						/>
 					) ) }
 				</ToggleGroupControl>

--- a/packages/block-editor/src/text-input/sidebar.js
+++ b/packages/block-editor/src/text-input/sidebar.js
@@ -26,27 +26,30 @@ export default ( { attributes, setAttributes } ) => {
 			[ key ]: value,
 		} );
 
+	const handleChangeNumericAttribute = ( key ) => ( value ) =>
+		handleChangeAttribute( key )( parseInt( value ) );
+
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Field Settings', 'blocks' ) }
+				title={ __( 'Field Settings', 'block-editor' ) }
 				initialOpen={ true }
 			>
 				<ToggleControl
-					label={ __( 'The field is required' ) }
+					label={ __( 'The field is required', 'block-editor' ) }
 					checked={ attributes.mandatory }
 					onChange={ handleChangeAttribute( 'mandatory' ) }
 				/>
 				<TextControl
-					label="Input field height"
+					label={ __( 'Input field height', 'block-editor' ) }
 					type="number"
 					value={ attributes.inputHeight }
-					onChange={ handleChangeAttribute( 'inputHeight' ) }
+					onChange={ handleChangeNumericAttribute( 'inputHeight' ) }
 				/>
 				<ToggleGroupControl
-					onChange={ handleChangeAttribute( 'width' ) }
+					label={ __( 'Field Width', 'block-editor' ) }
 					value={ attributes.width }
-					label={ __( 'Field Width' ) }
+					onChange={ handleChangeAttribute( 'width' ) }
 				>
 					{ widthOptions.map( ( option ) => (
 						<ToggleGroupControlOption

--- a/packages/block-editor/src/text-input/sidebar.js
+++ b/packages/block-editor/src/text-input/sidebar.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import {
+	// eslint-disable-next-line
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	PanelBody,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import ColorSettings from '../components/color-settings';
+
+export default ( { attributes, setAttributes } ) => {
+	const widthOptions = [ 25, 50, 75, 100 ];
+
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Field Settings', 'blocks' ) }
+				initialOpen={ true }
+			>
+				<ToggleControl
+					label={ __( 'The field is required' ) }
+					checked={ attributes.mandatory }
+					onChange={ handleChangeAttribute( 'mandatory' ) }
+				/>
+				<TextControl
+					label="Input field height"
+					type="number"
+					value={ attributes.inputHeight }
+					onChange={ handleChangeAttribute( 'inputHeight' ) }
+				/>
+				<ToggleGroupControl
+					onChange={ handleChangeAttribute( 'width' ) }
+					value={ attributes.width }
+					label={ __( 'Field Width' ) }
+				>
+					{ widthOptions.map( ( option ) => (
+						<ToggleGroupControlOption
+							key={ option }
+							value={ option }
+							label={ `${ option }%` }
+						/>
+					) ) }
+				</ToggleGroupControl>
+			</PanelBody>
+			<ColorSettings
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</InspectorControls>
+	);
+};

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -3,22 +3,32 @@
  */
 import styled from '@emotion/styled';
 
-const FormTextInputWrapper = styled.div`
-	pointer-events: none;
+const FormTextInputWapper = styled.div(
+	{
+		width: '100%',
+		height: '100%',
+	},
+	( props ) => ( {
+		pointerEvents: props.isPreview && 'none',
+	} )
+);
+
+const Input = styled.input`
+	width: 100%;
+	height: 100%;
+	min-height: 40px;
 `;
 
-const FormTextInput = ( { className, ...props } ) => {
+const FormTextInput = ( { className, isPreview, ...props } ) => {
 	return (
-		<div className={ className }>
-			<input type="text" { ...props } />
-		</div>
+		<FormTextInputWapper className={ className } isPreview={ isPreview }>
+			<Input type="text" { ...props } />
+		</FormTextInputWapper>
 	);
 };
 
 FormTextInput.Preview = ( props ) => (
-	<FormTextInputWrapper>
-		<FormTextInput { ...props } />
-	</FormTextInputWrapper>
+	<FormTextInput isPreview={ true } { ...props } />
 );
 
 export default FormTextInput;

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -3,32 +3,29 @@
  */
 import styled from '@emotion/styled';
 
-const FormTextInputWapper = styled.div(
-	{
-		width: '100%',
-		height: '100%',
-	},
-	( props ) => ( {
-		pointerEvents: props.isPreview && 'none',
-	} )
-);
-
-const Input = styled.input`
+const FormTextInputWapper = styled.div`
 	width: 100%;
 	height: 100%;
-	min-height: 40px;
+	pointer-events: none;
 `;
 
-const FormTextInput = ( { className, isPreview, ...props } ) => {
-	return (
-		<FormTextInputWapper className={ className } isPreview={ isPreview }>
-			<Input type="text" { ...props } />
-		</FormTextInputWapper>
-	);
-};
+const FormTextInput = ( { style = {}, ...props } ) => (
+	<input
+		type="text"
+		style={ {
+			width: '100%',
+			height: '100%',
+			minHeight: '40px',
+			...style,
+		} }
+		{ ...props }
+	/>
+);
 
-FormTextInput.Preview = ( props ) => (
-	<FormTextInput isPreview={ true } { ...props } />
+FormTextInput.Preview = ( { className, ...props } ) => (
+	<FormTextInputWapper className={ className }>
+		<FormTextInput { ...props } />
+	</FormTextInputWapper>
 );
 
 export default FormTextInput;

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -1,3 +1,12 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+const FormTextInputWrapper = styled.div`
+	pointer-events: none;
+`;
+
 const FormTextInput = ( { className, ...props } ) => {
 	return (
 		<div className={ className }>
@@ -5,5 +14,11 @@ const FormTextInput = ( { className, ...props } ) => {
 		</div>
 	);
 };
+
+FormTextInput.Preview = ( props ) => (
+	<FormTextInputWrapper>
+		<FormTextInput { ...props } />
+	</FormTextInputWrapper>
+);
 
 export default FormTextInput;

--- a/packages/blocks/src/components/index.js
+++ b/packages/blocks/src/components/index.js
@@ -1,5 +1,6 @@
 export { default as Button } from './button';
 export { default as FormCheckbox } from './form-checkbox';
 export { default as FormTextarea } from './form-textarea';
+export { default as FormTextInput } from './form-text-input';
 export { default as QuestionHeader } from './question-header';
 export { default as QuestionWrapper } from './question-wrapper';

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -5,6 +5,7 @@ export { default as MultipleChoiceQuestion } from './multiple-choice-question';
 export { default as Poll } from './poll';
 export { default as PollAnswer } from './poll-answer';
 export { default as SubmitButton } from './submit-button';
+export { default as TextInput } from './text-input';
 export { default as TextQuestion } from './text-question';
 
 export { renderBlocks } from './render-blocks';

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useColorStyles } from '@crowdsignal/styles';
+import { FormTextInput } from '../components';
+
+const TextInput = ( { attributes } ) => {
+	return (
+		<div style={ { ...useColorStyles( attributes ) } }>
+			<RichText.Content value={ attributes.label } />
+			<FormTextInput
+				style={ {
+					width: `${ attributes.width }%`,
+					height: `${ attributes.inputHeight }px`,
+				} }
+			/>
+		</div>
+	);
+};
+
+export default TextInput;

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -15,7 +15,7 @@ const TextInput = ( { attributes } ) => {
 			<RichText.Content value={ attributes.label } />
 			<FormTextInput
 				style={ {
-					width: `${ attributes.width }%`,
+					width: attributes.inputWidth,
 					height: `${ attributes.inputHeight }px`,
 				} }
 			/>

--- a/packages/icons/src/text-input.js
+++ b/packages/icons/src/text-input.js
@@ -1,4 +1,4 @@
-export const TextInput = () => (
+export const TextInputIcon = () => (
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
 		width="24"


### PR DESCRIPTION
## Description

This PR is to create a new block (Text Input) that will be used, mainly, to create forms like contact, address, etc.

Ref: c/pTOrFn0d-tr

### Reference Image
![image](https://user-images.githubusercontent.com/7811225/143492852-a7258554-1334-4e6c-8f22-9c1b8b9f78d2.png)

## Test Instructions

* Go to the project editor (`project/:projectId`)
* Click the plus button to add a new block and search for `Text Input`, or type `/text input`
* You should be able to add the new block to the page and play with its settings