### PR TITLE
Add preview for Crowdsignal blocks

### DIFF
--- a/packages/block-editor/src/multiple-choice-question/index.js
+++ b/packages/block-editor/src/multiple-choice-question/index.js
@@ -59,6 +59,37 @@ const settings = {
 			},
 		},
 	],
+	example: {
+		attributes: {
+			question: __( 'What is your favorite food?', 'block-editor' ),
+		},
+		innerBlocks: [
+			{
+				name: 'crowdsignal-forms/multiple-choice-answer',
+				attributes: {
+					label: __( 'Pizza', 'block-editor' ),
+				},
+			},
+			{
+				name: 'crowdsignal-forms/multiple-choice-answer',
+				attributes: {
+					label: __( 'Hamburger', 'block-editor' ),
+				},
+			},
+			{
+				name: 'crowdsignal-forms/multiple-choice-answer',
+				attributes: {
+					label: __( 'Pasta', 'block-editor' ),
+				},
+			},
+			{
+				name: 'crowdsignal-forms/multiple-choice-answer',
+				attributes: {
+					label: __( 'Salad', 'block-editor' ),
+				},
+			},
+		],
+	},
 };
 
 export default {

--- a/packages/block-editor/src/submit-button/index.js
+++ b/packages/block-editor/src/submit-button/index.js
@@ -26,6 +26,11 @@ const settings = {
 	icon: <SubmitButtonIcon />,
 	edit: EditSubmitButton,
 	attributes,
+	example: {
+		attributes: {
+			label: __( 'Submit', 'block-editor' ),
+		},
+	},
 };
 
 export default {

--- a/packages/block-editor/src/text-input/index.js
+++ b/packages/block-editor/src/text-input/index.js
@@ -28,6 +28,11 @@ const settings = {
 	icon: <TextInputIcon />,
 	edit: Edit,
 	attributes,
+	example: {
+		attributes: {
+			label: __( 'Name', 'block-editor' ),
+		},
+	},
 };
 
 export default {

--- a/packages/block-editor/src/text-question/index.js
+++ b/packages/block-editor/src/text-question/index.js
@@ -33,6 +33,11 @@ const settings = {
 		html: false,
 		reusable: false,
 	},
+	example: {
+		attributes: {
+			question: __( 'How does gravity work?', 'block-editor' ),
+		},
+	},
 };
 
 export default {


### PR DESCRIPTION
## Summary

When hovering the mouse over a Crowdsignal block inside the block library, we see a message `No Preview Available`.
The purpose of this PR is to add previews for Crowdsignal blocks.

Ref: c/6cX4eSTC-tr

## Test Instructions

* Open or create a new project;
* Click the `+` button on the top left side of the screen;
* Hover the mouse over the Crowdsignal blocks;
* You should see a popup showing a block preview;

Note: This PR doesn't fix a known issue related to the block preview style. This should be handled in another PR.