### PR TITLE
Inject a nonce into requests to api.crowdsignal.com when present

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -24,6 +24,7 @@
     "@crowdsignal/components": "^0.1.0",
     "@crowdsignal/form": "^0.1.0",
     "@crowdsignal/hooks": "^0.1.0",
+    "@crowdsignal/http": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
     "@wordpress/blocks": "^11.1.1",

--- a/apps/dashboard/src/index.js
+++ b/apps/dashboard/src/index.js
@@ -7,6 +7,7 @@ import { render } from '@wordpress/element';
  * Internal dependencies
  */
 import { StyleProvider } from '@crowdsignal/components';
+import { setHostHeader } from '@crowdsignal/http';
 import App from './components/app';
 
 const renderApp = () =>
@@ -18,4 +19,14 @@ const renderApp = () =>
 	);
 
 // eslint-disable-next-line @wordpress/no-global-event-listener
-window.addEventListener( 'load', renderApp );
+window.addEventListener( 'load', () => {
+	if ( document.body.dataset.ajaxNonce ) {
+		setHostHeader(
+			'https://api.crowdsignal.com',
+			'x-ajax-api-token',
+			document.body.dataset.ajaxNonce
+		);
+	}
+
+	renderApp();
+} );


### PR DESCRIPTION
This patch adds some compatibility code to append a nonce to any requests to `api.crowdsignal.com` if one is present on `document.body`.  
This enables the application to be used outside of the local development environment with appropriate security measures in place.

# Testing

To see if the code works, modify `dashboard/public/index.html` with the following body tag:

```
<body data-ajax-nonce="foo">
```

When you refresh the page, you should notice requests going out to `api.crowdsignal.com` now have an `x-ajax-api-token: foo` header attached to them.