### PR TITLE
Fix duplication of crowdsignal clientIDs

### DIFF
--- a/packages/hooks/src/use-client-id/index.js
+++ b/packages/hooks/src/use-client-id/index.js
@@ -25,7 +25,7 @@ const useClientId = ( { attributes, clientId: blockId, setAttributes } ) => {
 
 		const clientId = uuid();
 
-		crowdsignalClientIds[ blockId ] = clientId;
+		crowdsignalClientIds[ clientId ] = blockId;
 
 		setAttributes( { clientId } );
 	}, [] );


### PR DESCRIPTION
This patch addresses an issue that sneaked past in #119, where if you add a new block that didn't exist when the editor was loaded and duplicate it, the Crowdsignal clientID would still get duplicated.  

The issue was related to an incorrect key-value mapping in the object used for matching crowdsignal clientIDs with block clientIDs in the current editor session.

# Testing

 - Open the editor.
 - Add a new question block. 
 - Duplicate the question block.
 - `attributes.clientId` for both blocks should be different when saved.

The additional side-effect with multiple choice questions described in #119 should also no longer occur.