### PR TITLE
Collapse color and border settings panel by default

### DIFF
--- a/packages/block-editor/src/components/border-settings/index.js
+++ b/packages/block-editor/src/components/border-settings/index.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-const BorderSettings = ( { attributes, setAttributes } ) => {
+const BorderSettings = ( { attributes, setAttributes, initialOpen } ) => {
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
 			[ key ]: value,
@@ -22,6 +22,7 @@ const BorderSettings = ( { attributes, setAttributes } ) => {
 	return (
 		<PanelColorGradientSettings
 			title={ __( 'Border', 'blocks' ) }
+			initialOpen={ initialOpen }
 			settings={ [
 				{
 					label: __( 'Border color', 'blocks ' ),

--- a/packages/block-editor/src/components/color-settings/index.js
+++ b/packages/block-editor/src/components/color-settings/index.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-const ColorSettings = ( { attributes, setAttributes } ) => {
+const ColorSettings = ( { attributes, setAttributes, initialOpen } ) => {
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
 			[ key ]: value,
@@ -18,6 +18,7 @@ const ColorSettings = ( { attributes, setAttributes } ) => {
 		<PanelColorGradientSettings
 			title={ __( 'Color', 'blocks' ) }
 			disableCustomGradients={ false }
+			initialOpen={ initialOpen }
 			settings={ [
 				{
 					label: __( 'Text color', 'blocks' ),

--- a/packages/block-editor/src/multiple-choice-question/sidebar.js
+++ b/packages/block-editor/src/multiple-choice-question/sidebar.js
@@ -54,10 +54,12 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 			</PanelBody>
 
 			<ColorSettings
+				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>
 			<BorderSettings
+				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>

--- a/packages/block-editor/src/text-input/sidebar.js
+++ b/packages/block-editor/src/text-input/sidebar.js
@@ -61,6 +61,7 @@ export default ( { attributes, setAttributes } ) => {
 				</ToggleGroupControl>
 			</PanelBody>
 			<ColorSettings
+				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>

--- a/packages/block-editor/src/text-question/sidebar.js
+++ b/packages/block-editor/src/text-question/sidebar.js
@@ -42,10 +42,12 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 			</PanelBody>
 
 			<ColorSettings
+				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>
 			<BorderSettings
+				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>


### PR DESCRIPTION
## Summary

The purpose of this PR is to set the color and border panel to be closed by default in the sidebar.
The affected blocks are:

* Text Question
* Multiple Choice Question
* Text Input Form

Ref: c/UxeXfX8Q-tr

## Test Instructions

* Checkout this branch, setup and run the `dashboard`
* Open or create a new project
* Add at least one instance of each affected block
* Check if the Border and Color settings are closed by default in the sidebar, for each block