### PR TITLE
Include Text Input data when submitting the form

### DIFF
--- a/packages/block-editor/src/text-input/attributes.js
+++ b/packages/block-editor/src/text-input/attributes.js
@@ -1,4 +1,8 @@
 export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
 	label: {
 		type: 'string',
 		default: '',

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -11,9 +11,12 @@ import { __ } from '@wordpress/i18n';
 import { FormTextInput } from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
+import { useClientId } from '@crowdsignal/hooks';
 
 const EditTextInput = ( props ) => {
 	const { attributes, setAttributes, isSelected } = props;
+
+	useClientId( props );
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
 
@@ -35,6 +38,7 @@ const EditTextInput = ( props ) => {
 				placeholder={ __( 'Enter form label', 'block-editor' ) }
 				onChange={ handleChangeLabel }
 				value={ attributes.label }
+				data-client-id={ attributes.clientId }
 			/>
 			<ResizableBox
 				minHeight="40px"

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -38,7 +38,6 @@ const EditTextInput = ( props ) => {
 				placeholder={ __( 'Enter form label', 'block-editor' ) }
 				onChange={ handleChangeLabel }
 				value={ attributes.label }
-				data-client-id={ attributes.clientId }
 			/>
 			<ResizableBox
 				minHeight="40px"

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -8,8 +8,13 @@ import { RichText } from '@wordpress/block-editor';
  */
 import { useColorStyles } from '@crowdsignal/styles';
 import { FormTextInput } from '../components';
+import { useField } from '@crowdsignal/form';
 
 const TextInput = ( { attributes } ) => {
+	const { inputProps } = useField( {
+		name: `q_${ attributes.clientId }[text]`,
+	} );
+
 	return (
 		<div style={ { ...useColorStyles( attributes ) } }>
 			<RichText.Content value={ attributes.label } />
@@ -18,6 +23,7 @@ const TextInput = ( { attributes } ) => {
 					width: attributes.inputWidth,
 					height: `${ attributes.inputHeight }px`,
 				} }
+				{ ...inputProps }
 			/>
 		</div>
 	);

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -42,7 +42,10 @@ export const useField = ( { name: fieldName, type, value } ) => {
 	const inputProps = {
 		name: fieldName,
 		onChange,
-		value: type === 'checkbox' || type === 'radio' ? value : currentValue,
+		value:
+			type === 'checkbox' || type === 'radio'
+				? value
+				: currentValue || '',
 	};
 
 	if ( type === 'checkbox' ) {


### PR DESCRIPTION
## Summary

The purpose of this PR is to include the Text Input Form block data when submitting the page by hitting the Submit Button.

## Test Instructions

* Checkout this branch
* Run `yarn install` and then start the dashboard by `running yarn workspace @crowdsignal/dashboard start`
* Open or create a new project
* Include some `Text Input Form` block (and a Submit Button, if not present) on the page and set the necessary properties accordingly
* Hit the `Update` button on the top right (if available) to make sure the changes are saved.
* Start the `project-renderer` by running `yarn workspace @crowdsignal/project-renderer start`
* Open your project (usually https://crowdsignal.localhost:9001/[ProjectId])
* Open the network tab of your Developer Tools
* Fill the input fields and click the Submit Button
* On the Network tab, you should be able to see a request to https://api.crowdsignal.com/v4/projects/[ProjectId]/form and the input fields data should be on the request body.