### PR TITLE
Include empty paragraph when including submit button

### DIFF
--- a/apps/dashboard/src/components/editor/auto-submit-button.js
+++ b/apps/dashboard/src/components/editor/auto-submit-button.js
@@ -74,8 +74,15 @@ const AutoSubmitButton = () => {
 			submitButtonBlocks === 0
 		) {
 			insertBlock(
+				createBlock( 'core/paragraph' ),
+				totalBlocks + 1,
+				'',
+				false
+			);
+
+			insertBlock(
 				createBlock( submitButtonBlock.name ),
-				totalBlocks,
+				totalBlocks + 2,
 				'',
 				false
 			);


### PR DESCRIPTION
## Summary

On the project editor, when including the first Form Block, we automatically include a Submit button.
It turns out that, since the Submit button is included right after the Form block and the way Gutenberg works, it gets hard to continue adding content between the first block and the Submit button.
The purpose of this PR is to include an empty paragraph before the Submit button to make it easier for the user to add content after the Form Block.

Ref: c/2qVSDGzP-tr

## Test Instructions

* Create a new project, or open one without any Form block and Submit button;
* Include a Form block;
* You should see the Submit button being added to the page but now, it's also added an empty paragraph between the Form Block and the Submit button;