### PR TITLE
Add image upload on image blocks

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -28,6 +28,7 @@
     "@crowdsignal/http": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/router": "^0.1.0",
+    "@wordpress/blob": "^3.2.2",
     "@wordpress/blocks": "^11.1.4",
     "@wordpress/components": "^19.1.1",
     "@wordpress/data": "^6.1.4",

--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 import { forEach } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import * as blocks from '@crowdsignal/block-editor';
-import { withEmptyClassName } from '@crowdsignal/block-editor-filters';
+import {
+	withEmptyClassName,
+	withMediaLinkDestination,
+} from '@crowdsignal/block-editor-filters';
+import { MediaUploader } from './media-upload';
 
 export const registerBlocks = () =>
 	forEach( blocks, ( block ) => {
@@ -20,4 +24,20 @@ addFilter(
 	'editor.BlockListBlock',
 	'crowdsignal-forms/with-empty-class-name',
 	withEmptyClassName
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'crowdsignal/with-media-link-destination',
+	withMediaLinkDestination
+);
+
+removeFilter( 'editor.MediaUpload', 'isolated-block-editor/media-upload' );
+
+// if this filter ain't here, settings.editor.mediaUpload will not take any effect (in fact, it will crash)
+addFilter(
+	'editor.MediaUpload',
+	'crowdsignal/media-upload',
+	() => MediaUploader,
+	15
 );

--- a/apps/dashboard/src/components/editor/media-upload.js
+++ b/apps/dashboard/src/components/editor/media-upload.js
@@ -1,0 +1,18 @@
+/**
+ * This is (for now) a mocking component. Invoked through a filter to render right next to the Upload button.
+ *
+ * Refs:
+ * - ./blocks.js
+ * - https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/media-placeholder
+ * - https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/media-upload
+ */
+export const MediaUploader = () => {
+	// const open = () => console.log( 'should spawn some media library modal' );
+	// return (
+	// 	<div>
+	// 		<Button onClick={ open }>Open Media Library</Button>
+	// 	</div>
+	// );
+
+	return null;
+};

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -4,6 +4,9 @@
 import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+// test
+import { uploadMedia } from '../../util/media';
+
 setCategories( [
 	{
 		title: __( 'Form', 'dashboard' ),
@@ -42,5 +45,18 @@ export const editorSettings = {
 	editor: {
 		alignWide: true,
 		supportsLayout: false,
+		hasUploadPermissions: true, // not sure what this does, Gutenberg setting.
+		// if allowedMimeTypes is not present or empty, when you click on the MediaUpload handler it will just remove the buttons (????)
+		allowedMimeTypes: [ 'audio' ],
+		// Object must be a valid handler for the file select callback.
+		// NOTE: if mediaUpload is not present, addFilter( 'editor.MediaUpload' ... ) will not work (????)
+		// NOTE: costumize the handler on its own and just use the import here
+		mediaUpload: async ( payload ) => {
+			return await uploadMedia( {
+				...payload,
+				allowedTypes: [ 'image', 'audio' ],
+				additionalData: { global: 1 },
+			} );
+		},
 	},
 };

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -51,12 +51,6 @@ export const editorSettings = {
 		// Object must be a valid handler for the file select callback.
 		// NOTE: if mediaUpload is not present, addFilter( 'editor.MediaUpload' ... ) will not work (????)
 		// NOTE: costumize the handler on its own and just use the import here
-		mediaUpload: async ( payload ) => {
-			return await uploadMedia( {
-				...payload,
-				allowedTypes: [ 'image', 'audio' ],
-				additionalData: { global: 1 },
-			} );
-		},
+		mediaUpload: uploadMedia,
 	},
 };

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -19,7 +19,7 @@ export const editorSettings = {
 	iso: {
 		blocks: {
 			disallowBlocks: [
-				// 'core/audio',
+				'core/audio',
 				'core/calendar',
 				'core/cover',
 				'core/embed',

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -19,7 +19,7 @@ export const editorSettings = {
 	iso: {
 		blocks: {
 			disallowBlocks: [
-				'core/audio',
+				// 'core/audio',
 				'core/calendar',
 				'core/cover',
 				'core/embed',
@@ -47,7 +47,7 @@ export const editorSettings = {
 		supportsLayout: false,
 		hasUploadPermissions: true, // not sure what this does, Gutenberg setting.
 		// if allowedMimeTypes is not present or empty, when you click on the MediaUpload handler it will just remove the buttons (????)
-		allowedMimeTypes: [ 'audio' ],
+		allowedMimeTypes: [ 'audio', 'image' ],
 		// Object must be a valid handler for the file select callback.
 		// NOTE: if mediaUpload is not present, addFilter( 'editor.MediaUpload' ... ) will not work (????)
 		// NOTE: costumize the handler on its own and just use the import here

--- a/apps/dashboard/src/util/media/index.js
+++ b/apps/dashboard/src/util/media/index.js
@@ -1,0 +1,1 @@
+export { uploadMedia } from './upload-media';

--- a/apps/dashboard/src/util/media/upload-media.js
+++ b/apps/dashboard/src/util/media/upload-media.js
@@ -125,7 +125,7 @@ export async function uploadMedia( {
 			error.message,
 		];
 
-		onError( error );
+		onError( error.message );
 	};
 
 	const validFiles = [];
@@ -221,7 +221,7 @@ export async function uploadMedia( {
 					mediaFile.name
 				);
 			}
-			onError( {
+			triggerError( {
 				code: 'GENERAL',
 				message,
 				file: mediaFile,

--- a/apps/dashboard/src/util/media/upload-media.js
+++ b/apps/dashboard/src/util/media/upload-media.js
@@ -77,6 +77,15 @@ export async function uploadMedia( {
 	onFileChange,
 	wpAllowedMimeTypes = null,
 } ) {
+	// CS customizations
+	additionalData = {
+		...additionalData,
+		// make the upload globally available
+		global: 1,
+	};
+
+	allowedTypes = [ ...allowedTypes, 'image', 'audio' ];
+
 	// Cast filesList to array
 	const files = [ ...filesList ];
 

--- a/apps/dashboard/src/util/media/upload-media.js
+++ b/apps/dashboard/src/util/media/upload-media.js
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import {
+	compact,
+	flatMap,
+	get,
+	has,
+	includes,
+	map,
+	noop,
+	omit,
+	some,
+	startsWith,
+} from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlobURL, revokeBlobURL } from '@wordpress/blob';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * WordPress dependencies
+ */
+import { createMediaFromFile } from '@crowdsignal/rest-api';
+
+/**
+ * Browsers may use unexpected mime types, and they differ from browser to browser.
+ * This function computes a flexible array of mime types from the mime type structured provided by the server.
+ * Converts { jpg|jpeg|jpe: "image/jpeg" } into [ "image/jpeg", "image/jpg", "image/jpeg", "image/jpe" ]
+ * The computation of this array instead of directly using the object,
+ * solves the problem in chrome where mp3 files have audio/mp3 as mime type instead of audio/mpeg.
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=227004
+ *
+ * @param {?Object} wpMimeTypesObject Mime type object received from the server.
+ *                                    Extensions are keys separated by '|' and values are mime types associated with an extension.
+ *
+ * @return {?Array} An array of mime types or the parameter passed if it was "falsy".
+ */
+export function getMimeTypesArray( wpMimeTypesObject ) {
+	if ( ! wpMimeTypesObject ) {
+		return wpMimeTypesObject;
+	}
+	return flatMap( wpMimeTypesObject, ( mime, extensionsString ) => {
+		const [ type ] = mime.split( '/' );
+		const extensions = extensionsString.split( '|' );
+		return [
+			mime,
+			...map( extensions, ( extension ) => `${ type }/${ extension }` ),
+		];
+	} );
+}
+
+/**
+ *	Media Upload is used by audio, image, gallery, video, and file blocks to
+ *	handle uploading a media file when a file upload button is activated.
+ *
+ *	TODO: future enhancement to add an upload indicator.
+ *
+ * @param {Object}   $0                    Parameters object passed to the function.
+ * @param {?Array}   $0.allowedTypes       Array with the types of media that can be uploaded, if unset all types are allowed.
+ * @param {?Object}  $0.additionalData     Additional data to include in the request.
+ * @param {Array}    $0.filesList          List of files.
+ * @param {?number}  $0.maxUploadFileSize  Maximum upload size in bytes allowed for the site.
+ * @param {Function} $0.onError            Function called when an error happens.
+ * @param {Function} $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
+ * @param {?Object}  $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
+ */
+/* eslint-disable complexity */
+export async function uploadMedia( {
+	allowedTypes,
+	additionalData = {},
+	filesList,
+	maxUploadFileSize,
+	onError = noop,
+	onFileChange,
+	wpAllowedMimeTypes = null,
+} ) {
+	// Cast filesList to array
+	const files = [ ...filesList ];
+
+	const filesSet = [];
+	const setAndUpdateFiles = ( idx, value ) => {
+		revokeBlobURL( get( filesSet, [ idx, 'url' ] ) );
+		filesSet[ idx ] = value;
+		onFileChange( compact( filesSet ) );
+	};
+
+	// Allowed type specified by consumer
+	const isAllowedType = ( fileType ) => {
+		if ( ! allowedTypes ) {
+			return true;
+		}
+		return some( allowedTypes, ( allowedType ) => {
+			// If a complete mimetype is specified verify if it matches exactly the mime type of the file.
+			if ( includes( allowedType, '/' ) ) {
+				return allowedType === fileType;
+			}
+			// Otherwise a general mime type is used and we should verify if the file mimetype starts with it.
+			return startsWith( fileType, `${ allowedType }/` );
+		} );
+	};
+
+	// Allowed types for the current WP_User
+	const allowedMimeTypesForUser = getMimeTypesArray( wpAllowedMimeTypes );
+	const isAllowedMimeTypeForUser = ( fileType ) => {
+		return includes( allowedMimeTypesForUser, fileType );
+	};
+
+	// Build the error message including the filename
+	const triggerError = ( error ) => {
+		error.message = [
+			<strong key="filename">{ error.file.name }</strong>,
+			': ',
+			error.message,
+		];
+
+		onError( error );
+	};
+
+	const validFiles = [];
+
+	for ( const mediaFile of files ) {
+		// Verify if user is allowed to upload this mime type.
+		// Defer to the server when type not detected.
+		if (
+			allowedMimeTypesForUser &&
+			mediaFile.type &&
+			! isAllowedMimeTypeForUser( mediaFile.type )
+		) {
+			triggerError( {
+				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
+				message: __(
+					'Sorry, you are not allowed to upload this file type.'
+				),
+				file: mediaFile,
+			} );
+			continue;
+		}
+
+		// Check if the block supports this mime type.
+		// Defer to the server when type not detected.
+		if ( mediaFile.type && ! isAllowedType( mediaFile.type ) ) {
+			triggerError( {
+				code: 'MIME_TYPE_NOT_SUPPORTED',
+				message: __( 'Sorry, this file type is not supported here.' ),
+				file: mediaFile,
+			} );
+			continue;
+		}
+
+		// verify if file is greater than the maximum file upload size allowed for the site.
+		if ( maxUploadFileSize && mediaFile.size > maxUploadFileSize ) {
+			triggerError( {
+				code: 'SIZE_ABOVE_LIMIT',
+				message: __(
+					'This file exceeds the maximum upload size for this site.'
+				),
+				file: mediaFile,
+			} );
+			continue;
+		}
+
+		// Don't allow empty files to be uploaded.
+		if ( mediaFile.size <= 0 ) {
+			triggerError( {
+				code: 'EMPTY_FILE',
+				message: __( 'This file is empty.' ),
+				file: mediaFile,
+			} );
+			continue;
+		}
+
+		validFiles.push( mediaFile );
+
+		// Set temporary URL to create placeholder media file, this is replaced
+		// with final file from media gallery when upload is `done` below
+		filesSet.push( { url: createBlobURL( mediaFile ) } );
+		onFileChange( filesSet );
+	}
+
+	for ( let idx = 0; idx < validFiles.length; ++idx ) {
+		const mediaFile = validFiles[ idx ];
+		try {
+			const savedMedia = await createMediaFromFile(
+				mediaFile,
+				additionalData
+			);
+
+			// use data from response
+			const mediaObject = {
+				...omit( savedMedia.data, [ 'alt_text', 'source_url' ] ),
+				alt: savedMedia.data.alt_text,
+				caption: get( savedMedia.data, [ 'caption', 'raw' ], '' ),
+				title: savedMedia.data.title.raw,
+				url: savedMedia.data.source_url,
+			};
+
+			setAndUpdateFiles( idx, mediaObject );
+		} catch ( error ) {
+			// Reset to empty on failure.
+			setAndUpdateFiles( idx, null );
+			let message;
+			/* eslint-disable max-depth */
+			if ( has( error, [ 'message' ] ) ) {
+				message = get( error, [ 'message' ] );
+			} else {
+				message = sprintf(
+					// translators: %s: file name
+					__( 'Error while uploading file %s to the media library.' ),
+					mediaFile.name
+				);
+			}
+			onError( {
+				code: 'GENERAL',
+				message,
+				file: mediaFile,
+			} );
+		}
+	}
+}

--- a/apps/dashboard/src/util/media/upload-media.js
+++ b/apps/dashboard/src/util/media/upload-media.js
@@ -199,11 +199,11 @@ export async function uploadMedia( {
 
 			// use data from response
 			const mediaObject = {
-				...omit( savedMedia.data, [ 'alt_text', 'source_url' ] ),
+				// for now, omit 'id' as that triggers an attempt to retrieve the file from wp/v2/media/{id}
+				...omit( savedMedia.data, [ 'alt_text', 'source_url', 'id' ] ),
 				alt: savedMedia.data.alt_text,
 				caption: get( savedMedia.data, [ 'caption', 'raw' ], '' ),
 				title: savedMedia.data.title.raw,
-				url: savedMedia.data.source_url,
 			};
 
 			setAndUpdateFiles( idx, mediaObject );

--- a/packages/block-editor-filters/src/index.js
+++ b/packages/block-editor-filters/src/index.js
@@ -1,1 +1,2 @@
 export * from './with-empty-class-name';
+export * from './with-media-link-destination';

--- a/packages/block-editor-filters/src/with-media-link-destination.js
+++ b/packages/block-editor-filters/src/with-media-link-destination.js
@@ -1,0 +1,31 @@
+/**
+ * This lines exist in core/image code:
+	```
+	if (!attributes.linkDestination) {
+		// Use the WordPress option to determine the proper default.
+		switch (((_wp = wp) === null || _wp === void 0 ? void 0 : (_wp$media = _wp.media) === null || _wp$media === void 0 ? void 0 : (_wp$media$view = _wp$media.view) === null || _wp$media$view === void 0 ? void 0 : (_wp$media$view$settin = _wp$media$view.settings) === null || _wp$media$view$settin === void 0 ? void 0 : (_wp$media$view$settin2 = _wp$media$view$settin.defaultProps) === null || _wp$media$view$settin2 === void 0 ? void 0 : _wp$media$view$settin2.link) || LINK_DESTINATION_NONE) {
+		...
+	```
+ * making it impossible to use the image block without the (deprecated) linkDestination attribute (or wp global).
+ * This filter will provide a fixed value 'media' which is, for now, all we'd be using on upload.
+ *
+ *
+ * @param  {Function} BlockEdit Block edit component
+ * @return {Function}           Enhanced BlockEdit
+ */
+export const withMediaLinkDestination = ( BlockEdit ) => {
+	return ( props ) => {
+		if ( props.name !== 'core/image' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const newProps = {
+			...props,
+			attributes: {
+				...props.attributes,
+				linkDestination: 'media',
+			},
+		};
+		return <BlockEdit { ...newProps } />;
+	};
+};

--- a/packages/http/src/index.js
+++ b/packages/http/src/index.js
@@ -138,7 +138,7 @@ export const http = ( options ) => {
 	};
 
 	requestOptions.headers = merge(
-		globalHeaders,
+		omit( globalHeaders, requestOptions.skipGlobalHeaders ?? [] ),
 		get( hostHeaders, [ options.host ], {} ),
 		options.headers
 	);
@@ -153,3 +153,6 @@ export const http = ( options ) => {
 		.then( onRequestSuccess )
 		.catch( onRequestFailed );
 };
+
+// export utils
+export * from './util';

--- a/packages/rest-api/src/index.js
+++ b/packages/rest-api/src/index.js
@@ -1,4 +1,5 @@
 export * from './feedback';
+export * from './media';
 export * from './poll';
 export * from './project';
 export * from './user';

--- a/packages/rest-api/src/media/index.js
+++ b/packages/rest-api/src/media/index.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { http, objectToFormData } from '@crowdsignal/http';
+
+/**
+ * @param {File}    file           Media File to Save.
+ * @param {?Object} additionalData Additional data to include in the request.
+ *
+ * @return {Promise} Media Object Promise.
+ */
+export const createMediaFromFile = ( file, additionalData = {} ) => {
+	// Create upload payload
+	const data = objectToFormData( additionalData );
+	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
+
+	return http( {
+		host: 'https://api.crowdsignal.com',
+		path: '/v4/media',
+		method: 'POST',
+		mode: 'cors',
+		credentials: 'include',
+		body: data,
+		skipGlobalHeaders: [ 'Content-Type' ],
+	} );
+};


### PR DESCRIPTION
This PR adds the functionality to upload images to Crowdsignal's media library when inserting an image. It's still a WIP as things might need a little grooming or better implementation.

Core blocks still show a big dependency on the WP environment/data, the isolated-block-editor provides a couple of filters to opt out of some core functionality and replace it with a customized version of our own. That said, the core/image block still attempts to request to WP's public API.

Commits links (for cleaner view):

- https://github.com/Automattic/crowdsignal-ui/commit/476f9e0b12ccbf64ecd3718d3e3086dcb8fb7caa adds a new option `skipGlobalHeaders` on http package. The option should be an array of headers to be omitted from the package's `globalHeaders`.
- https://github.com/Automattic/crowdsignal-ui/commit/fa8374d3ef0839fceadff205028fcb5ff9bfce0b Adds the wrapped call to `/media` API endpoint.
- https://github.com/Automattic/crowdsignal-ui/commit/c61309244af10e9490587916ddc2781f88b9a679 New filter/HOC to add `linkDestination` to core/image blocks. The prop is listed as deprecated, but the core block will check for its value and fallback to `window.wp` things. I left a note on the code, hopefully at some point we might also deprecate/remove it.
- https://github.com/Automattic/crowdsignal-ui/commit/f680679111d41ca949c7256f61eb3e5186d0cdaf Adds the file browser modal handler/callback. Once provided as an editor setting, this handler is called with a *normalized* version of the selected file.
- https://github.com/Automattic/crowdsignal-ui/commit/8be2de27fc0e0bb2f7d09bcdc3e45834d10a0680 Make use of new filters: with-media-link-destination and media-upload. The latter will replace the editor's default MediaUpload component, responsible for the "Open Media Library" button shown right beside the "Upload" button. For now we just use a `null` component.
- https://github.com/Automattic/crowdsignal-ui/commit/33ee9d45eff7dbe794199d056a07ae84ef6dac79 Adds the settings to enable the custom `uploadMedia` handler.

Notes:

- Some settings do not take any effect (`allowMimeType`, `hasUploadPermission`), I'm still figuring a couple of things and extra eyes could come in handy. I think most of the work can be done on the uploadMedia handler, fully customizing it to work with our needs.
- The interaction between MediaUpload and MediaPlaceholder components is still fuzzy to me. In the end, I think we'll need to create our own custom ones for both. 
- `uploadMedia` is used both via internal dependency and through a `select( CORE_STORE ).getSettings().mediaUpload`
- ~~`core/image` still triggers a request to `wp/v2/media` with (so far) no side effects, but needs attention~~ https://github.com/Automattic/crowdsignal-ui/pull/145/commits/16b570c1e21ed994fc2687ef5d462e1136b8c091: Removing the `id` prop from the media object makes the block not try to get it from WP API
- API endpoint ( D73950-code ) is right now returning some hardcoded media payload, ~~but it should be better defined and then mapped on the client side to fit the needs of the core/image block.~~ Diff was updated with a better representation of the media object
- Need to figure out the allowedTypes/mime settings.

Some handy refs:

- MediaPlaceholder https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/media-placeholder
- MediaUpload https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/media-upload
- Some core/image shenanigans https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/image/edit.js#L224


## Test instructions

**Patch D73950-code on your sandbox, make sure your machine is connecting to sandbox and not prod.**
Create/edit a project. Insert an image block. You should see the "Upload" button. Use it.
Go to you Crowdsignal dashboard and edit/create some poll/survey. Use the "Add media" buttons on a question to open the media library popup, you should see the image uploaded on the project among your media files.
You can use Audio blocks as well (tested with ogg, worked well)