### PR TITLE
Add .yarn and .yarnrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 lerna-debug.log
 npm-debug.log
 yarn-error.log
+.yarnrc
+.yarn


### PR DESCRIPTION
This PR adds `.yarn` directory and `.yarnrc` file to the .gitignore list

These 2 work together whenever a local change (such as `yarn policies set-version [VERSION]`) is called.

