### PR TITLE
Add behavior to remove empty MC answers using backspace/delete key

### DIFF
--- a/packages/block-editor/src/multiple-choice-answer/edit-button.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit-button.js
@@ -28,6 +28,7 @@ const EditButtonAnswer = ( {
 	onChange,
 	onReplace,
 	onSplit,
+	onDelete,
 } ) => {
 	const width = attributes.width ? `${ attributes.width }%` : null;
 
@@ -48,6 +49,7 @@ const EditButtonAnswer = ( {
 					onChange={ onChange }
 					onReplace={ onReplace }
 					onSplit={ onSplit }
+					onRemove={ onDelete }
 					value={ attributes.label }
 					multiline={ false }
 					preserveWhiteSpace={ false }

--- a/packages/block-editor/src/multiple-choice-answer/edit-checkbox.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit-checkbox.js
@@ -17,6 +17,7 @@ const EditCheckboxAnswer = ( {
 	onChange,
 	onReplace,
 	onSplit,
+	onDelete,
 } ) => (
 	<FormCheckbox.Label
 		as={ 'div' }
@@ -32,6 +33,7 @@ const EditCheckboxAnswer = ( {
 			onChange={ onChange }
 			onReplace={ onReplace }
 			onSplit={ onSplit }
+			onRemove={ onDelete }
 			value={ attributes.label }
 			allowedFormats={ [] }
 			withoutInteractiveFormatting

--- a/packages/block-editor/src/multiple-choice-answer/edit.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit.js
@@ -3,6 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,6 +19,20 @@ import Sidebar from './sidebar';
 const EditMultipleChoiceAnswer = ( props ) => {
 	const { attributes, className, clientId, onReplace, setAttributes } = props;
 
+	const { removeBlock } = useDispatch( 'core/block-editor' );
+
+	const answersCount = useSelect(
+		( select ) => {
+			const { getBlockCount, getBlockRootClientId } = select(
+				'core/block-editor'
+			);
+
+			const questionClientId = getBlockRootClientId( clientId );
+			return getBlockCount( questionClientId );
+		},
+		[ clientId ]
+	);
+
 	const questionAttributes = useParentAttributes( clientId );
 
 	useClientId( { attributes, setAttributes } );
@@ -25,7 +40,7 @@ const EditMultipleChoiceAnswer = ( props ) => {
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
 
 	const handleSplit = ( label ) =>
-		createBlock( 'crowdsignal-forms/answer', {
+		createBlock( 'crowdsignal-forms/multiple-choice-answer', {
 			...attributes,
 			clientId:
 				label && attributes.label.indexOf( label ) === 0
@@ -33,6 +48,14 @@ const EditMultipleChoiceAnswer = ( props ) => {
 					: undefined,
 			label,
 		} );
+
+	const handleDelete = () => {
+		if ( answersCount <= 2 ) {
+			return;
+		}
+
+		removeBlock( clientId );
+	};
 
 	const blockStyle = getBlockStyle( questionAttributes.className );
 
@@ -59,6 +82,7 @@ const EditMultipleChoiceAnswer = ( props ) => {
 					onChange={ handleChangeLabel }
 					onReplace={ onReplace }
 					onSplit={ handleSplit }
+					onDelete={ handleDelete }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/util/use-parent-attributes.js
+++ b/packages/block-editor/src/util/use-parent-attributes.js
@@ -8,6 +8,6 @@ export const useParentAttributes = ( clientId ) =>
 		const blockEditor = select( 'core/block-editor' );
 
 		return blockEditor.getBlockAttributes(
-			blockEditor.getBlockHierarchyRootClientId( clientId )
+			blockEditor.getBlockRootClientId( clientId )
 		);
 	} );


### PR DESCRIPTION
## Summary

The purpose of this PR is to improve Multiple Choice Question block usability by adding the possibility to remove an empty answer by hitting the `backspace/delete` key.

During the development, found an issue in the ` useParentAttributes` hook, which was taking the wrong `clientId` if the block was nested inside other blocks.
That's why we have some 'unrelated' changes on `packages/block-editor/src/util/use-parent-attributes.js`

Ref: c/o9P7UFwf-tr

## Test Instructions

* Checkout this branch
* Run `yarn install` and then start the dashboard running `yarn workspace @crowdsignal/dashboard start`
* Open or create a new project
* Add a Multiple Choice Question
* You should be able to remove an empty answer by hitting the `backspace/delete` key

_Note_: Like on WP.com, you shouldn't be able to remove an empty answer using this method if there are two or less 
 answers on the MC block.