### PR TITLE
Include submit button when adding Text Input block

### DIFF
--- a/apps/dashboard/src/components/editor/auto-submit-button.js
+++ b/apps/dashboard/src/components/editor/auto-submit-button.js
@@ -13,6 +13,7 @@ import {
 	multipleChoiceAnswerBlock,
 	multipleChoiceQuestionBlock,
 	textQuestionBlock,
+	textInputBlock,
 	submitButtonBlock,
 } from '@crowdsignal/block-editor';
 
@@ -21,6 +22,7 @@ const FORM_BLOCKS = map(
 		multipleChoiceAnswerBlock,
 		multipleChoiceQuestionBlock,
 		textQuestionBlock,
+		textInputBlock,
 	],
 	'name'
 );


### PR DESCRIPTION
## Summary

When the user adds the first block that includes "input" or data collecting elements, we need by default add the submit button.
This works already for MC and Question Block but is not happening yet for Text Input block.

## Text Instructions

* Checkout this branch, setup and run the `dashboard`
* Using a project without a submit button, add a Text Input block
* Along with the added block, you should see a Submit Button right after the block