### PR TITLE
Fix style inconsistencies between the editor and project renderer

### DIFF
--- a/apps/dashboard/src/components/editor/style.scss
+++ b/apps/dashboard/src/components/editor/style.scss
@@ -62,6 +62,7 @@ html.interface-interface-skeleton__html-container {
 	.block-editor-block-list__layout.is-root-container {
 		padding-left: 0;
 		padding-right: 0;
+		padding-top: 40px;
 	}
 
 	.components-panel__header.edit-post-sidebar__panel-tabs ul {

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -129,8 +129,14 @@ const App = ( {
 	}
 
 	return (
-		<Form name={ `f-${ projectCode }` } onSubmit={ handleSubmit }>
-			<ContentWrapper>{ renderContent() }</ContentWrapper>
+		<Form
+			className="crowdsignal-forms-form"
+			name={ `f-${ projectCode }` }
+			onSubmit={ handleSubmit }
+		>
+			<ContentWrapper className="crowdsignal-forms-form__content">
+				{ renderContent() }
+			</ContentWrapper>
 		</Form>
 	);
 };

--- a/packages/block-editor/src/multiple-choice-question/attributes.js
+++ b/packages/block-editor/src/multiple-choice-question/attributes.js
@@ -33,15 +33,15 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
-		default: 0,
+		default: 5,
 	},
 	boxShadow: {
 		type: 'boolean',
-		default: true,
+		default: false,
 	},
 	borderWidth: {
 		type: 'number',
-		default: 0,
+		default: 1,
 	},
 	gradient: {
 		type: 'string',

--- a/packages/block-editor/src/multiple-choice-question/attributes.js
+++ b/packages/block-editor/src/multiple-choice-question/attributes.js
@@ -37,11 +37,11 @@ export default {
 	},
 	boxShadow: {
 		type: 'boolean',
-		default: false,
+		default: true,
 	},
 	borderWidth: {
 		type: 'number',
-		default: 2,
+		default: 0,
 	},
 	gradient: {
 		type: 'string',

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -29,15 +29,15 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
-		default: 0,
+		default: 5,
 	},
 	boxShadow: {
 		type: 'boolean',
-		default: true,
+		default: false,
 	},
 	borderWidth: {
 		type: 'number',
-		default: 0,
+		default: 1,
 	},
 	fontFamily: {
 		type: 'string',

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -33,11 +33,11 @@ export default {
 	},
 	boxShadow: {
 		type: 'boolean',
-		default: false,
+		default: true,
 	},
 	borderWidth: {
 		type: 'number',
-		default: 2,
+		default: 0,
 	},
 	fontFamily: {
 		type: 'string',

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -20,6 +20,10 @@ const StyledQuestionWrapper = styled.div`
 	position: relative;
 	text-align: left;
 	width: 100%;
+
+	&.has-box-shadow {
+		box-shadow: 2px 2px 8px rgba( 0, 0, 0, 0.23 );
+	}
 `;
 
 const Content = styled.div`
@@ -49,7 +53,10 @@ const QuestionWrapper = ( {
 } ) => {
 	const classes = classnames(
 		'crowdsignal-forms-question-wrapper',
-		className
+		className,
+		{
+			'has-box-shadow': attributes.boxShadow,
+		}
 	);
 
 	return (

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -16,7 +16,7 @@ const StyledQuestionWrapper = styled.div`
 	flex-direction: column;
 	margin-bottom: 24px;
 	margin-top: 24px;
-	padding: 24px;
+	padding: 32px;
 	position: relative;
 	text-align: left;
 	width: 100%;

--- a/packages/theme-compatibility/stylesheets/leven-editor.scss
+++ b/packages/theme-compatibility/stylesheets/leven-editor.scss
@@ -1,3 +1,11 @@
+.editor .iso-editor .block-editor-writing-flow {
+	font-family: "Crimson Text", sans-serif;
+	font-family: var(--font-base, "Crimson Text", sans-serif);
+	font-size: 18px;
+	font-weight: normal;
+	line-height: 1.78;
+}
+
 .crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout > * {
 	margin-top: 0;
 	margin-bottom: 16px;

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -20,3 +20,7 @@
 		margin-bottom: 32px;
 	}
 }
+
+.crowdsignal-forms-question-wrapper {
+	background-color: #fff;
+}

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -12,3 +12,11 @@
 	margin-bottom: 64px;
 	margin-top: 64px;
 }
+
+.crowdsignal-forms-form__content {
+	padding: 64px 0 32px;
+
+	& > *:not(.crowdsignal-forms-question-wrapper) {
+		margin-bottom: 32px;
+	}
+}

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -23,4 +23,5 @@
 
 .crowdsignal-forms-question-wrapper {
 	background-color: #fff;
+	border-color: #eee;
 }


### PR DESCRIPTION
This patch fixes any remaining style inconsistencies not yet addressed in #97, #100 or #108. This includes:

- More consistent spacing*
- Updated ...Question blocks to feature a solid background and a shadow by default.
- Added padding at the top of the editor so the toolbar for the uppermost block doesn't get cut-off.

_Note: The spacing remains a little inconsistent between the editor and project-editor. Specifically, in case of nested blocks, some of them might have extra margin in the editor but appear closer together on the public view. I did test the same theme and blocks combination on a WordPress site and got the exact same behavior. See the example below:_

Editor:

![Screen Shot 2021-12-14 at 5 10 01 PM](https://user-images.githubusercontent.com/8056203/146035789-0cbb71c8-8f34-4dc1-b1f5-a6b493df45dd.png)

Preview:

![Screen Shot 2021-12-14 at 5 10 19 PM](https://user-images.githubusercontent.com/8056203/146035820-660397ef-3ed4-4fdb-b9d1-e5a3cbaaff92.png)

# Testing

Make sure to run `yarn workspace @crowdsignal/theme-compatibility build` before testing.

- Create a new project and proceed to add various blocks.
- There shouldn't be any differences between the editor and the preview/project renderer other than the spacing one mentioned above.