### PR TITLE
Fill project settings tab

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,6 +29,7 @@
     "@wordpress/blocks": "^11.1.4",
     "@wordpress/components": "^19.0.4",
     "@wordpress/data": "^6.1.4",
+    "@wordpress/date": "^4.2.3",
     "@wordpress/element": "^4.0.4",
     "@wordpress/i18n": "^4.2.4",
     "classnames": "^2.2.5",

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -3,33 +3,19 @@
  */
 // eslint-disable-next-line import/named
 import { DocumentSection } from 'isolated-block-editor';
-import { get } from 'lodash';
 import { __ } from '@wordpress/i18n';
-// eslint-disable-next-line
-import { __experimentalGetSettings, format } from '@wordpress/date';
 import { ExternalLink, PanelBody, PanelRow } from '@wordpress/components';
 
-const DocumentSettings = ( { project } ) => {
-	const DATETIME_FORMAT = 'F j, Y H:i';
-	const formatDate = ( timestamp ) =>
-		format( DATETIME_FORMAT, timestamp * 1000 );
+/**
+ * Internal dependencies
+ */
+import { isPublic, getLastUpdatedDate } from '../../util/project';
+import { timestampToDate } from '../../util/date';
 
-	const isPublic = get( project, [ 'content', 'public' ], false );
-	const visibiliy = isPublic
+const DocumentSettings = ( { project } ) => {
+	const visibiliy = isPublic( project )
 		? __( 'Public', 'dashboard' )
 		: __( 'Private', 'dashboard' );
-
-	const publicTimestamp = get(
-		project,
-		[ 'content', 'public', 'timestamp' ],
-		0
-	);
-	const draftTimestamp = get(
-		project,
-		[ 'content', 'draft', 'timestamp' ],
-		0
-	);
-	const lastUpdated = Math.max( publicTimestamp, draftTimestamp );
 
 	return (
 		<DocumentSection>
@@ -40,11 +26,13 @@ const DocumentSettings = ( { project } ) => {
 				</PanelRow>
 				<PanelRow className="project-created-date">
 					<span>{ __( 'Created', 'dashboard' ) }</span>
-					<span>{ formatDate( project.created ) }</span>
+					<span>{ timestampToDate( project.created ) }</span>
 				</PanelRow>
 				<PanelRow className="project-updated-date">
 					<span>{ __( 'Updated', 'dashboard' ) }</span>
-					<span>{ formatDate( lastUpdated ) }</span>
+					<span>
+						{ timestampToDate( getLastUpdatedDate( project ) ) }
+					</span>
 				</PanelRow>
 			</PanelBody>
 			<PanelBody title={ __( 'Permalink', 'dashboard' ) }>

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -39,8 +39,13 @@ const DocumentSettings = ( { project } ) => {
 				<PanelRow>
 					<span>{ __( 'View Project', 'dashboard' ) }</span>
 				</PanelRow>
-				<ExternalLink href={ project.permalink }>
-					{ project.permalink }
+				<ExternalLink
+					href={ project.permalink }
+					title={ project.permalink }
+				>
+					<span className="components-external-link__text">
+						{ project.permalink }
+					</span>
 				</ExternalLink>
 			</PanelBody>
 		</DocumentSection>

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -3,13 +3,118 @@
  */
 // eslint-disable-next-line import/named
 import { DocumentSection } from 'isolated-block-editor';
+import { get } from 'lodash';
+import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line
+import { __experimentalGetSettings, format } from '@wordpress/date';
+import {
+	CustomSelectControl,
+	ExternalLink,
+	PanelBody,
+	PanelRow,
+	ToggleControl,
+} from '@wordpress/components';
 // import { GlobalStylesUI } from '@wordpress/edit-site/src/components/global-styles';
 
-const DocumentSettings = () => (
-	<DocumentSection>
-		Great things will come here
-		{ /*<GlobalStylesUI />*/ }
-	</DocumentSection>
-);
+const DocumentSettings = ( { project } ) => {
+	const dateSettings = __experimentalGetSettings();
+	const formatDate = ( timestamp ) =>
+		format( dateSettings.formats.datetime, timestamp * 1000 );
+
+	const formTimeoutOptions = [ { key: 24, name: '24 hours' } ];
+
+	const isPublic = get( project, [ 'content', 'public' ], false );
+	const visibiliy = isPublic
+		? __( 'Public', 'dashboard' )
+		: __( 'Private', 'dashboard' );
+
+	const publicTimestamp = get(
+		project,
+		[ 'content', 'public', 'timestamp' ],
+		0
+	);
+	const draftTimestamp = get(
+		project,
+		[ 'content', 'draft', 'timestamp' ],
+		0
+	);
+	const lastUpdated = Math.max( publicTimestamp, draftTimestamp );
+
+	//eslint-disable-next-line
+	const handleChangeRestriction = ( key ) => ( value ) => {
+		//TODO: Call API to save values
+	};
+
+	return (
+		<DocumentSection>
+			<PanelBody title={ __( 'Status & Visibility', 'dashboard' ) }>
+				<PanelRow>
+					<span>{ __( 'Visibility', 'dashboard' ) }</span>
+					<span>{ visibiliy }</span>
+				</PanelRow>
+				<PanelRow>
+					<span>{ __( 'Created', 'dashboard' ) }</span>
+					<span>{ formatDate( project.created ) }</span>
+				</PanelRow>
+				<PanelRow>
+					<span>{ __( 'Last Updated', 'dashboard' ) }</span>
+					<span>{ formatDate( lastUpdated ) }</span>
+				</PanelRow>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Permalink', 'dashboard' ) }
+				initialOpen={ false }
+			>
+				<PanelRow>
+					<span>View Project</span>
+				</PanelRow>
+				<ExternalLink href={ project.permalink }>
+					{ project.permalink }
+				</ExternalLink>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Restrictions', 'dashboard' ) }
+				initialOpen={ false }
+			>
+				<ToggleControl
+					label={ __( 'Captcha protection', 'dashboard' ) }
+					value={ project.restrictCaptcha }
+					onChange={ handleChangeRestriction( 'restrictCaptcha' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Password protection', 'dashboard' ) }
+					value={ project.restrictPassword }
+					onChange={ handleChangeRestriction( 'restrictPassword' ) }
+				/>
+				<ToggleControl
+					label={ __( 'One response per computer', 'dashboard' ) }
+					value={ project.restrictQuota }
+					onChange={ handleChangeRestriction( 'restrictQuota' ) }
+				/>
+				<ToggleControl
+					label={ __( 'IP restriction', 'dashboard' ) }
+					value={ project.restrictIp }
+					onChange={ handleChangeRestriction( 'restrictIp' ) }
+				/>
+				<ToggleControl
+					label={ __( 'Email restriction', 'dashboard' ) }
+					value={ project.restrictEmail }
+					onChange={ handleChangeRestriction( 'restrictEmail' ) }
+				/>
+				<CustomSelectControl
+					label={ __( 'Form Timeout', 'dashboard' ) }
+					options={ formTimeoutOptions }
+					value={ formTimeoutOptions.find(
+						( o ) => o.key === project.responseTimeout
+					) }
+				/>
+			</PanelBody>
+			{ /*<PanelBody title={ __( 'Theme', 'dashboard' ) } />*/ }
+			{ /*<PanelBody title={ __( 'Navigation', 'dashboard' ) } />*/ }
+			{ /*<PanelBody title={ __( 'Language', 'dashboard' ) } />*/ }
+			{ /*<GlobalStylesUI />*/ }
+		</DocumentSection>
+	);
+};
 
 export default DocumentSettings;

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line
 import { __experimentalGetSettings, format } from '@wordpress/date';
 import { ExternalLink, PanelBody, PanelRow } from '@wordpress/components';
-// import { GlobalStylesUI } from '@wordpress/edit-site/src/components/global-styles';
 
 const DocumentSettings = ( { project } ) => {
 	const dateSettings = __experimentalGetSettings();
@@ -50,13 +49,12 @@ const DocumentSettings = ( { project } ) => {
 			</PanelBody>
 			<PanelBody title={ __( 'Permalink', 'dashboard' ) }>
 				<PanelRow>
-					<span>View Project</span>
+					<span>{ __( 'View Project', 'dashboard' ) }</span>
 				</PanelRow>
 				<ExternalLink href={ project.permalink }>
 					{ project.permalink }
 				</ExternalLink>
 			</PanelBody>
-			{ /*<GlobalStylesUI />*/ }
 		</DocumentSection>
 	);
 };

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -10,9 +10,9 @@ import { __experimentalGetSettings, format } from '@wordpress/date';
 import { ExternalLink, PanelBody, PanelRow } from '@wordpress/components';
 
 const DocumentSettings = ( { project } ) => {
-	const dateSettings = __experimentalGetSettings();
+	const DATETIME_FORMAT = 'F j, Y H:i';
 	const formatDate = ( timestamp ) =>
-		format( dateSettings.formats.datetime, timestamp * 1000 );
+		format( DATETIME_FORMAT, timestamp * 1000 );
 
 	const isPublic = get( project, [ 'content', 'public' ], false );
 	const visibiliy = isPublic
@@ -38,12 +38,12 @@ const DocumentSettings = ( { project } ) => {
 					<span>{ __( 'Visibility', 'dashboard' ) }</span>
 					<span>{ visibiliy }</span>
 				</PanelRow>
-				<PanelRow className="project-creation-date">
+				<PanelRow className="project-created-date">
 					<span>{ __( 'Created', 'dashboard' ) }</span>
 					<span>{ formatDate( project.created ) }</span>
 				</PanelRow>
-				<PanelRow className="project-last-update-date">
-					<span>{ __( 'Last Updated', 'dashboard' ) }</span>
+				<PanelRow className="project-updated-date">
+					<span>{ __( 'Updated', 'dashboard' ) }</span>
 					<span>{ formatDate( lastUpdated ) }</span>
 				</PanelRow>
 			</PanelBody>

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -34,15 +34,15 @@ const DocumentSettings = ( { project } ) => {
 	return (
 		<DocumentSection>
 			<PanelBody title={ __( 'Status & Visibility', 'dashboard' ) }>
-				<PanelRow>
+				<PanelRow className="project-visibility">
 					<span>{ __( 'Visibility', 'dashboard' ) }</span>
 					<span>{ visibiliy }</span>
 				</PanelRow>
-				<PanelRow>
+				<PanelRow className="project-creation-date">
 					<span>{ __( 'Created', 'dashboard' ) }</span>
 					<span>{ formatDate( project.created ) }</span>
 				</PanelRow>
-				<PanelRow>
+				<PanelRow className="project-last-update-date">
 					<span>{ __( 'Last Updated', 'dashboard' ) }</span>
 					<span>{ formatDate( lastUpdated ) }</span>
 				</PanelRow>

--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -7,21 +7,13 @@ import { get } from 'lodash';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line
 import { __experimentalGetSettings, format } from '@wordpress/date';
-import {
-	CustomSelectControl,
-	ExternalLink,
-	PanelBody,
-	PanelRow,
-	ToggleControl,
-} from '@wordpress/components';
+import { ExternalLink, PanelBody, PanelRow } from '@wordpress/components';
 // import { GlobalStylesUI } from '@wordpress/edit-site/src/components/global-styles';
 
 const DocumentSettings = ( { project } ) => {
 	const dateSettings = __experimentalGetSettings();
 	const formatDate = ( timestamp ) =>
 		format( dateSettings.formats.datetime, timestamp * 1000 );
-
-	const formTimeoutOptions = [ { key: 24, name: '24 hours' } ];
 
 	const isPublic = get( project, [ 'content', 'public' ], false );
 	const visibiliy = isPublic
@@ -40,11 +32,6 @@ const DocumentSettings = ( { project } ) => {
 	);
 	const lastUpdated = Math.max( publicTimestamp, draftTimestamp );
 
-	//eslint-disable-next-line
-	const handleChangeRestriction = ( key ) => ( value ) => {
-		//TODO: Call API to save values
-	};
-
 	return (
 		<DocumentSection>
 			<PanelBody title={ __( 'Status & Visibility', 'dashboard' ) }>
@@ -61,10 +48,7 @@ const DocumentSettings = ( { project } ) => {
 					<span>{ formatDate( lastUpdated ) }</span>
 				</PanelRow>
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Permalink', 'dashboard' ) }
-				initialOpen={ false }
-			>
+			<PanelBody title={ __( 'Permalink', 'dashboard' ) }>
 				<PanelRow>
 					<span>View Project</span>
 				</PanelRow>
@@ -72,46 +56,6 @@ const DocumentSettings = ( { project } ) => {
 					{ project.permalink }
 				</ExternalLink>
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Restrictions', 'dashboard' ) }
-				initialOpen={ false }
-			>
-				<ToggleControl
-					label={ __( 'Captcha protection', 'dashboard' ) }
-					value={ project.restrictCaptcha }
-					onChange={ handleChangeRestriction( 'restrictCaptcha' ) }
-				/>
-				<ToggleControl
-					label={ __( 'Password protection', 'dashboard' ) }
-					value={ project.restrictPassword }
-					onChange={ handleChangeRestriction( 'restrictPassword' ) }
-				/>
-				<ToggleControl
-					label={ __( 'One response per computer', 'dashboard' ) }
-					value={ project.restrictQuota }
-					onChange={ handleChangeRestriction( 'restrictQuota' ) }
-				/>
-				<ToggleControl
-					label={ __( 'IP restriction', 'dashboard' ) }
-					value={ project.restrictIp }
-					onChange={ handleChangeRestriction( 'restrictIp' ) }
-				/>
-				<ToggleControl
-					label={ __( 'Email restriction', 'dashboard' ) }
-					value={ project.restrictEmail }
-					onChange={ handleChangeRestriction( 'restrictEmail' ) }
-				/>
-				<CustomSelectControl
-					label={ __( 'Form Timeout', 'dashboard' ) }
-					options={ formTimeoutOptions }
-					value={ formTimeoutOptions.find(
-						( o ) => o.key === project.responseTimeout
-					) }
-				/>
-			</PanelBody>
-			{ /*<PanelBody title={ __( 'Theme', 'dashboard' ) } />*/ }
-			{ /*<PanelBody title={ __( 'Navigation', 'dashboard' ) } />*/ }
-			{ /*<PanelBody title={ __( 'Language', 'dashboard' ) } />*/ }
 			{ /*<GlobalStylesUI />*/ }
 		</DocumentSection>
 	);

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -121,7 +121,7 @@ const Editor = ( { projectId } ) => {
 				onError={ noop }
 			>
 				<Toolbar projectId={ projectId } />
-				<DocumentSettings />
+				<DocumentSettings project={ project } />
 
 				<AutoSubmitButton />
 			</IsolatedBlockEditor>

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -29,7 +29,7 @@ export const editorSettings = {
 			fixedToolbar: false,
 		},
 		toolbar: {
-			documentInspector: __( 'Project', 'dashboard' ),
+			documentInspector: __( 'Document', 'dashboard' ),
 			inspector: true,
 			navigation: true,
 			toc: false,

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -29,7 +29,7 @@ export const editorSettings = {
 			fixedToolbar: false,
 		},
 		toolbar: {
-			documentInspector: __( 'Document', 'dashboard' ),
+			documentInspector: __( 'Project', 'dashboard' ),
 			inspector: true,
 			navigation: true,
 			toc: false,

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -63,11 +63,30 @@ html.interface-interface-skeleton__html-container {
 			padding: 0
 	}
 
+	.components-panel__body-title {
+		.components-panel__body-toggle {
+			font-weight: 600;
+		}
+	}
+
 	// Fix isolated-block-editor's misalignment of list blocks
 	ul.block-editor-block-list__block,
 	ol.block-editor-block-list__block {
 		margin-left: auto;
 		margin-right: auto;
+	}
+}
+
+.iso-sidebar {
+	.project-visibility, .project-creation-date, .project-last-update-date {
+		span {
+			&:first-child {
+				margin-right: 5px;
+			}
+			&:last-child {
+				white-space: nowrap;
+			}
+		}
 	}
 }
 

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -75,6 +75,24 @@ html.interface-interface-skeleton__html-container {
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	.components-external-link {
+		display: flex;
+		align-items: center;
+
+		&__text {
+			text-overflow: ellipsis;
+			max-width: 100%;
+			box-sizing: border-box;
+			overflow: hidden;
+			display: inline-block;
+			white-space: nowrap;
+		}
+
+		&__icon {
+			margin: 0;
+		}
+	}
 }
 
 .iso-sidebar {

--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -78,7 +78,7 @@ html.interface-interface-skeleton__html-container {
 }
 
 .iso-sidebar {
-	.project-visibility, .project-creation-date, .project-last-update-date {
+	.project-visibility, .project-created-date, .project-updated-date {
 		span {
 			&:first-child {
 				margin-right: 5px;

--- a/apps/dashboard/src/util/date/index.js
+++ b/apps/dashboard/src/util/date/index.js
@@ -1,0 +1,6 @@
+import { format } from '@wordpress/date';
+
+const DEFAULT_FORMAT = 'F j, Y H:i';
+
+export const timestampToDate = ( timestamp, defaultFormat = DEFAULT_FORMAT ) =>
+	format( defaultFormat, timestamp * 1000 );

--- a/apps/dashboard/src/util/project/index.js
+++ b/apps/dashboard/src/util/project/index.js
@@ -3,6 +3,20 @@
  */
 import { get } from 'lodash';
 
+const getProjectTimestamp = ( project, contentType ) =>
+	get( project, [ 'content', contentType, 'timestamp' ], 0 );
+
+const getPublicTimestamp = ( project ) =>
+	getProjectTimestamp( project, 'public' );
+
+const getDraftTimestamp = ( project ) =>
+	getProjectTimestamp( project, 'draft' );
+
 export const hasUnpublishedChanges = ( project ) =>
-	get( project, [ 'content', 'draft', 'timestamp' ], 0 ) >
-	get( project, [ 'content', 'public', 'timestamp' ], 0 );
+	getDraftTimestamp( project ) > getPublicTimestamp( project );
+
+export const getLastUpdatedDate = ( project ) =>
+	Math.max( getPublicTimestamp( project ), getDraftTimestamp( project ) );
+
+export const isPublic = ( project ) =>
+	get( project, [ 'content', 'public' ], false );


### PR DESCRIPTION
## Summary 
This PR will start filling the project's sidebar settings with information we already have on the API.

Ref: c/Qga7WIeF-tr

![image](https://user-images.githubusercontent.com/7811225/144642404-f66ce6ed-9c36-4f10-9ba7-4543b9c03e86.png)

## Test Instructions

* Checkout this branch
* Run `yarn install` and then start the dashboard running `yarn workspace @crowdsignal/dashboard start`
* Open or create a new project
* Click the settings icon on the upper right corner and select `Document` tab
* You should something similar with the image above