### PR TITLE
Open the editor sidebar by default

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -10,6 +10,7 @@ import {
 	PanelRow,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line import/named
 import { DocumentSection } from 'isolated-block-editor';
@@ -23,6 +24,7 @@ import { timestampToDate } from '../../util/date';
 import { isPublic, getLastUpdatedDate } from '../../util/project';
 
 const DocumentSettings = ( { project } ) => {
+	const { openGeneralSidebar } = useDispatch( 'isolated/editor' );
 	const { saveAndUpdateProject, saveEditorContent } = useDispatch(
 		STORE_NAME
 	);
@@ -31,6 +33,10 @@ const DocumentSettings = ( { project } ) => {
 		( select ) => select( 'core/block-editor' ).getBlocks(),
 		[]
 	);
+
+	useEffect( () => {
+		openGeneralSidebar( 'edit-post/document' );
+	}, [] );
 
 	const updateProjectVisibility = ( event ) => {
 		if ( event.target.value === 'private' ) {


### PR DESCRIPTION
This patch will force the editor sidebar to be open by default making settings more accessible to users.

Solves c/WsLxmq4P-tr.

# Testing

- Open the editor.
- The right sidebar should be open.