### PR TITLE
Add keywords for Crowdsignal blocks

### DIFF
--- a/packages/block-editor/src/multiple-choice-answer/index.js
+++ b/packages/block-editor/src/multiple-choice-answer/index.js
@@ -16,6 +16,11 @@ const settings = {
 	title: __( 'Answer', 'blocks' ),
 	description: __( 'Add more answer options to your question', 'blocks' ),
 	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'answer', 'block-edtor' ),
+		__( 'option', 'block-edtor' ),
+		__( 'choice', 'block-edtor' ),
+	],
 	icon: <MultipleChoiceAnswerIcon />,
 	parent: [ 'crowdsignal-forms/multiple-choice-question' ],
 	edit: EditMultipleChoiceAnswer,

--- a/packages/block-editor/src/multiple-choice-question/index.js
+++ b/packages/block-editor/src/multiple-choice-question/index.js
@@ -22,6 +22,15 @@ const settings = {
 		'blocks'
 	),
 	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'multiple choice', 'block-edtor' ),
+		__( 'question', 'block-edtor' ),
+		__( 'form', 'block-edtor' ),
+		__( 'quiz', 'block-edtor' ),
+		__( 'poll', 'block-edtor' ),
+		__( 'mc', 'block-edtor' ),
+		__( 'mc question', 'block-edtor' ),
+	],
 	icon: <MultipleChoiceQuestionIcon />,
 	edit: EditMultipleChoiceQuestion,
 	save: () => <InnerBlocks.Content />,

--- a/packages/block-editor/src/submit-button/index.js
+++ b/packages/block-editor/src/submit-button/index.js
@@ -16,6 +16,13 @@ const settings = {
 	title: __( 'Submit Button', 'blocks' ),
 	description: __( 'Submit the form', 'blocks' ),
 	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'submit', 'block-edtor' ),
+		__( 'button', 'block-edtor' ),
+		__( 'continue', 'block-edtor' ),
+		__( 'next', 'block-edtor' ),
+		__( 'send', 'block-edtor' ),
+	],
 	icon: <SubmitButtonIcon />,
 	edit: EditSubmitButton,
 	attributes,

--- a/packages/block-editor/src/text-input/index.js
+++ b/packages/block-editor/src/text-input/index.js
@@ -20,6 +20,11 @@ const settings = {
 		'block-editor'
 	),
 	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'form', 'block-edtor' ),
+		__( 'input', 'block-edtor' ),
+		__( 'text input', 'block-edtor' ),
+	],
 	icon: <TextInputIcon />,
 	edit: Edit,
 	attributes,

--- a/packages/block-editor/src/text-question/index.js
+++ b/packages/block-editor/src/text-question/index.js
@@ -20,6 +20,12 @@ const settings = {
 		'blocks'
 	),
 	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'question', 'block-edtor' ),
+		__( 'text', 'block-edtor' ),
+		__( 'open text', 'block-edtor' ),
+		__( 'input', 'block-edtor' ),
+	],
 	icon: <TextQuestionIcon />,
 	edit: EditFreeText,
 	attributes,


### PR DESCRIPTION
This patch adds keywords to Crowdsignal blocks for improved discoverability.

Solves c/5NnuyXMl-tr.

# Testing

You can verify if the keywords work by typing them in the inserter - matching blocks should show up.