### PR TITLE
Update Text Question and Text Input styles

### DIFF
--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -32,7 +32,10 @@ const EditTextInput = ( props ) => {
 	};
 
 	return (
-		<div style={ { ...useColorStyles( attributes ) } }>
+		<div
+			className="crowdsignal-forms-text-input-block"
+			style={ { ...useColorStyles( attributes ) } }
+		>
 			<Sidebar { ...props } />
 			<RichText
 				placeholder={ __( 'Enter form label', 'block-editor' ) }
@@ -49,7 +52,7 @@ const EditTextInput = ( props ) => {
 					height: `${ attributes.inputHeight }px`,
 				} }
 			>
-				<FormTextInput.Preview />
+				<FormTextInput.Preview className="crowdsignal-forms-text-input-block__wrapper" />
 			</ResizableBox>
 		</div>
 	);

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -47,6 +47,7 @@ export default {
 	},
 	inputHeight: {
 		type: 'string',
+		default: '80px',
 	},
 	textColor: {
 		type: 'string',

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -9,17 +9,14 @@ const FormTextInputWapper = styled.div`
 	pointer-events: none;
 `;
 
+const Input = styled.input`
+	width: 100%;
+	height: 100%;
+	min-height: 40px;
+`;
+
 const FormTextInput = ( { style = {}, ...props } ) => (
-	<input
-		type="text"
-		style={ {
-			width: '100%',
-			height: '100%',
-			minHeight: '40px',
-			...style,
-		} }
-		{ ...props }
-	/>
+	<Input type="text" style={ { ...style } } { ...props } />
 );
 
 FormTextInput.Preview = ( { className, ...props } ) => (

--- a/packages/theme-compatibility/stylesheets/leven-editor.scss
+++ b/packages/theme-compatibility/stylesheets/leven-editor.scss
@@ -20,3 +20,9 @@
 		margin-top: 32px;
 	}
 }
+
+.crowdsignal-forms-text-input-block {
+	&__wrapper input {
+		padding: 8px;
+	}
+}

--- a/packages/theme-compatibility/stylesheets/leven.scss
+++ b/packages/theme-compatibility/stylesheets/leven.scss
@@ -25,3 +25,7 @@
 	background-color: #fff;
 	border-color: #eee;
 }
+
+.crowdsignal-forms-text-input-block input {
+	padding: 8px;
+}


### PR DESCRIPTION
## Summary

The purpose of this PR is to make the Text Input and Text Question styles more consistent.
We want the paddings to be the same and the Text Question default input height to have room for at least 3 lines of text.

## Test Instructions

* Checkout this branch, setup and run the `dashboard` and the `project-renderer`
* Open or create a new project and add a Text Question and a Text Input block
* The padding for both blocks should be the same and the Text Question input height should have room for at least 3 lines of text