### PR TITLE
Update Editor and Results header styles

### DIFF
--- a/apps/dashboard/src/components/masterbar/styles.scss
+++ b/apps/dashboard/src/components/masterbar/styles.scss
@@ -3,11 +3,13 @@
 	background: var(--color-secondary-90);
 	box-sizing: border-box;
 	display: flex;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 	height: 64px;
 	justify-content: center;
 	padding: 0;
 	position: relative;
 	width: 100%;
+	-webkit-font-smoothing: antialiased;
 
 	&.is-admin {
 		background: linear-gradient(135deg, var(--color-secondary-90) 10%, var(--color-highlight) 100%);

--- a/apps/dashboard/src/components/masterbar/styles.scss
+++ b/apps/dashboard/src/components/masterbar/styles.scss
@@ -10,6 +10,7 @@
 	position: relative;
 	width: 100%;
 	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 
 	&.is-admin {
 		background: linear-gradient(135deg, var(--color-secondary-90) 10%, var(--color-highlight) 100%);

--- a/apps/dashboard/src/components/project-navigation/style.scss
+++ b/apps/dashboard/src/components/project-navigation/style.scss
@@ -2,13 +2,20 @@
 	align-items: center;
 	background-color: var(--color-surface);
 	border-bottom: 1px solid var(--color-border);
+	color: var(--color-neutral-80);
 	box-sizing: border-box;
 	display: grid;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 	grid-template-columns: 1fr auto 1fr;
 	padding: 0 32px;
 	width: 100%;
+	-webkit-font-smoothing: initial;
 
 	.tab-navigation {
 		border-bottom: 0;
+	}
+
+	.page-header {
+		letter-spacing: initial;
 	}
 }

--- a/apps/dashboard/src/components/project-navigation/style.scss
+++ b/apps/dashboard/src/components/project-navigation/style.scss
@@ -10,6 +10,7 @@
 	padding: 0 32px;
 	width: 100%;
 	-webkit-font-smoothing: initial;
+	-moz-osx-font-smoothing: initial;
 
 	.tab-navigation {
 		border-bottom: 0;


### PR DESCRIPTION
## Summary

The purpose of this PR is to make the header styles for the Editor and Results tabs consistent.
Currently, when switching between those two tabs, the loaded styles are a bit different, causing a tiny flickering.

Ref: c/uprHKmOb-tr

## Test Instructions

* Open or create a new project;
* Switch between the Editor and the Results tab;
* The header texts should look equal on both tabs and you should not see any flickering;