### PR TITLE
Hide empty MultipleChoiceAnswer blocks when parent question isn't selected

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -20,6 +20,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@crowdsignal/block-editor": "^0.1.0",
+    "@crowdsignal/block-editor-filters": "^0.1.0",
     "@crowdsignal/blocks": "^0.1.0",
     "@crowdsignal/components": "^0.1.0",
     "@crowdsignal/form": "^0.1.0",
@@ -31,6 +32,7 @@
     "@wordpress/components": "^19.0.4",
     "@wordpress/data": "^6.1.4",
     "@wordpress/element": "^4.0.4",
+    "@wordpress/hooks": "^3.2.2",
     "@wordpress/i18n": "^4.2.4",
     "classnames": "^2.2.5",
     "isolated-block-editor": "git://github.com/Automattic/isolated-block-editor.git#a1fa71448efddd02ed645939d284fbe81dfe13a2",

--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -2,14 +2,22 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import * as blocks from '@crowdsignal/block-editor';
+import { withEmptyClassName } from '@crowdsignal/block-editor-filters';
 
 export const registerBlocks = () =>
 	forEach( blocks, ( block ) => {
 		registerBlockType( block.name, block.settings );
 	} );
+
+addFilter(
+	'editor.BlockListBlock',
+	'crowdsignal-forms/with-empty-class-name',
+	withEmptyClassName
+);

--- a/packages/block-editor-filters/README.md
+++ b/packages/block-editor-filters/README.md
@@ -1,0 +1,1 @@
+# @crowdsignal/block-editor-filters

--- a/packages/block-editor-filters/package.json
+++ b/packages/block-editor-filters/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@crowdsignal/block-editor-filters",
+  "version": "0.1.0",
+  "description": "Crowdsignal block editor filter functions.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/block-editor-filters/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@crowdsignal/block-editor": "^0.1.0",
+    "classnames": "^2.3.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/block-editor-filters/src/index.js
+++ b/packages/block-editor-filters/src/index.js
@@ -1,0 +1,1 @@
+export * from './with-empty-class-name';

--- a/packages/block-editor-filters/src/with-empty-class-name.js
+++ b/packages/block-editor-filters/src/with-empty-class-name.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { includes, isEmpty, keys } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { multipleChoiceAnswerBlock } from '@crowdsignal/block-editor';
+
+/**
+ * An 'is-empty' class name will be applied to the wrappers of blocks
+ * in this list based on the value of given attribute.
+ *
+ * @type {Object}
+ */
+const BLOCKS = {
+	[ multipleChoiceAnswerBlock.name ]: 'label',
+};
+
+export const withEmptyClassName = ( BlockListBlock ) => {
+	return ( props ) => {
+		if ( ! includes( keys( BLOCKS ), props.name ) ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		const attribute = BLOCKS[ props.name ];
+
+		const wrapperProps = {
+			...props.wrapperProps,
+			className: classnames( props?.wrapperProps?.className, {
+				'is-empty': isEmpty( props?.attributes[ attribute ] ),
+			} ),
+		};
+
+		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+	};
+};

--- a/packages/block-editor/src/multiple-choice-answer/edit.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit.js
@@ -4,6 +4,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -15,6 +16,11 @@ import { withSharedSiblingAttributes } from '../util/with-shared-sibling-attribu
 import EditButtonAnswer from './edit-button';
 import EditCheckboxAnswer from './edit-checkbox';
 import Sidebar from './sidebar';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const EditMultipleChoiceAnswer = ( props ) => {
 	const { attributes, className, clientId, onReplace, setAttributes } = props;
@@ -59,6 +65,14 @@ const EditMultipleChoiceAnswer = ( props ) => {
 
 	const blockStyle = getBlockStyle( questionAttributes.className );
 
+	const classes = classnames(
+		'crowdsignal-forms-multiple-choice-answer-block',
+		className,
+		{
+			'is-empty': ! attributes.label,
+		}
+	);
+
 	return (
 		<>
 			<Sidebar blockStyle={ blockStyle } { ...props } />
@@ -66,7 +80,7 @@ const EditMultipleChoiceAnswer = ( props ) => {
 			{ blockStyle === MultipleChoiceQuestion.Style.LIST && (
 				<EditCheckboxAnswer
 					attributes={ attributes }
-					className={ className }
+					className={ classes }
 					multipleChoice={ questionAttributes.maximumChoices !== 1 }
 					onChange={ handleChangeLabel }
 					onReplace={ onReplace }
@@ -77,7 +91,7 @@ const EditMultipleChoiceAnswer = ( props ) => {
 			{ blockStyle === MultipleChoiceQuestion.Style.BUTTON && (
 				<EditButtonAnswer
 					attributes={ attributes }
-					className={ className }
+					className={ classes }
 					multipleChoice={ questionAttributes.maximumChoices !== 1 }
 					onChange={ handleChangeLabel }
 					onReplace={ onReplace }

--- a/packages/block-editor/src/multiple-choice-answer/style.scss
+++ b/packages/block-editor/src/multiple-choice-answer/style.scss
@@ -1,8 +1,5 @@
-.crowdsignal-forms-multiple-choice-answer-block {
-    .wp-block[data-type="crowdsignal-forms/multiple-choice-question"]:not(.is-selected):not(.has-child-selected) &.is-empty {
-        height: 0;
-        opacity: 0;
-        margin-bottom: -16px;
-        margin-top: 0;
+.wp-block[data-type="crowdsignal-forms/multiple-choice-question"]:not(.is-selected):not(.has-child-selected) {
+    .wp-block[data-type="crowdsignal-forms/multiple-choice-answer"].is-empty {
+        display: none;
     }
 }

--- a/packages/block-editor/src/multiple-choice-answer/style.scss
+++ b/packages/block-editor/src/multiple-choice-answer/style.scss
@@ -1,0 +1,8 @@
+.crowdsignal-forms-multiple-choice-answer-block {
+    .wp-block[data-type="crowdsignal-forms/multiple-choice-question"]:not(.is-selected):not(.has-child-selected) &.is-empty {
+        height: 0;
+        opacity: 0;
+        margin-bottom: -16px;
+        margin-top: 0;
+    }
+}

--- a/packages/blocks/src/multiple-choice-answer/index.js
+++ b/packages/blocks/src/multiple-choice-answer/index.js
@@ -26,9 +26,13 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 		value: attributes.clientId,
 	} );
 
-	const classes = classnames( className, {
-		'is-selected': inputProps.checked,
-	} );
+	const classes = classnames(
+		'crowdsignal-forms-multiple-choice-answer-block',
+		className,
+		{
+			'is-selected': inputProps.checked,
+		}
+	);
 
 	if ( ! attributes.label ) {
 		return null;

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -4,7 +4,7 @@
 	}
 }
 
-.crowdsignal-forms__question-wrapper {
+.crowdsignal-forms-question-wrapper {
 	margin-bottom: 64px;
 	margin-top: 64px;
 }


### PR DESCRIPTION
This patch will hide any empty multiple choice answers when the parent multiple choice question isn't selected.

There are a couple of ways to do this. I opted for one that's slightly more complicated but should give us less headaches down the line.  
The main culprit was that in the editor, each block is wrapped inside another `div.block-editor-block-list__block` which has some spacing styles on it - so hiding just our block doesn't quite cut it.  
This is solved by adding a filter `BlockListBlock` filter to adjust the wrappers' class name based on the block properties. I tried to write it in a way that could be extended to other blocks that might need similar functionality in the future (looking at you poll block 👀 ).

Solves c/4bf109b4-tr.

# Testing

As this introduces a new package, make sure you run `yarn install` before anything else.

- Add a multiple choice question block and leave at least one answer block without a label.
- Any answer blocks without a label should be hidden whenever the wrapping multiple choice question block is not in focus.