### PR TITLE
Fix Image block is not displaying the image on Project Renderer

### DIFF
--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -109,7 +109,7 @@ const appendInnerBlocks = ( blockName, elements, innerBlocks ) => {
  */
 const createElementsRecursive = ( elements ) => {
 	if ( isEmpty( elements ) ) {
-		return [];
+		return null;
 	}
 
 	return map( elements, ( element ) => {
@@ -117,18 +117,13 @@ const createElementsRecursive = ( elements ) => {
 			return element;
 		}
 
-		const children = [
-			...( element.innerBlocks || [] ),
-			...createElementsRecursive( element.children ),
-		];
-
 		return createElement(
 			element.name,
 			element.props,
 
 			// In practice, if an element is the host for inner blocks
 			// it's children should alwyas be empty here.
-			( children.length && children ) || null
+			element.innerBlocks || createElementsRecursive( element.children )
 		);
 	} );
 };

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -87,15 +87,6 @@ const appendInnerBlocks = ( blockName, elements, innerBlocks ) => {
 	}
 
 	switch ( blockName ) {
-		// case 'core/media-text':
-		// 	const container = find(
-		// 		elements[0].children,
-
-		// 		( element ) => element.props.className.indexOf( 'wp-block-media-text__content' ) >= 0
-		// 	);
-
-		// 	container.innerBlocks = innerBlocks;
-		// 	return;
 		case 'core/cover':
 			const container = find(
 				elements[ 0 ].children,

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -109,7 +109,7 @@ const appendInnerBlocks = ( blockName, elements, innerBlocks ) => {
  */
 const createElementsRecursive = ( elements ) => {
 	if ( isEmpty( elements ) ) {
-		return null;
+		return [];
 	}
 
 	return map( elements, ( element ) => {
@@ -117,13 +117,18 @@ const createElementsRecursive = ( elements ) => {
 			return element;
 		}
 
+		const children = [
+			...( element.innerBlocks || [] ),
+			...createElementsRecursive( element.children ),
+		];
+
 		return createElement(
 			element.name,
 			element.props,
 
 			// In practice, if an element is the host for inner blocks
 			// it's children should alwyas be empty here.
-			element.innerBlocks || createElementsRecursive( element.children )
+			( children.length && children ) || null
 		);
 	} );
 };

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -14,6 +14,7 @@ import {
 	map,
 	uniqueId,
 	zipObject,
+	find,
 } from 'lodash';
 
 const KEY_PREFIX = 'crowdsignal-block-';
@@ -95,7 +96,16 @@ const appendInnerBlocks = ( blockName, elements, innerBlocks ) => {
 
 		// 	container.innerBlocks = innerBlocks;
 		// 	return;
-
+		case 'core/cover':
+			const container = find(
+				elements[ 0 ].children,
+				( element ) =>
+					element.props.className.indexOf(
+						'wp-block-cover__inner-container'
+					) >= 0
+			);
+			container.innerBlocks = innerBlocks;
+			break;
 		default:
 			elements[ 0 ].innerBlocks = innerBlocks;
 	}


### PR DESCRIPTION
## Summary

The purpose of this PR is to fix an issue regarding the images from Image Block not being rendered on Project Renderer view.

Ref: c/szZ0mf3V-tr

## Test Instructions
 
* Checkout this branch
* Run `yarn install` and start the dashboard using `yarn workspace @crowdsignal/dashboard start`
* Create or open a project, add an Image Block and set the image properly.
* Start the Project Renderer using `yarn workspace @crowdsignal/project-renderer start`
* Open the project page inside the Renderer (usually: https://crowdsignal.localhost:9001/[projectId])
* You should see the Image Block rendering the image correctly.
