### PR TITLE
Prevent Crowdsignal clientIds from being duplicated when blocks are duplicated

### DIFF
--- a/packages/block-editor/src/multiple-choice-answer/edit.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit.js
@@ -41,7 +41,7 @@ const EditMultipleChoiceAnswer = ( props ) => {
 
 	const questionAttributes = useParentAttributes( clientId );
 
-	useClientId( { attributes, setAttributes } );
+	useClientId( props );
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
 

--- a/packages/hooks/src/use-client-id/index.js
+++ b/packages/hooks/src/use-client-id/index.js
@@ -4,15 +4,30 @@
 import { useEffect } from '@wordpress/element';
 import { v4 as uuid } from 'uuid';
 
-const useClientId = ( { attributes, setAttributes } ) => {
+/**
+ * A list containing crowdsignal client IDs as keys and block ID's as values.
+ *
+ * @type {Object}
+ */
+const crowdsignalClientIds = {};
+
+const useClientId = ( { attributes, clientId: blockId, setAttributes } ) => {
 	useEffect( () => {
 		if ( attributes.clientId ) {
-			return;
+			if ( ! crowdsignalClientIds[ attributes.clientId ] ) {
+				crowdsignalClientIds[ attributes.clientId ] = blockId;
+			}
+
+			if ( crowdsignalClientIds[ attributes.clientId ] === blockId ) {
+				return;
+			}
 		}
 
-		setAttributes( {
-			clientId: uuid(),
-		} );
+		const clientId = uuid();
+
+		crowdsignalClientIds[ blockId ] = clientId;
+
+		setAttributes( { clientId } );
 	}, [] );
 };
 


### PR DESCRIPTION
This fixes an issue where Crowdsignal client IDs were being duplicated along with all other block settings whenever using "Duplicate Block" functionality.  

It'll also prevents the same issue when using copy/paste, and since block clientIds are mapped for each project individually, it should be possible to copy a set of questions from one project to another and them be recognized correctly in each one even though it's possible they'd share the same clientId at that point.

Solves c/Jj2Ae1XC-tr.

# Testing

Duplicate or copy&paste any of our Crowdsignal blocks and validate that `attributes.clientId` is different for the duplicated/copied instance on the outgoing save request.  
Reload the editor and save again - verify that `attributes.clientId` stays the same for questions/answers that already existed.

Additionally, a side-effect of this was that selecting an answer on a duplicated multiple choice block would also select the corresponding answer in the original one. This should no longer happen and answers should be tracked correctly and separately for each question.