### PR TITLE
Disable nav buttons when project is still unsaved

### DIFF
--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -44,11 +44,13 @@ const ProjectNavigation = ( { activeTab, projectId } ) => {
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.EDITOR }
 					href={ `/project/${ projectId }` }
+					isDisabled={ ! projectId }
 				>
 					{ __( 'Editor', 'dashboard' ) }
 				</TabNavigation.Tab>
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.RESULTS }
+					isDisabled={ ! projectId }
 					href={ `/project/${ projectId }/results` }
 				>
 					{ __( 'Results', 'dashboard' ) }

--- a/packages/components/src/tab-navigation/style.scss
+++ b/packages/components/src/tab-navigation/style.scss
@@ -47,4 +47,8 @@
 		border-color: var(--color-neutral-70);
 		font-weight: bold;
 	}
+
+	.tab-navigation__item.is-disabled & {
+		pointer-events: none;
+	}
 }

--- a/packages/components/src/tab-navigation/tab.js
+++ b/packages/components/src/tab-navigation/tab.js
@@ -3,11 +3,12 @@
  */
 import classnames from 'classnames';
 
-const Tab = ( { children, href, isSelected, ...props } ) => {
+const Tab = ( { children, href, isSelected, isDisabled, ...props } ) => {
 	const ButtonComponent = href ? 'a' : 'button';
 
 	const classes = classnames( 'tab-navigation__item', {
 		'is-selected': isSelected,
+		'is-disabled': isDisabled,
 	} );
 
 	return (


### PR DESCRIPTION
This PR adds a class/prop combo to disable nav buttons.

The prop `isDisabled` will trigger the class `is-disabled` which sets `pointer-events: none` to the element.

## Test instructions
Checkout and run `yarn workspace @crowdsignal/dashboard start`. Open http://crowdsignal.localhost:9000/project

* see that both "Editor" and "Results" tab buttons don't work while the project is not saved
* make some changes and let the project save (or hit "Save draft"/"Publish")
* see that now the nav buttons work