### PR TITLE
Implement a theme compatibility layer

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -94,6 +94,7 @@ const Editor = ( { projectId } ) => {
 		'https://app.crowdsignal.com/themes/leven/style-editor.css'
 	);
 	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );
+	useStylesheet( '/ui/stable/theme-compatibility/leven-editor.min.css' );
 
 	const handleChangeContent = useCallback(
 		( content ) => {

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -93,6 +93,7 @@ const Editor = ( { projectId } ) => {
 	useStylesheet(
 		'https://app.crowdsignal.com/themes/leven/style-editor.css'
 	);
+	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );
 
 	const handleChangeContent = useCallback(
 		( content ) => {

--- a/apps/dashboard/src/components/form-preview/index.js
+++ b/apps/dashboard/src/components/form-preview/index.js
@@ -35,6 +35,7 @@ const FormPreview = ( { projectId } ) => {
 	useStylesheet(
 		'https://app.crowdsignal.com/themes/leven/style-editor.css'
 	);
+	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );
 
 	if ( ! project?.content?.draft ) {
 		return null;

--- a/apps/dashboard/webpack.config.js
+++ b/apps/dashboard/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const express = require( 'express' );
 const webpack = require( 'webpack' );
 const package = require( './package.json' );
 const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
@@ -49,6 +50,14 @@ function getWebpackConfig( env, { entry, ...argv } ) {
 					secure: false,
 					target: 'https://app.crowdsignal.com',
 				},
+			},
+			before: ( app ) => {
+				app.use(
+					'/ui/stable/theme-compatibility',
+					express.static(
+						path.resolve( __dirname, '../../packages/theme-compatibility/dist' )
+					)
+				);
 			},
 			historyApiFallback: true,
 		},

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -54,6 +54,7 @@ const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
 	}, [ projectCode ] );
 
 	useStylesheet( 'https://app.crowdsignal.com/themes/leven/style.css' );
+	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );
 
 	const handleSubmit = ( data ) => {
 		if ( ! data ) {

--- a/apps/project-renderer/webpack.config.js
+++ b/apps/project-renderer/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const express = require( 'express' );
 const webpack = require( 'webpack' );
 const package = require( './package.json' );
 const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
@@ -43,6 +44,14 @@ function getWebpackConfig( env, { entry, ...argv } ) {
 			host: 'crowdsignal.localhost',
 			https: true,
 			port: 9001,
+			before: ( app ) => {
+				app.use(
+					'/ui/stable/theme-compatibility',
+					express.static(
+						path.resolve( __dirname, '../../packages/theme-compatibility/dist' )
+					)
+				);
+			},
 			historyApiFallback: true,
 		},
 	};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "redux": "^4.1.1",
     "sass-loader": "^11.1.1",
     "typescript": "^4.3.5",
-    "webpack": "^5.46.0"
+    "webpack": "^5.46.0",
+    "webpack-fix-style-only-entries": "^0.6.1"
   },
   "scripts": {
     "check-licenses": "wp-scripts check-licenses --prod --gpl2",

--- a/packages/block-editor/src/multiple-choice-question/edit.js
+++ b/packages/block-editor/src/multiple-choice-question/edit.js
@@ -30,9 +30,13 @@ const EditMultipleChoiceQuestion = ( props ) => {
 
 	const handleChangeQuestion = ( question ) => setAttributes( { question } );
 
-	const classes = classnames( className, {
-		'is-required': attributes.mandatory,
-	} );
+	const classes = classnames(
+		'crowdsignal-forms-multiple-choice-question-block',
+		className,
+		{
+			'is-required': attributes.mandatory,
+		}
+	);
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ classes }>

--- a/packages/block-editor/src/multiple-choice-question/edit.js
+++ b/packages/block-editor/src/multiple-choice-question/edit.js
@@ -49,24 +49,21 @@ const EditMultipleChoiceQuestion = ( props ) => {
 				onChange={ handleChangeQuestion }
 				value={ attributes.question }
 			/>
-			<InnerBlocks
-				template={ [
-					[ 'crowdsignal-forms/multiple-choice-answer', {} ],
-					[ 'crowdsignal-forms/multiple-choice-answer', {} ],
-					[ 'crowdsignal-forms/multiple-choice-answer', {} ],
-				] }
-				templateLock={ false }
-				allowedBlocks={ ALLOWED_ANSWER_BLOCKS }
-				orientation="vertical"
-				__experimentalMoverDirection="vertical"
-			/>
+			<QuestionWrapper.Content>
+				<InnerBlocks
+					template={ [
+						[ 'crowdsignal-forms/multiple-choice-answer', {} ],
+						[ 'crowdsignal-forms/multiple-choice-answer', {} ],
+						[ 'crowdsignal-forms/multiple-choice-answer', {} ],
+					] }
+					templateLock={ false }
+					allowedBlocks={ ALLOWED_ANSWER_BLOCKS }
+					orientation="vertical"
+					__experimentalMoverDirection="vertical"
+				/>
+			</QuestionWrapper.Content>
 		</QuestionWrapper>
 	);
 };
 
 export default EditMultipleChoiceQuestion;
-
-// get parent attributes might work like:
-//
-// getBlockHierarchyRootClientId = return parent clientId
-// getblockAttributes( parentClientId );

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -10,6 +10,8 @@ import classnames from 'classnames';
 import { useColorStyles } from '@crowdsignal/styles';
 
 const StyledButtonWrapper = styled.div`
+	display: flex;
+
 	&.is-selected {
 		filter: invert( 1 );
 	}
@@ -18,7 +20,7 @@ const StyledButtonWrapper = styled.div`
 const StyledButton = styled.button`
 	border: 0;
 	cursor: pointer;
-	display: flex;
+	display: inline-flex;
 	overflow: hidden;
 	position: relative;
 
@@ -35,10 +37,14 @@ const Button = ( {
 	...props
 } ) => (
 	<StyledButtonWrapper
-		className={ classnames( className, 'wp-block-button' ) }
+		className={ classnames(
+			'crowdsignal-forms-button',
+			className,
+			'wp-block-button'
+		) }
 	>
 		<StyledButton
-			className="wp-block-button__link"
+			className="crowdsignal-forms-button__button wp-block-button__link"
 			style={ {
 				...useColorStyles( attributes ),
 				...style,

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,8 +30,8 @@ const Content = styled.div`
 	margin: 0;
 	width: 100%;
 
-	& > *:not( .block-editor-inner-blocks ),
-	.block-editor-block-list__layout > * {
+	& > *:not( .block-editor-inner-blocks ) {
+		margin-top: 0;
 		margin-bottom: 16px;
 
 		&:last-child {
@@ -39,20 +40,43 @@ const Content = styled.div`
 	}
 `;
 
-const QuestionWrapper = ( { attributes, children, style = {}, ...props } ) => (
-	<StyledQuestionWrapper
-		style={ {
-			...useColorStyles( attributes ),
-			...useBorderStyles( attributes ),
-			...style,
-		} }
-		{ ...props }
-	>
-		{ children }
-	</StyledQuestionWrapper>
-);
+const QuestionWrapper = ( {
+	attributes,
+	children,
+	className,
+	style = {},
+	...props
+} ) => {
+	const classes = classnames(
+		'crowdsignal-forms-question-wrapper',
+		className
+	);
+
+	return (
+		<StyledQuestionWrapper
+			className={ classes }
+			style={ {
+				...useColorStyles( attributes ),
+				...useBorderStyles( attributes ),
+				...style,
+			} }
+			{ ...props }
+		>
+			{ children }
+		</StyledQuestionWrapper>
+	);
+};
+
+const QuestionWrapperContent = ( { className, ...props } ) => {
+	const classes = classnames(
+		'crowdsignal-forms-question-wrapper__content',
+		className
+	);
+
+	return <Content className={ classes } { ...props } />;
+};
 
 QuestionWrapper.className = StyledQuestionWrapper;
-QuestionWrapper.Content = Content;
+QuestionWrapper.Content = QuestionWrapperContent;
 
 export default QuestionWrapper;

--- a/packages/blocks/src/multiple-choice-question/index.js
+++ b/packages/blocks/src/multiple-choice-question/index.js
@@ -14,9 +14,13 @@ import { Style } from './constants';
 const Context = createContext();
 
 const MultipleChoiceQuestion = ( { attributes, children, className } ) => {
-	const classes = classnames( className, {
-		'is-required': attributes.mandatory,
-	} );
+	const classes = classnames(
+		'crowdsignal-forms-multiple-choice-question-block',
+		className,
+		{
+			'is-required': attributes.mandatory,
+		}
+	);
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ classes }>

--- a/packages/theme-compatibility/package.json
+++ b/packages/theme-compatibility/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@crowdsignal/theme-compatibility",
+  "version": "0.1.0",
+  "description": "Crowdsignal compatibility stylesheets for WordPress themes",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal",
+    "themes"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/form/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "scripts": {
+    "build": "calypso-build"
+  }
+}

--- a/packages/theme-compatibility/stylesheets/leven-editor.scss
+++ b/packages/theme-compatibility/stylesheets/leven-editor.scss
@@ -1,0 +1,14 @@
+.crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout > * {
+	margin-top: 0;
+	margin-bottom: 16px;
+
+	.wp-block.is-selected &:nth-last-child(2),
+	.wp-block.has-child-selected &:nth-last-child(2),
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	&[data-type="crowdsignal-forms/multiple-choice-answer"] + :not(.wp-block[data-type="crowdsignal-forms/multiple-choice-answer"]) {
+		margin-top: 32px;
+	}
+}

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -1,0 +1,10 @@
+.crowdsignal-forms-button {
+	.crowdsignal-forms-multiple-choice-question-block & + *:not(&) {
+		margin-top: 16px;
+	}
+}
+
+.crowdsignal-forms__question-wrapper {
+	margin-bottom: 64px;
+	margin-top: 64px;
+}

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -4,7 +4,8 @@ const FixStyleOnlyEntriesPlugin = require( 'webpack-fix-style-only-entries' );
 module.exports = {
 	mode: 'production',
 	entry: {
-		leven: './stylesheets/leven.scss',
+		'leven': './stylesheets/leven.scss',
+		'leven-editor': './stylesheets/leven-editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'dist' ),

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require( 'path' );
+const FixStyleOnlyEntriesPlugin = require( 'webpack-fix-style-only-entries' );
+
+module.exports = {
+	mode: 'production',
+	entry: {
+		leven: './stylesheets/leven.scss',
+	},
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+	},
+	module: {
+		rules: [
+			{
+				test: /\.scss$/,
+				exclude: /node_modules/,
+				type: 'asset/resource',
+				generator: {
+					filename: '[name].min.css',
+				},
+				use: [
+					'sass-loader',
+				],
+			},
+		],
+	},
+	plugins: [
+		new FixStyleOnlyEntriesPlugin(),
+	]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -20994,6 +20994,11 @@ webpack-filter-warnings-plugin@^1.2.1:
   resolved "https://registry.yarnpkg.com/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz#dc61521cf4f9b4a336fbc89108a75ae1da951cdb"
   integrity sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==
 
+webpack-fix-style-only-entries@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.6.1.tgz#8e517085cc3426ccd1cb37ff2897b993563a424a"
+  integrity sha512-wyIhoxS3DD3Fr9JA8hQPA+ZmaWnqPxx12Nv166wcsI/0fbReqyEtiIk2llOFYIg57WVS3XX5cZJxw2ji70R0sA==
+
 webpack-hot-middleware@^2.25.0:
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz#4528a0a63ec37f8f8ef565cf9e534d57d09fe706"


### PR DESCRIPTION
This patch adds a theme compatibility layer in the form of an `@crowdsignal/theme-compatibility` package.  
The package would contain the so called _compatibility stylesheets_ for each of our base WordPress themes to optimize them for our environment and our blocks.

Right now the setup is pretty basic, every theme would have a single `.scss` file in the `stylesheets` directory named after itself which is then compiled into the respective `dist/[themeName].min.scss`.  
If we ever feel like we need to, we could technically expand this so each theme gets a whole folder but let's keep it simple for now.

One caveat is, since it's a separate package and build, webpack won't hot-reload or even recompile any changes made there when running the dashboard or project-renderer locally.  
For now, it's necessary to run `yarn workspace @crowdsignal/theme-compatibility build` to recompile the css bundles and refresh the page afterwards.  
I'd say this is good enough right now, but I think we might be getting to a point where it might be handy to implement a single command inside the main `package.json` which would bring up both the dashboard and the project renderer as well as set up a watcher on the theme compatibility package.

Because the themes are a separate package and thus part of this repository, their introduction wouldn't change anything about any of the deployment tactics we discussed, so there's that as well.

Solves c/NbfltGwA-tr.

# Testing

Apply the patch and run `yarn workspace @crowdsignal/theme-compatibility build` before testing.
Ensure the following issues are fixed:

- When a `MultipleChoiceAnswer` is followed by a block other than another `MultipleChoiceAnswer`, the margin between the two should be doubled.
- Submit button should no longer appear as full width in the editor. (And should match the preview)
- Increased margin between `QuestionWrapper`s.