### PR TITLE
Fix block alignment on preview and inside the project renderer

### DIFF
--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -59,6 +59,11 @@ html.interface-interface-skeleton__html-container {
 		position: relative;
 	}
 
+	.block-editor-block-list__layout.is-root-container {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
 	.components-panel__header.edit-post-sidebar__panel-tabs ul {
 			padding: 0
 	}

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -98,6 +98,14 @@ html.interface-interface-skeleton__html-container {
 			margin: 0;
 		}
 	}
+
+	& :where(.wp-block)[data-align=right] > * {
+		float: right;
+	}
+
+	& :where(.wp-block)[data-align=left] > * {
+		float: left;
+	}
 }
 
 .iso-sidebar {

--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
  */
 import {
+	ContentWrapper,
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	SubmitButton,
@@ -18,14 +18,6 @@ import {
 import { Form } from '@crowdsignal/form';
 import { useStylesheet } from '@crowdsignal/hooks';
 import { STORE_NAME } from '../../data';
-
-const ContentWrapper = styled.div`
-	box-sizing: border-box;
-	margin: 0 auto;
-	max-width: 720px;
-	padding: 20px;
-	width: 100%;
-`;
 
 const FormPreview = ( { projectId } ) => {
 	const project = useSelect( ( select ) =>
@@ -45,8 +37,12 @@ const FormPreview = ( { projectId } ) => {
 	const handleSubmit = ( data ) => console.log( data );
 
 	return (
-		<ContentWrapper>
-			<Form name={ `f-${ projectId }` } onSubmit={ handleSubmit }>
+		<Form
+			name={ `f-${ projectId }` }
+			onSubmit={ handleSubmit }
+			className="project-content"
+		>
+			<ContentWrapper>
 				{ renderBlocks( project.content.draft.pages[ 0 ], {
 					'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
 					'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
@@ -54,8 +50,8 @@ const FormPreview = ( { projectId } ) => {
 					'crowdsignal-forms/text-input': TextInput,
 					'crowdsignal-forms/text-question': TextQuestion,
 				} ) }
-			</Form>
-		</ContentWrapper>
+			</ContentWrapper>
+		</Form>
 	);
 };
 

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import styled from '@emotion/styled';
 
 /**
  * Internal dependencies
  */
 import {
+	ContentWrapper,
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	SubmitButton,
@@ -20,14 +20,10 @@ import { useStylesheet } from '@crowdsignal/hooks';
 import { setHostOption } from '@crowdsignal/http';
 import { fetchProjectForm } from '@crowdsignal/rest-api';
 
+/**
+ * Style dependencies
+ */
 import './style.scss';
-
-// TODO: this is just to make the render look good, selected theme should take care of this?
-const ContentWrapper = styled.div`
-	margin: 0 auto;
-	max-width: 720px;
-	padding: 20px;
-`;
 
 const App = ( {
 	projectCode,
@@ -128,21 +124,14 @@ const App = ( {
 			'crowdsignal-forms/text-question': TextQuestion,
 		} );
 
-	return (
-		<div className="app">
-			<ContentWrapper>
-				{ ! hasResponded && (
-					<Form
-						name={ `f-${ projectCode }` }
-						onSubmit={ handleSubmit }
-					>
-						{ renderContent() }
-					</Form>
-				) }
+	if ( hasResponded ) {
+		return <ContentWrapper>{ renderContent() }</ContentWrapper>;
+	}
 
-				{ hasResponded && renderContent() }
-			</ContentWrapper>
-		</div>
+	return (
+		<Form name={ `f-${ projectCode }` } onSubmit={ handleSubmit }>
+			<ContentWrapper>{ renderContent() }</ContentWrapper>
+		</Form>
 	);
 };
 

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import { useColorStyles } from '@crowdsignal/styles';
 
 const StyledButtonWrapper = styled.div`
-	display: flex;
+	display: block;
 `;
 
 const StyledButton = styled.button`

--- a/packages/blocks/src/components/content-wrapper/index.js
+++ b/packages/blocks/src/components/content-wrapper/index.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+const ContentWrapper = styled.div`
+	box-sizing: border-box;
+	margin: 0;
+	width: 100%;
+
+	&
+		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .wp-block-separator ):not( .entry-attachment ),
+	&
+		[class*='inner-container']
+		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .wp-block-separator ) {
+		max-width: 720px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	& > .alignwide,
+	& > .wp-block-image.alignwide {
+		max-width: 1080px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+`;
+
+export default ContentWrapper;

--- a/packages/blocks/src/components/index.js
+++ b/packages/blocks/src/components/index.js
@@ -1,4 +1,5 @@
 export { default as Button } from './button';
+export { default as ContentWrapper } from './content-wrapper';
 export { default as FormCheckbox } from './form-checkbox';
 export { default as FormTextarea } from './form-textarea';
 export { default as FormTextInput } from './form-text-input';


### PR DESCRIPTION
This patch fixes the issues with alignment settings having no effect inside the preview or the project renderer.

Solves c/H3p0CZCg-tr.

# Testing

- Add some blocks with alignment options, for example image blocks.
- Verify the alignment settings selected inside the editor are also reflected in the preview or the project renderer.