### PR TITLE
Fix image alignment inside MC Questions

### DIFF
--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -49,6 +49,13 @@
 	}
 }
 
+.wp-block-image {
+	.alignleft,.alignright {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
 .crowdsignal-forms-form__content {
 	padding: var(--crowdsignal-forms-content-padding);
 
@@ -99,6 +106,16 @@
 			}
 		}
 	}
+}
+
+.crowdsignal-forms-button {
+	.crowdsignal-forms-multiple-choice-question-block & + *:not(&) {
+		margin-top: 24px;
+	}
+}
+
+.crowdsignal-forms-multiple-choice-answer-block {
+	display: flex;
 }
 
 @include break-medium {

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -66,3 +66,35 @@
 		float: left;
 	}
 }
+
+.crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout {
+	> * {
+		margin-top: 0;
+		margin-bottom: 16px;
+
+		.wp-block.is-selected &:nth-last-child(2),
+		.wp-block.has-child-selected &:nth-last-child(2),
+		&:last-child {
+			margin-bottom: 0;
+		}
+
+		&[data-type="crowdsignal-forms/multiple-choice-answer"] + :not(.wp-block[data-type="crowdsignal-forms/multiple-choice-answer"]) {
+			margin-top: 32px;
+		}
+
+		&[data-align="left"], &[data-align="right"] {
+			figure {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+		}
+
+		.crowdsignal-forms-multiple-choice-answer-block {
+			margin-bottom: 0;
+		}
+
+		.components-resizable-box__container {
+			display: flex;
+		}
+	}
+}

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -26,6 +26,18 @@
 		margin-bottom: 64px;
 		margin-top: 64px;
 	}
+
+	.crowdsignal-forms-question-wrapper__content {
+		.block-editor-block-list__layout {
+			display: flex;
+			flex-direction: column;
+
+			.wp-block {
+				margin-left: unset;
+				margin-right: unset;
+			}
+		}
+	}
 }
 
 .editor .iso-editor {

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -67,34 +67,32 @@
 	}
 }
 
-.crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout {
-	> * {
+.crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout > * {
 		margin-top: 0;
 		margin-bottom: 16px;
 
-		.wp-block.is-selected &:nth-last-child(2),
-		.wp-block.has-child-selected &:nth-last-child(2),
-		&:last-child {
+	.wp-block.is-selected &:nth-last-child(2),
+	.wp-block.has-child-selected &:nth-last-child(2),
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	&[data-type="crowdsignal-forms/multiple-choice-answer"] + :not(.wp-block[data-type="crowdsignal-forms/multiple-choice-answer"]) {
+		margin-top: 32px;
+	}
+
+	&[data-align="left"], &[data-align="right"] {
+		figure {
+			margin-top: 0;
 			margin-bottom: 0;
 		}
+	}
 
-		&[data-type="crowdsignal-forms/multiple-choice-answer"] + :not(.wp-block[data-type="crowdsignal-forms/multiple-choice-answer"]) {
-			margin-top: 32px;
-		}
+	.crowdsignal-forms-multiple-choice-answer-block {
+		margin-bottom: 0;
+	}
 
-		&[data-align="left"], &[data-align="right"] {
-			figure {
-				margin-top: 0;
-				margin-bottom: 0;
-			}
-		}
-
-		.crowdsignal-forms-multiple-choice-answer-block {
-			margin-bottom: 0;
-		}
-
-		.components-resizable-box__container {
-			display: flex;
-		}
+	.components-resizable-box__container {
+		display: flex;
 	}
 }

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -23,10 +23,6 @@ body {
 }
 
 .crowdsignal-forms-button {
-	.crowdsignal-forms-multiple-choice-question-block & + *:not(&) {
-		margin-top: 16px;
-	}
-
 	&.is-selected & {
 		&__button {
 			background-color: var(--crowdsignal-forms-button-selected-background-color);

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -47,3 +47,7 @@ body {
 .crowdsignal-forms-text-question-block textarea {
 	border: 1px solid var(--crowdsignal-forms-input-border-color);
 }
+
+.wp-block-image {
+	text-align: unset;
+}

--- a/packages/theme-compatibility/src/leven/editor.scss
+++ b/packages/theme-compatibility/src/leven/editor.scss
@@ -6,18 +6,3 @@
 	font-weight: normal;
 	line-height: 1.78;
 }
-
-.crowdsignal-forms-question-wrapper__content .block-editor-block-list__layout > * {
-	margin-top: 0;
-	margin-bottom: 16px;
-
-	.wp-block.is-selected &:nth-last-child(2),
-	.wp-block.has-child-selected &:nth-last-child(2),
-	&:last-child {
-		margin-bottom: 0;
-	}
-
-	&[data-type="crowdsignal-forms/multiple-choice-answer"] + :not(.wp-block[data-type="crowdsignal-forms/multiple-choice-answer"]) {
-		margin-top: 32px;
-	}
-}


### PR DESCRIPTION
## Summary

The alignment of the images placed inside an MC Question is inconsistent between the Editor and the Project Renderer.
Also, on the Editor, if the image alignment is set to `left` or `right` the layout gets weird.

Ref: c/gsVmjQs9-tr

## Test Instructions

* Open or create a new project and add an MC Question block;
* Add a few images between the answers and play with the alignment of the images;
* The layout on the editor should look good;
* Also, check the Project Renderer, the layout should be consistent with the Editor layout.
