### PR TITLE
Add scripts for running and building the entire Crowdsignal UI project

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "webpack-fix-style-only-entries": "^0.6.1"
   },
   "scripts": {
+    "build": "./scripts/build-release.sh",
     "check-licenses": "wp-scripts check-licenses --prod --gpl2",
     "format": "wp-scripts format",
     "lint:js": "wp-scripts lint-js",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
+    "start": "./scripts/build-development.sh",
     "storybook": "start-storybook -p 8000",
     "postinstall": "node ./node_modules/husky/lib/bin install"
   },

--- a/scripts/build-development.sh
+++ b/scripts/build-development.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+yarn workspace @crowdsignal/dashboard start &
+yarn workspace @crowdsignal/project-renderer start &
+yarn workspace @crowdsignal/theme-compatibility build --watch

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROJECT_DIR="$(dirname "$0")/.."
+TARGET_DIR="$PROJECT_DIR/dist"
+
+APPS=(
+	"dashboard"
+	"project-renderer"
+)
+
+PACKAGES=(
+	"theme-compatibility"
+)
+
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+for app in ${APPS[@]}; do
+	rm -rf "$PROJECT_DIR/apps/$app/dist"
+
+	NODE_ENV=production yarn workspace @crowdsignal/${app} build
+
+	cp -R "$PROJECT_DIR/apps/$app/dist" "$TARGET_DIR/$app"
+done
+
+for pkg in ${PACKAGES[@]}; do
+	rm -rf "${PROJECT_DIR}/packages/$pkg/dist"
+
+	NODE_ENV=production yarn workspace @crowdsignal/${pkg} build
+
+	cp -R "${PROJECT_DIR}/packages/$pkg/dist" "$TARGET_DIR/$pkg"
+done


### PR DESCRIPTION
This is a small but effective quality of life improvement which will allow us to run all of our apps as well as build the complete bundle with one command.

- `yarn build`: Builds all relevant bundles and outputs the result inside `/dist` where each package/app goes into its own subfolder names after it.
- `yarn start`: Spins up the development environment. Currently that's `@crowdsignal/dashboard`, `@crowdsignal/project-renderer` and `@crowdsignal/theme-compatibility`.

This should free up a few of those precious shell sessions but on a more serious note, it should also prevent any issues while testing due to forgetting to build/refresh a part of the application.

# Testing

Verify the commands above work as described.