### PR TITLE
Implement a HeaderMeta component

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -34,7 +34,8 @@
     "@wordpress/i18n": "^4.2.4",
     "classnames": "^2.2.5",
     "isolated-block-editor": "git://github.com/Automattic/isolated-block-editor.git#a1fa71448efddd02ed645939d284fbe81dfe13a2",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.11.2"

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -4,6 +4,7 @@
 import { parse } from '@wordpress/blocks';
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { debounce, get, noop } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
 
@@ -11,6 +12,7 @@ import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line 
  * Internal dependencies
  */
 import { useStylesheet } from '@crowdsignal/hooks';
+import HeaderMeta from '../header-meta';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import { registerBlocks } from './blocks';
@@ -104,11 +106,18 @@ const Editor = ( { projectId } ) => {
 
 	if ( projectId && null === project ) {
 		// project is being loaded
-		return <EditorLoadingPlaceholder />;
+		return (
+			<>
+				<HeaderMeta title={ __( 'Edit Project', 'dashboard' ) } />
+				<EditorLoadingPlaceholder />
+			</>
+		);
 	}
 
 	return (
 		<div className="editor">
+			<HeaderMeta title={ __( 'Edit Project', 'dashboard' ) } />
+
 			<ProjectNavigation
 				activeTab={ ProjectNavigation.Tab.EDITOR }
 				projectId={ projectId }

--- a/apps/dashboard/src/components/header-meta/index.js
+++ b/apps/dashboard/src/components/header-meta/index.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { Helmet } from 'react-helmet';
+
+const HeaderMeta = ( { title } ) => (
+	<Helmet>
+		<title>{ `${ title } | Crowdsignal` }</title>
+	</Helmet>
+);
+
+export default HeaderMeta;

--- a/apps/dashboard/src/components/results/index.js
+++ b/apps/dashboard/src/components/results/index.js
@@ -1,12 +1,20 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import IFrame from '../iframe';
+import HeaderMeta from '../header-meta';
 import ProjectNavigation from '../project-navigation';
 
 const Results = ( { projectId } ) => {
 	return (
 		<div className="results">
+			<HeaderMeta title={ __( `Project Results`, 'dashboard' ) } />
+
 			<ProjectNavigation
 				activeTab={ ProjectNavigation.Tab.RESULTS }
 				projectId={ projectId }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17379,7 +17379,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -17394,6 +17394,16 @@ react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
@@ -17461,6 +17471,11 @@ react-resize-aware@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.1.0.tgz#fa1da751d1d72f90c3b79969d05c2c577dfabd92"
   integrity sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-sizeme@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
We currently don't have a way to control the page header (`<head>`) from within our application which is slightly less than ideal.  

To help with this, I've implemented a `HeaderMeta` component that is powered by `react-helmet` under the hood. For now it just accepts a single `title` prop and updates the page title accordingly.

It's worth noting that the way `react-helmet` works, if let's say there are multiple nested views where each might want to affect the title, it'll take the data from the last/deepest one which in theory would be the most specific. So that's nice.

# Testing

Verify the title is set correctly for the editor and results views. It should be `Edit Project | Crowdsignal` and `Project Results | Crowdsignal` respectively.