### PR TITLE
Add missing classNames to Crowdsignal blocks

### DIFF
--- a/packages/block-editor/src/poll-answer/edit.js
+++ b/packages/block-editor/src/poll-answer/edit.js
@@ -4,6 +4,7 @@
 import { RichText } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -31,6 +32,11 @@ const PollAnswer = ( props ) => {
 
 	const width = attributes.width ? `${ attributes.width }%` : null;
 
+	const classes = classnames(
+		'crowdsignal-forms-poll-answer-block',
+		className
+	);
+
 	return (
 		<>
 			<Sidebar { ...props } />
@@ -38,7 +44,7 @@ const PollAnswer = ( props ) => {
 			<Button
 				attributes={ attributes }
 				as={ RichText }
-				className={ className }
+				className={ classes }
 				style={ {
 					width,
 				} }

--- a/packages/block-editor/src/poll/edit.js
+++ b/packages/block-editor/src/poll/edit.js
@@ -5,6 +5,7 @@ import { InnerBlocks, RichText } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { includes, round } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -45,6 +46,8 @@ const PollBlock = ( props ) => {
 	const blockWidth =
 		attributes.align !== 'full' ? `${ attributes.width }%` : 'auto';
 
+	const classes = classnames( 'crowdsignal-forms-poll-block', className );
+
 	return (
 		<EditorWrapper>
 			<Sidebar { ...props } />
@@ -60,7 +63,7 @@ const PollBlock = ( props ) => {
 			>
 				<QuestionWrapper
 					attributes={ attributes }
-					className={ className }
+					className={ classes }
 				>
 					<RichText
 						tagName="h3"

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -4,6 +4,7 @@
 import { RichText } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import Sidebar from './sidebar';
 import { useClientId } from '@crowdsignal/hooks';
 
 const EditTextInput = ( props ) => {
-	const { attributes, setAttributes, isSelected } = props;
+	const { attributes, setAttributes, className, isSelected } = props;
 
 	useClientId( props );
 
@@ -30,10 +31,14 @@ const EditTextInput = ( props ) => {
 			inputWidth: `${ element.offsetWidth }px`,
 		} );
 	};
+	const classes = classnames(
+		className,
+		'crowdsignal-forms-text-input-block'
+	);
 
 	return (
 		<FormInputWrapper
-			className="crowdsignal-forms-text-input-block"
+			className={ classes }
 			style={ { ...useColorStyles( attributes ) } }
 		>
 			<Sidebar { ...props } />

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,14 +11,19 @@ import { useColorStyles } from '@crowdsignal/styles';
 import { FormInputWrapper, FormTextInput } from '../components';
 import { useField } from '@crowdsignal/form';
 
-const TextInput = ( { attributes } ) => {
+const TextInput = ( { attributes, className } ) => {
 	const { inputProps } = useField( {
 		name: `q_${ attributes.clientId }[text]`,
 	} );
 
+	const classes = classnames(
+		'crowdsignal-forms-text-input-block',
+		className
+	);
+
 	return (
 		<FormInputWrapper
-			className="crowdsignal-forms-text-input-block"
+			className={ classes }
 			style={ { ...useColorStyles( attributes ) } }
 		>
 			<FormInputWrapper.Label className="crowdsignal-forms-text-input-block__label">


### PR DESCRIPTION
## Summary

The purpose of this PR is to add a proper CSS class name to the Crowdsignal blocks that don't have it yet.

Ref: c/LvxBEcPZ-tr

## Test Instructions

* Open or create a new project;
* Add at least one instance of each Crowdsignal block;
* Inspect each of them and verify if all blocks have a CSS class according to the pattern: `crowdsignal-forms-[block-name]`