### PR TITLE
Update multiple choice answer styles

### DIFF
--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -11,10 +11,6 @@ import { useColorStyles } from '@crowdsignal/styles';
 
 const StyledButtonWrapper = styled.div`
 	display: flex;
-
-	&.is-selected {
-		filter: invert( 1 );
-	}
 `;
 
 const StyledButton = styled.button`
@@ -26,6 +22,12 @@ const StyledButton = styled.button`
 
 	&.rich-text {
 		cursor: text;
+	}
+
+	${ StyledButtonWrapper }.is-selected & {
+		background-color: var(
+			--crowdsignal-forms-button-selected-background-color
+		);
 	}
 `;
 

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -28,6 +28,7 @@ const CheckboxWrapper = styled.div`
 	margin-right: 0.7em;
 	overflow: hidden;
 	position: relative;
+	transform: translateY( 1px );
 	width: 1em;
 
 	&.is-selected {

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -35,20 +35,18 @@ const CheckboxWrapper = styled.div`
 	}
 
 	&.is-selected::after {
-		border-color: #fff;
+		border-color: inherit;
 		border-style: solid;
-		border-width: 0 0 2px 2px;
+		border-width: 0 0 3px 3px;
 		box-sizing: border-box;
 		content: '';
 		display: inline-flex;
-		height: 0.25em;
-		margin: -20% 0 0 -30%;
-		mix-blend-mode: unset;
+		filter: invert( 1 ) grayscale( 1 ) contrast( 100 );
+		height: 50%;
+		margin: 0;
 		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: rotateZ( -45deg );
-		width: 0.5em;
+		transform: scale( 0.7 ) rotate( -45deg );
+		width: 100%;
 	}
 
 	&.is-radio {
@@ -69,6 +67,7 @@ const CheckboxWrapper = styled.div`
 		background-blend-mode: multiply;
 		border: 4.5px solid transparent;
 		border-radius: 50%;
+		filter: none;
 		height: 1em;
 		margin: 0;
 		position: absolute;

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -31,6 +31,10 @@ const CheckboxWrapper = styled.div`
 	transform: translateY( 1px );
 	width: 1em;
 
+	.crowdsignal-forms-button & {
+		transform: none;
+	}
+
 	&.is-selected {
 		background-color: currentColor;
 	}

--- a/packages/blocks/src/multiple-choice-answer/button.js
+++ b/packages/blocks/src/multiple-choice-answer/button.js
@@ -22,7 +22,12 @@ const ButtonContent = styled.span`
 	}
 `;
 
-const ButtonAnswer = ( { attributes, className, inputProps } ) => {
+const ButtonAnswer = ( {
+	attributes,
+	className,
+	inputProps,
+	isMultiSelect,
+} ) => {
 	const width = attributes.width ? `${ attributes.width }%` : null;
 
 	return (
@@ -40,7 +45,7 @@ const ButtonAnswer = ( { attributes, className, inputProps } ) => {
 				{ attributes.label }
 
 				<Checkmark
-					attributes={ attributes }
+					isMultiSelect={ isMultiSelect }
 					isSelected={ inputProps.checked }
 				/>
 			</ButtonContent>

--- a/packages/blocks/src/multiple-choice-answer/button.js
+++ b/packages/blocks/src/multiple-choice-answer/button.js
@@ -7,12 +7,14 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { Button, FormCheckbox } from '../components';
+import Checkmark from './checkmark';
 
 const ButtonContent = styled.span`
 	align-items: center;
 	display: flex;
 	overflow: hidden;
 	position: relative;
+	width: 100%;
 
 	${ FormCheckbox.className }.is-radio {
 		position: absolute;
@@ -36,6 +38,11 @@ const ButtonAnswer = ( { attributes, className, inputProps } ) => {
 				<FormCheckbox { ...inputProps } />
 
 				{ attributes.label }
+
+				<Checkmark
+					attributes={ attributes }
+					isSelected={ inputProps.checked }
+				/>
 			</ButtonContent>
 		</Button>
 	);

--- a/packages/blocks/src/multiple-choice-answer/button.js
+++ b/packages/blocks/src/multiple-choice-answer/button.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { RichText } from '@wordpress/block-editor';
 import styled from '@emotion/styled';
 
 /**
@@ -42,7 +43,7 @@ const ButtonAnswer = ( {
 			<ButtonContent>
 				<FormCheckbox { ...inputProps } />
 
-				{ attributes.label }
+				<RichText.Content value={ attributes.label } />
 
 				<Checkmark
 					isMultiSelect={ isMultiSelect }

--- a/packages/blocks/src/multiple-choice-answer/checkbox.js
+++ b/packages/blocks/src/multiple-choice-answer/checkbox.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { useColorStyles } from '@crowdsignal/styles';
@@ -12,7 +17,7 @@ const Checkbox = ( { attributes, className, inputProps } ) => {
 		>
 			<FormCheckbox { ...inputProps } />
 
-			{ attributes.label }
+			<RichText.Content value={ attributes.label } />
 		</FormCheckbox.Label>
 	);
 };

--- a/packages/blocks/src/multiple-choice-answer/checkmark.js
+++ b/packages/blocks/src/multiple-choice-answer/checkmark.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+const Checkmark = styled.span`
+	display: inline-block;
+	box-sizing: content-box;
+	height: 1em;
+	margin-left: auto;
+	padding-left: 16px;
+	width: 1em;
+
+	&::before {
+		border-bottom: 6px solid currentColor;
+		border-right: 6px solid currentColor;
+		content: '';
+		display: block;
+		margin: 0 auto;
+		height: 100%;
+		transform: scale( 0.5 ) rotate( 45deg ) translateY( -5px )
+			translateX( -5px );
+		width: 50%;
+	}
+`;
+
+const CheckmarkWrapper = ( { attributes, isSelected } ) => {
+	if ( attributes.isMultiSelect || ! isSelected ) {
+		return null;
+	}
+
+	return <Checkmark />;
+};
+
+export default CheckmarkWrapper;

--- a/packages/blocks/src/multiple-choice-answer/checkmark.js
+++ b/packages/blocks/src/multiple-choice-answer/checkmark.js
@@ -24,8 +24,8 @@ const Checkmark = styled.span`
 	}
 `;
 
-const CheckmarkWrapper = ( { attributes, isSelected } ) => {
-	if ( attributes.isMultiSelect || ! isSelected ) {
+const CheckmarkWrapper = ( { isMultiSelect, isSelected } ) => {
+	if ( isMultiSelect || ! isSelected ) {
 		return null;
 	}
 

--- a/packages/blocks/src/multiple-choice-answer/index.js
+++ b/packages/blocks/src/multiple-choice-answer/index.js
@@ -56,6 +56,7 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 			attributes={ attributes }
 			className={ classes }
 			inputProps={ inputProps }
+			isMultiSelect={ isMultiSelect }
 		/>
 	);
 };

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -1,3 +1,7 @@
+:root {
+	--crowdsignal-forms-button-selected-background-color: #1285ce;
+}
+
 .crowdsignal-forms-button {
 	.crowdsignal-forms-multiple-choice-question-block & + *:not(&) {
 		margin-top: 16px;


### PR DESCRIPTION
This patch updates the selection styles for multiple choice answers. Solves c/7l4loi8V-tr.

![Screen Shot 2021-12-13 at 7 03 17 PM](https://user-images.githubusercontent.com/8056203/145865566-83710c76-ae58-4cd2-83b0-145ca04b862a.png)
![Screen Shot 2021-12-13 at 7 02 39 PM](https://user-images.githubusercontent.com/8056203/145865575-568e1a55-4892-4cfe-8bb0-70bb4299f114.png)
![Screen Shot 2021-12-13 at 7 05 44 PM](https://user-images.githubusercontent.com/8056203/145865582-75f6518f-4687-45d1-a4da-8e2a46aef8db.png)
![Screen Shot 2021-12-13 at 7 06 19 PM](https://user-images.githubusercontent.com/8056203/145865595-587a7182-f639-4279-af0a-6e919e5a2273.png)

# Testing

Make sure to run `yarn workspace @crowdsignal/theme-compatibility build` before testing.

- Create multiple choice blocks using button and list styles, in multiple- and single-choice modes.
- Make sure the selection styles are correct and clearly visible for each one.