### PR TITLE
Fix editor/base.scss stylesheet

### DIFF
--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -29,42 +29,6 @@
 }
 
 .editor .iso-editor {
-	--wp-admin-theme-color: var(--color-neutral-80);
-	--wp-admin-theme-color-darker-10: var(--color-neutral-90);
-	--wp-admin-theme-color-darker-20: var(--color-neutral-100);
-
-	background-color: transparent;
-	border: 0;
-	color: var(--color-text);
-	flex: 1;
-	max-height: 100%;
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	top: 65px;
-
-	.edit-post-layout.interface-interface-skeleton {
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		top: 0;
-	}
-
-	.edit-post-visual-editor__content-area .is-desktop-preview {
-		background-color: transparent !important;
-	}
-
-	.interface-interface-skeleton__content > .components-notice-list .components-notice {
-		margin: 0;
-	}
-
-	.edit-post-visual-editor {
-		background-color: transparent;
-		position: relative;
-	}
-
 	.block-editor-writing-flow {
 		line-height: initial;
 	}


### PR DESCRIPTION
This is a small patch to clean up styles which already have been moved to [editor/styles/editor.js](https://github.com/Automattic/crowdsignal-ui/blob/main/apps/dashboard/src/components/editor/styles/editor.js), but I forgot to remove from [base/editor.scss](https://github.com/Automattic/crowdsignal-ui/blob/main/packages/theme-compatibility/src/base/editor.scss) in #138. By being duplicated, they're causing conflicts.

# Testing

- The changes should not affect the editor in its current state, functionally or visually.