### PR TITLE
Enable nonce usage in project-renderer for preview mode to work on survey.fm

### DIFF
--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -7,6 +7,7 @@ import { render } from '@wordpress/element';
  * Internal dependencies
  */
 import { StyleProvider } from '@crowdsignal/components';
+import { setHostHeader } from '@crowdsignal/http';
 import { Route, Router } from '@crowdsignal/router';
 import App from './components/app';
 
@@ -37,4 +38,14 @@ const renderProject = () => {
 };
 
 // eslint-disable-next-line @wordpress/no-global-event-listener
-window.addEventListener( 'load', renderProject );
+window.addEventListener( 'load', () => {
+	if ( document.body.dataset.ajaxNonce ) {
+		setHostHeader(
+			'https://api.crowdsignal.com',
+			'x-ajax-api-token',
+			document.body.dataset.ajaxNonce
+		);
+	}
+
+	renderProject();
+} );


### PR DESCRIPTION
This patch updates the `project-renderer` to accept a nonce, similar to the `dashboard` app, so we can make authenticated requests from survey.fm domains.  

Solves c/T9MG7flZ-tr.
Depends on D71582-code.

# Testing

To see if the code works, modify `project-renderer/public/index.html` with the following body tag:

```
<body data-ajax-nonce="foo">
```

When you refresh the page, you should notice requests going out to `api.crowdsignal.com` now have an `x-ajax-api-token: foo` header attached to them.