### PR TITLE
Fix project renderer's stylesheet URL when compiling for production

### DIFF
--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -68,7 +68,13 @@ const App = ( {
 	}, [ projectCode, preview ] );
 
 	useStylesheet( 'https://app.crowdsignal.com/themes/leven/style.css' );
-	useStylesheet( '/ui/stable/theme-compatibility/leven.min.css' );
+	useStylesheet(
+		`${
+			process.env.NODE_ENV === 'production'
+				? 'https://app.crowdsignal.com'
+				: ''
+		}/ui/stable/theme-compatibility/leven.min.css`
+	);
 
 	const handleSubmit = ( data ) => {
 		if ( ! data ) {


### PR DESCRIPTION
This is a small patch that explicitly lists the host from which to fetch the theme compatibility layer when `@crowdsignal/project-renderer` is compiled for production.  
This is so we can preserve our functionality inside the local development environment but so it won't break when the project renderer is embedded on a different domain than the theme compatibility stylesheet.

Solves c/5AMNs1n1-tr.

# Testing

Theme compatibility layer (`leven.min.scss`) should still load as usual in the local development environment.  
When compiled for production (`NODE_ENV=production`), it should load a stylesheet from `https://app.crowdsignal.com`.