### PR TITLE
Implement the project results view

### DIFF
--- a/apps/dashboard/src/components/iframe/index.js
+++ b/apps/dashboard/src/components/iframe/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { uniqueId } from 'lodash';
+
+const IFrame = ( { title = uniqueId(), ...props } ) => {
+	const [ frameHeight, setFrameHeight ] = useState( 0 );
+
+	const frame = useRef();
+
+	useEffect( () => {
+		frame.current.addEventListener( 'load', () => {
+			setFrameHeight( frame.current.contentDocument.body.scrollHeight );
+		} );
+	}, [] );
+
+	return (
+		<iframe
+			ref={ frame }
+			frameBorder="0"
+			height={ `${ frameHeight }px` }
+			scrolling="no"
+			title={ title }
+			{ ...props }
+		/>
+	);
+};
+
+export default IFrame;

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -49,7 +49,7 @@ const ProjectNavigation = ( { activeTab, projectId } ) => {
 				</TabNavigation.Tab>
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.RESULTS }
-					href={ `/edit/poll/${ projectId }/results` }
+					href={ `/project/${ projectId }/results` }
 				>
 					{ __( 'Results', 'dashboard' ) }
 				</TabNavigation.Tab>

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -43,7 +43,7 @@ const ProjectNavigation = ( { activeTab, projectId } ) => {
 			<TabNavigation>
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.EDITOR }
-					href={ `/edit/poll/${ projectId }` }
+					href={ `/project/${ projectId }` }
 				>
 					{ __( 'Editor', 'dashboard' ) }
 				</TabNavigation.Tab>

--- a/apps/dashboard/src/components/results/index.js
+++ b/apps/dashboard/src/components/results/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import IFrame from '../iframe';
 import ProjectNavigation from '../project-navigation';
 
 const Results = ( { projectId } ) => {
@@ -10,7 +11,11 @@ const Results = ( { projectId } ) => {
 				activeTab={ ProjectNavigation.Tab.RESULTS }
 				projectId={ projectId }
 			/>
-			Results
+
+			<IFrame
+				src={ `/surveys/${ projectId }/report/overview` }
+				width="100%"
+			/>
 		</div>
 	);
 };

--- a/apps/dashboard/webpack.config.js
+++ b/apps/dashboard/webpack.config.js
@@ -43,6 +43,13 @@ function getWebpackConfig( env, { entry, ...argv } ) {
 			host: 'crowdsignal.localhost',
 			https: true,
 			port: 9000,
+			proxy: {
+				'/surveys': {
+					changeOrigin: true,
+					secure: false,
+					target: 'https://app.crowdsignal.com',
+				},
+			},
 			historyApiFallback: true,
 		},
 	};


### PR DESCRIPTION
This patch updates the project results view to feature an iframe which will be used to display current Crowdsignal survey results pages until we reimplement them as part of the SPA.

Solves c/Ks05yCWT-tr.

# Testing

Go to `/project/:projectId/results` to see the iframe.

I set up a proxy on the webpack dev server which will allow the iframe to load locally, but it will currently always be in an unauthenticated state due to missing cookies.

See d70582-code for testing instructions on the platform.