### PR TITLE
Fix toolbar button styles

### DIFF
--- a/apps/dashboard/src/components/editor/styles/button.js
+++ b/apps/dashboard/src/components/editor/styles/button.js
@@ -9,7 +9,7 @@ export const ToolbarButton = styled.button`
 	--wp-admin-theme-color-darker-20: var( --color-primary-70 );
 
 	&:disabled:not( .is-primary ) {
-		background-color: transparent;
+		background-color: transparent !important;
 	}
 `;
 


### PR DESCRIPTION
A wee fix for toolbar button styles which were getting overridden by base editor styles from the theme compatibility layer.  
As these are already quite specific in what they target and where they used, `!important` shouldn't cause issues in this case and prevent regressions in the future.

Before:

![Screen Shot 2022-01-13 at 2 14 57 PM](https://user-images.githubusercontent.com/8056203/149337120-704bfb9c-2b04-480d-9bfa-610a4c5d5b90.png)

After:

![Screen Shot 2022-01-13 at 2 13 55 PM](https://user-images.githubusercontent.com/8056203/149337135-96ac1cd6-c1a0-4a8f-aa65-766eb60f4eaf.png)

# Testing

Verify the toolbar buttons now have the correct appearance.