### PR TITLE
Move project previews to the project renderer

### DIFF
--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -69,7 +69,7 @@ const Toolbar = ( { projectId } ) => {
 			? `https://crowdsignal.localhost:9001/${ projectHash(
 					project
 			  ) }?preview=true`
-			: `${ project.permalink }?preview=true`;
+			: `${ project?.permalink }?preview=true`;
 
 	return (
 		<ToolbarSlot className="block-editor__crowdsignal-toolbar">

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -11,6 +11,7 @@ import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line impo
  */
 import PublishButton from './publish-button';
 import { STORE_NAME } from '../../data';
+import { projectHash } from '../../util/project';
 
 /**
  * Style dependencies
@@ -63,6 +64,13 @@ const Toolbar = ( { projectId } ) => {
 		return false;
 	};
 
+	const previewURL =
+		process.env.NODE_ENV !== 'production'
+			? `https://crowdsignal.localhost:9001/${ projectHash(
+					project
+			  ) }?preview=true`
+			: `${ project.permalink }?preview=true`;
+
 	return (
 		<ToolbarSlot className="block-editor__crowdsignal-toolbar">
 			<ToolbarButton
@@ -78,7 +86,7 @@ const Toolbar = ( { projectId } ) => {
 			<ToolbarButton
 				as={ Button }
 				variant="tertiary"
-				href={ `/project/${ projectId }/preview` }
+				href={ previewURL }
 				target="_blank"
 				disabled={ ! projectId }
 			>

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -11,7 +11,6 @@ import { ToolbarSlot } from 'isolated-block-editor'; // eslint-disable-line impo
  */
 import PublishButton from './publish-button';
 import { STORE_NAME } from '../../data';
-import { projectHash } from '../../util/project';
 
 /**
  * Style dependencies
@@ -66,9 +65,7 @@ const Toolbar = ( { projectId } ) => {
 
 	const previewURL =
 		process.env.NODE_ENV !== 'production'
-			? `https://crowdsignal.localhost:9001/${ projectHash(
-					project
-			  ) }?preview=true`
+			? `https://crowdsignal.localhost:9001/${ project?.code }?preview=true`
 			: `${ project?.permalink }?preview=true`;
 
 	return (

--- a/apps/dashboard/src/util/project/index.js
+++ b/apps/dashboard/src/util/project/index.js
@@ -22,6 +22,10 @@ export const isPublic = ( project ) =>
 	get( project, [ 'content', 'public' ], false );
 
 export const projectHash = ( project ) => {
+	if ( ! project ) {
+		return '';
+	}
+
 	const url = new window.URL( project.permalink );
 	const match = url.pathname.match( /^\/([0-9a-fA-F]+)\/?/ );
 

--- a/apps/dashboard/src/util/project/index.js
+++ b/apps/dashboard/src/util/project/index.js
@@ -20,3 +20,10 @@ export const getLastUpdatedDate = ( project ) =>
 
 export const isPublic = ( project ) =>
 	get( project, [ 'content', 'public' ], false );
+
+export const projectHash = ( project ) => {
+	const url = new window.URL( project.permalink );
+	const match = url.pathname.match( /^\/([0-9a-fA-F]+)\/?/ );
+
+	return match ? match[ 1 ] : '';
+};

--- a/apps/dashboard/src/util/project/index.js
+++ b/apps/dashboard/src/util/project/index.js
@@ -20,14 +20,3 @@ export const getLastUpdatedDate = ( project ) =>
 
 export const isPublic = ( project ) =>
 	get( project, [ 'content', 'public' ], false );
-
-export const projectHash = ( project ) => {
-	if ( ! project ) {
-		return '';
-	}
-
-	const url = new window.URL( project.permalink );
-	const match = url.pathname.match( /^\/([0-9a-zA-Z-]+)\/?/ );
-
-	return match ? match[ 1 ] : '';
-};

--- a/apps/dashboard/src/util/project/index.js
+++ b/apps/dashboard/src/util/project/index.js
@@ -27,7 +27,7 @@ export const projectHash = ( project ) => {
 	}
 
 	const url = new window.URL( project.permalink );
-	const match = url.pathname.match( /^\/([0-9a-fA-F]+)\/?/ );
+	const match = url.pathname.match( /^\/([0-9a-zA-Z-]+)\/?/ );
 
 	return match ? match[ 1 ] : '';
 };

--- a/apps/project-renderer/package.json
+++ b/apps/project-renderer/package.json
@@ -23,7 +23,9 @@
     "@crowdsignal/components": "^0.1.0",
     "@crowdsignal/form": "^0.1.0",
     "@crowdsignal/hooks": "^0.1.0",
+    "@crowdsignal/http": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
+    "@crowdsignal/router": "^0.1.0",
     "@wordpress/element": "^4.0.4",
     "@wordpress/i18n": "^4.2.4",
     "lodash": "^4.17.21"

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -17,6 +17,7 @@ import {
 } from '@crowdsignal/blocks';
 import { Form } from '@crowdsignal/form';
 import { useStylesheet } from '@crowdsignal/hooks';
+import { setHostOption } from '@crowdsignal/http';
 import { fetchProjectForm } from '@crowdsignal/rest-api';
 
 // TODO: this is just to make the render look good, selected theme should take care of this?
@@ -26,7 +27,13 @@ const ContentWrapper = styled.div`
 	padding: 20px;
 `;
 
-const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
+const App = ( {
+	projectCode,
+	page = 0,
+	preview,
+	respondentId = '',
+	startTime = 0,
+} ) => {
 	const [ content, setContent ] = useState( [] );
 	// eslint-disable-next-line
 	const [ startDate, setStartDate ] = useState( startTime );
@@ -38,7 +45,16 @@ const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
 	const [ hasResponded, setHasResponded ] = useState( false );
 
 	useEffect( () => {
-		fetchProjectForm( projectCode )
+		if ( preview ) {
+			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
+			setHostOption(
+				'https://api.crowdsignal.com',
+				'credentials',
+				'include'
+			);
+		}
+
+		fetchProjectForm( projectCode, preview ? { preview: true } : {} )
 			.then( ( res ) => {
 				if ( ! res.data || ! res.data.content ) {
 					throw new Error( 'Empty response' );
@@ -51,7 +67,7 @@ const App = ( { projectCode, page = 0, respondentId = '', startTime = 0 } ) => {
 				// eslint-disable-next-line
 				console.log( err );
 			} );
-	}, [ projectCode ] );
+	}, [ projectCode, preview ] );
 
 	useStylesheet( 'https://app.crowdsignal.com/themes/leven/style.css' );
 	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -16,10 +16,20 @@ const renderProject = () => {
 		return;
 	}
 
+	const projectProps = {};
+
+	if ( container.dataset.pid ) {
+		projectProps.projectCode = container.dataset.pid;
+	}
+
 	return render(
 		<StyleProvider reset>
 			<Router>
-				<Route path="/:projectCode" component={ App } />
+				<Route
+					path="/:projectCode"
+					component={ App }
+					{ ...projectProps }
+				/>
 			</Router>
 		</StyleProvider>,
 		container

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -7,6 +7,7 @@ import { render } from '@wordpress/element';
  * Internal dependencies
  */
 import { StyleProvider } from '@crowdsignal/components';
+import { Route, Router } from '@crowdsignal/router';
 import App from './components/app';
 
 const renderProject = () => {
@@ -14,21 +15,12 @@ const renderProject = () => {
 	if ( ! container ) {
 		return;
 	}
-	const { pid, page, rid, startDate } = container.dataset;
-
-	// default to location path
-	const projectId = pid
-		? pid
-		: window.location.pathname.replaceAll( '/', '' );
 
 	return render(
 		<StyleProvider reset>
-			<App
-				projectCode={ projectId }
-				page={ page }
-				respondentId={ rid }
-				startTime={ startDate }
-			/>
+			<Router>
+				<Route path="/:projectCode" component={ App } />
+			</Router>
 		</StyleProvider>,
 		container
 	);

--- a/packages/http/src/index.js
+++ b/packages/http/src/index.js
@@ -25,6 +25,13 @@ const globalHeaders = {
 const hostHeaders = {};
 
 /**
+ * Host specific options added to every request to the host.
+ *
+ * @type {Object}
+ */
+const hostOptions = {};
+
+/**
  * Adds a key/value pair to the global headers array that's
  * appended to every ajax request.
  *
@@ -65,6 +72,22 @@ export const getHeader = ( key, host = '' ) => {
 
 	return globalHeaders[ key ];
 };
+
+/**
+ * Adds a key/value pair to the host specific options array
+ * appended to every ajax request to the given host.
+ *
+ * @param  {string} host  Hostname including protocol.
+ *                        Should be the same as the 'host' param for http() calls.
+ * @param  {string} key   Option key
+ * @param  {string} value Option value
+ * @return {void}
+ */
+export const setHostOption = ( host, key, value ) =>
+	( hostOptions[ host ] = {
+		...hostOptions[ host ],
+		[ key ]: value,
+	} );
 
 /**
  * Handles failed requests/error responses.
@@ -109,12 +132,10 @@ const onRequestSuccess = ( rawResponse ) => {
  * @return {Promise}         Request promise.
  */
 export const http = ( options ) => {
-	const requestOptions = omit( options, [
-		'headers',
-		'host',
-		'path',
-		'query',
-	] );
+	const requestOptions = {
+		...( hostOptions[ options.host ] || [] ),
+		...omit( options, [ 'headers', 'host', 'path', 'query' ] ),
+	};
 
 	requestOptions.headers = merge(
 		globalHeaders,

--- a/packages/rest-api/src/project/index.js
+++ b/packages/rest-api/src/project/index.js
@@ -35,9 +35,10 @@ export const updateProject = ( projectId, data ) =>
 		body: JSON.stringify( data ),
 	} );
 
-export const fetchProjectForm = ( projectId ) =>
+export const fetchProjectForm = ( projectId, query = {} ) =>
 	http( {
 		host: 'https://api.crowdsignal.com',
 		path: `/v4/projects/${ projectId }/form`,
 		method: 'GET',
+		query,
 	} );

--- a/packages/router/src/route.js
+++ b/packages/router/src/route.js
@@ -9,7 +9,7 @@ import { createElement, useContext } from '@wordpress/element';
 import { RouterContext } from './context';
 import { matchRoute } from './util';
 
-export const Route = ( { component, path } ) => {
+export const Route = ( { component, path, ...props } ) => {
 	const currentLocation = useContext( RouterContext );
 
 	const match = matchRoute( path, currentLocation.path );
@@ -18,5 +18,9 @@ export const Route = ( { component, path } ) => {
 		return null;
 	}
 
-	return createElement( component, { ...match, ...currentLocation.query } );
+	return createElement( component, {
+		...match,
+		...currentLocation.query,
+		...props,
+	} );
 };


### PR DESCRIPTION
This patch moves the preview responsibility into the project renderer to improve consistency and reduce complexity. The goal of these changes is to eventually completely remove `/project/:projectId/preview` but that in itself is not part of this PR.

Solves c/JApCaglu-tr.

# Testing

This PR depends on D71331-code.

Also make sure to run both `@crowdsignal/dashboard` and `@crowdsignal/project-renderer` when testing this.

- Verify that the projects `Preview` link correctly redirects you to the project renderer.
- Inside project renderer, you should be able to see the latest draft version whenever the url has `?preview=true` appended. Public otherwise.
- The 'public' URL should still work as expected.

Note that there are still a few edge cases which will be addressed separately: for example attempting to access `?preview=true` while not logged in or as a different user will just give you a blank page.  
We need to implement error handling for project-renderer in general and this would be done separately.