### PR TITLE
List optional chaining plugin explicitly in babel config

### DIFF
--- a/apps/dashboard/babel.config.js
+++ b/apps/dashboard/babel.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	],
 	plugins: [
 		'@babel/plugin-transform-runtime',
+		'@babel/plugin-proposal-optional-chaining',
 		'@wordpress/babel-plugin-import-jsx-pragma',
 		'babel-plugin-emotion',
 	],


### PR DESCRIPTION
I have recently been suffering from seemingly random errors thrown by webpack when building the app - after some investigation, it looks like they're related to the use of the optional chaining operator (`.?`) across our app.

Adding `@babel/plugin-proposal-optional-chaining` to the list of babel plugins explicitly fixes these issues.

# Testing

Test that `yarn workspace @crowdsignal/dashboard start` still builds correctly.