### PR TITLE
Add @crowdsignal/editor-data

### DIFF
--- a/packages/editor-data/package.json
+++ b/packages/editor-data/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@crowdsignal/editor-data",
+  "version": "0.1.0",
+  "description": "Data layer for the Crowdsignal block editor.",
+  "author": "Automattic Inc.",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "crowdsignal"
+  ],
+  "homepage": "https://github.com/Automattic/crowdsignal-ui/tree/HEAD/packages/editor-data/README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/crowdsignal-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Automattic/crowdsignal-ui/issues"
+  },
+  "main": "src/index.js",
+  "dependencies": {
+    "@crowdsignal/block-editor": "^0.1.0",
+    "@wordpress/blocks": "^11.1.4",
+    "@wordpress/data": "^6.1.4",
+    "@wordpress/hooks": "^3.2.2",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/editor-data/src/action-types.js
+++ b/packages/editor-data/src/action-types.js
@@ -1,0 +1,21 @@
+/**
+ * This list contains all action types for @crowdsignal/editor-data.
+ * Please keep this list alphabetized!
+ *
+ * Actions are named after the resoure followed by the intent.
+ */
+
+export const AUTOSAVE_TIMER_CANCEL = 'AUTOSAVE_TIMER_CANCEL';
+export const AUTOSAVE_TIMER_START = 'AUTOSAVE_TIMER_START';
+export const CURRENT_PAGE_INDEX_SET = 'CURRENT_PAGE_INDEX_SET';
+export const EDITOR_INIT = 'EDITOR_INIT';
+export const EDITOR_SAVE = 'EDITOR_SAVE';
+export const EDITOR_SAVE_ACTION_EXECUTE = 'EDITOR_SAVE_ACTION_EXECUTE';
+export const EDITOR_SAVE_ERROR = 'EDITOR_SAVE_ERROR';
+export const EDITOR_SAVE_SUCCESS = 'EDITOR_SAVE_SUCCESS';
+export const PAGE_DELETE = 'PAGE_DELETE';
+export const PAGE_INSERT = 'PAGE_INSERT';
+export const PAGE_UPDATE = 'PAGE_UPDATE';
+export const PAGE_ORDER_UPDATE = 'PAGE_ORDER_UPDATE';
+export const PROJECT_ID_SET = 'PROJECT_ID_SET';
+export const TITLE_UPDATE = 'TITLE_UPDATE';

--- a/packages/editor-data/src/actions.js
+++ b/packages/editor-data/src/actions.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	AUTOSAVE_TIMER_CANCEL,
+	AUTOSAVE_TIMER_START,
+	CURRENT_PAGE_INDEX_SET,
+	EDITOR_INIT,
+	EDITOR_SAVE,
+	EDITOR_SAVE_ACTION_EXECUTE,
+	EDITOR_SAVE_ERROR,
+	EDITOR_SAVE_SUCCESS,
+	PAGE_DELETE,
+	PAGE_INSERT,
+	PAGE_UPDATE,
+	PAGE_ORDER_UPDATE,
+	TITLE_UPDATE,
+} from './action-types';
+
+const autosave = ( actionCreator ) => {
+	return function* ( ...args ) {
+		yield { type: AUTOSAVE_TIMER_START };
+		return actionCreator( ...args );
+	};
+};
+
+export const initalizeEditor = ( projectId, title, pages ) => ( {
+	type: EDITOR_INIT,
+	projectId,
+	pages,
+	title,
+} );
+
+export const setCurrentPage = ( pageIndex ) => ( {
+	type: CURRENT_PAGE_INDEX_SET,
+	pageIndex,
+} );
+
+export function* saveChanges( options = {} ) {
+	yield { type: EDITOR_SAVE };
+	yield { type: AUTOSAVE_TIMER_CANCEL };
+
+	const projectId = select( 'crowdsignal/editor' ).getProjectId();
+	const changes = select( 'crowdsignal/editor' ).getChanges();
+	const data = select( 'crowdsignal/editor' ).getUpdatedProjectData();
+
+	if ( options.public ) {
+		data.publicContent = data.draftContent;
+		data.public = true;
+	}
+
+	const savedProjectId = yield {
+		type: EDITOR_SAVE_ACTION_EXECUTE,
+		projectId,
+		data,
+	};
+
+	if ( ! savedProjectId ) {
+		return { type: EDITOR_SAVE_ERROR, changes };
+	}
+
+	return {
+		type: EDITOR_SAVE_SUCCESS,
+		projectId: savedProjectId,
+	};
+}
+
+export const deletePage = autosave( ( pageIndex ) => ( {
+	type: PAGE_DELETE,
+	pageIndex,
+} ) );
+
+export const insertpage = autosave( ( pageIndex, pageContent ) => ( {
+	type: PAGE_INSERT,
+	pageIndex,
+	pageContent,
+} ) );
+
+export const updatePage = autosave( ( pageIndex, pageContent ) => ( {
+	type: PAGE_UPDATE,
+	pageIndex,
+	pageContent,
+} ) );
+
+export const updatePageOrder = autosave( ( order ) => ( {
+	type: PAGE_ORDER_UPDATE,
+	order,
+} ) );
+
+export const updateTitle = autosave( ( title ) => ( {
+	type: TITLE_UPDATE,
+	title,
+} ) );

--- a/packages/editor-data/src/controls.js
+++ b/packages/editor-data/src/controls.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { doAction } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	AUTOSAVE_TIMER_CANCEL,
+	AUTOSAVE_TIMER_START,
+	EDITOR_SAVE_ACTION_EXECUTE,
+} from './action-types';
+
+/**
+ * Autosave delay in ms.
+ *
+ * @type {number}
+ */
+const AUTOSAVE_DELAY = 5000;
+
+/**
+ * Contains the current autosave timer ID.
+ *
+ * @type {number|null}
+ */
+let timer = null;
+
+export default {
+	[ AUTOSAVE_TIMER_CANCEL ]: () => {
+		clearInterval( timer );
+
+		return true;
+	},
+	[ AUTOSAVE_TIMER_START ]: () => {
+		clearInterval( timer );
+
+		timer = setTimeout( () => {
+			dispatch( 'crowdsignal/editor' ).saveChanges();
+		}, AUTOSAVE_DELAY );
+
+		return true;
+	},
+	[ EDITOR_SAVE_ACTION_EXECUTE ]: ( { data, projectId } ) => {
+		try {
+			return doAction( 'crowdsignal.editor.save', projectId, data );
+		} catch ( error ) {
+			return 0;
+		}
+	},
+};

--- a/packages/editor-data/src/index.js
+++ b/packages/editor-data/src/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore } from '@wordpress/data';
+
+import * as actions from './actions';
+import controls from './controls';
+import reducer from './reducer';
+import * as selectors from './selectors';
+
+export const STORE_NAME = 'crowdsignal/editor';
+
+const storeConfig = {
+	actions,
+	controls,
+	reducer,
+	selectors,
+};
+
+export const store = createReduxStore( STORE_NAME, storeConfig );

--- a/packages/editor-data/src/reducer.js
+++ b/packages/editor-data/src/reducer.js
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+import { map, filter, slice, tap } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CURRENT_PAGE_INDEX_SET,
+	EDITOR_INIT,
+	EDITOR_SAVE,
+	EDITOR_SAVE_ERROR,
+	EDITOR_SAVE_SUCCESS,
+	PAGE_DELETE,
+	PAGE_INSERT,
+	PAGE_UPDATE,
+	PAGE_ORDER_UPDATE,
+	TITLE_UPDATE,
+} from './action-types';
+
+/**
+ * Tracks which project properties have changed since the last save.
+ *
+ * @param  {Object} state  Editor state.
+ * @param  {Object} action Action object.
+ * @return {Object}        Updated properties.
+ */
+const changes = ( state = {}, action ) => {
+	if ( action.type === EDITOR_INIT || action.type === EDITOR_SAVE ) {
+		return {};
+	}
+
+	if ( action.type === EDITOR_SAVE_ERROR ) {
+		return {
+			...state,
+			...action.changes,
+		};
+	}
+
+	if (
+		action.type === PAGE_INSERT ||
+		action.type === PAGE_DELETE ||
+		action.type === PAGE_UPDATE ||
+		action.type === PAGE_ORDER_UPDATE
+	) {
+		return {
+			...state,
+			content: true,
+		};
+	}
+
+	if ( action.type === TITLE_UPDATE ) {
+		return {
+			...state,
+			title: true,
+		};
+	}
+
+	return false;
+};
+
+/**
+ * Currently edited page index.
+ *
+ * @param  {number} state  App state.
+ * @param  {Object} action Action object.
+ * @return {number}        Page index.
+ */
+const currentPage = ( state = 0, action ) => {
+	if ( action.type === CURRENT_PAGE_INDEX_SET ) {
+		return action.pageIndex;
+	}
+
+	if (
+		action.type === PAGE_DELETE &&
+		action.pageIndex === state &&
+		state > 0
+	) {
+		return state - 1;
+	}
+
+	return state;
+};
+
+/**
+ * True when editor is saving.
+ *
+ * @param  {boolean} state  App state.
+ * @param  {Object}  action Action object.
+ * @return {boolean}        Saving flag.
+ */
+const isSaving = ( state = false, action ) => {
+	if ( action.type === EDITOR_SAVE ) {
+		return true;
+	}
+
+	if (
+		action.type === EDITOR_SAVE_SUCCESS ||
+		action.type === EDITOR_SAVE_ERROR
+	) {
+		return false;
+	}
+
+	return state;
+};
+
+/**
+ * Project's pages.
+ *
+ * @param  {Array}  state  App state.
+ * @param  {Object} action Action object.
+ * @return {Array}         Pages.
+ */
+const pages = ( state = [], action ) => {
+	if ( action.type === EDITOR_INIT ) {
+		return action.pages;
+	}
+
+	if ( action.type === PAGE_INSERT ) {
+		return [
+			...slice( state, 0, action.pageIndex ),
+			action.pageContent,
+			...slice( state, action.pageIndex ),
+		];
+	}
+
+	if ( action.type === PAGE_DELETE && 1 < state.length ) {
+		return filter( state, ( _, index ) => index !== action.pageIndex );
+	}
+
+	if ( action.type === PAGE_UPDATE ) {
+		return tap(
+			[ ...state ],
+			( pageArray ) =>
+				( pageArray[ action.pageIndex ] = action.pageContent )
+		);
+	}
+
+	if ( action.type === PAGE_ORDER_UPDATE ) {
+		return map( action.order, ( originalIndex ) => state[ originalIndex ] );
+	}
+
+	return state;
+};
+
+/**
+ * Project ID of the project that's currently loaded into the editor.
+ * '0' means the a new/non-existing project.
+ *
+ * @param  {number} state  App state.
+ * @param  {Object} action Action object.
+ * @return {number}        Project ID.
+ */
+const projectId = ( state = 0, action ) => {
+	if ( action.type === EDITOR_INIT || action.type === EDITOR_SAVE_SUCCESS ) {
+		return action.projectId;
+	}
+
+	return state;
+};
+
+/**
+ * Project title.
+ *
+ * @param  {string} state  App state.
+ * @param  {Object} action Action object.
+ * @return {string}        Title.
+ */
+const title = ( state = '', action ) => {
+	if ( action.type === EDITOR_INIT || action.type === TITLE_UPDATE ) {
+		return action.title;
+	}
+
+	return state;
+};
+
+export default combineReducers( {
+	changes,
+	currentPage,
+	isSaving,
+	pages,
+	projectId,
+	title,
+} );

--- a/packages/editor-data/src/selectors.js
+++ b/packages/editor-data/src/selectors.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { parse, serialize } from '@wordpress/blocks';
+import { isEmpty, get, map, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { submitButtonBlock } from '@crowdsignal/block-editor';
+
+/**
+ * Returns an object indicating which parts of the project have changed
+ * since the last save.
+ *
+ * @param  {Object} state App state.
+ * @return {Object}       Changes.
+ */
+export const getChanges = ( state ) => state.changes;
+
+/**
+ * Returns the project ID of the project that's currently loaded into
+ * the editor. 0 if the project doesn't (yet) exist.
+ *
+ * @param  {Object} state App state.
+ * @return {number}       Project ID.
+ */
+export const getProjectId = ( state ) => state.projectId;
+
+/**
+ * Returns an array containing all project pages.
+ *
+ * @param  {Object} state App state.
+ * @return {Array}        Pages.
+ */
+export const getPages = ( state ) => state.pages;
+
+/**
+ * Returns the index of currently edited page.
+ *
+ * @param  {Object} state App state.
+ * @return {number}       Current page index.
+ */
+export const getCurrentPageIndex = ( state ) => state.currentPage;
+
+/**
+ * Returns the currently edited page.
+ *
+ * @param  {Object} state     App state.
+ * @return {Array}            Blocks.
+ */
+export const getCurrentPage = ( state ) =>
+	get( getPages( state ), getCurrentPageIndex( state ) );
+
+/**
+ * Returns true if the editor doesn't contain any unsaved changes.
+ *
+ * @param  {Object}  state App state.
+ * @return {boolean}       True if no changes.
+ */
+export const isSaved = ( state ) => isEmpty( getChanges( state ) );
+
+/**
+ * Returns true if the editor is currently being saved.
+ *
+ * @param  {Object}  state App state.
+ * @return {boolean}       True when saving.
+ */
+export const isSaving = ( state ) => state.isSaving;
+
+/**
+ * Returns true if the project in the editor can be published.
+ *
+ * @param  {Object}  state App state.
+ * @return {boolean}       True if the project is valid.
+ */
+export const canPublish = ( state ) => {
+	const pages = getPages( state );
+
+	const containsSubmitButton = ( blocks ) =>
+		some(
+			blocks,
+			( block ) =>
+				block.name === submitButtonBlock.name ||
+				containsSubmitButton( block.innerBlocks )
+		);
+
+	return ! some( pages, ( page ) => ! containsSubmitButton( page ) );
+};
+
+/**
+ * Returns the editor project's title.
+ *
+ * @param  {Object} state App state.
+ * @return {string}       Title.
+ */
+export const getTitle = ( state ) => state.title;
+
+/**
+ * Returns a partial project containing all the changes made since the last save.
+ *
+ * @param  {Object} state App state.
+ * @return {Object}       Partial project.
+ */
+export const getUpdatedProjectData = ( state ) => {
+	const changes = getChanges( state );
+	const data = {};
+
+	if ( changes.content ) {
+		data.draftContent = {
+			pages: map( getPages( state ), ( page ) =>
+				parse( serialize( page ) )
+			),
+		};
+	}
+
+	if ( changes.title ) {
+		data.title = getTitle( state );
+	}
+
+	return data;
+};


### PR DESCRIPTION
This PR adds a new `@crowdsignal/editor-data` package which extracts the editor branch from the dashboard's data store into its own, separate data store. This approach aims to clean things up a bit by drawing a hard line between the editor state and the rest of the application, which does come with some limitations.

Most notably, we're no longer able to dispatch `saveAndUpdateProject()` directly from `saveChanges()` since these actions are now in two separate stores. It is possible technically, but creates this implicit dependency on another store which may or may not exist.

To solve this problem, I added a control which relies on `crowdsignal.editor.save` action which will bind everything together, by doing something like this in the editor (which also removes the `redirect()` from the state layer):

```
addAction( 'crowdsignal.editor.save', '@crowdsignal/dashboard', ( projectId, data ) => {
    await dispatch( 'crowdsignal/dashboard' ).saveAndUpdateProject( projectId, data );

    if ( projectId ) {
        return projectId;
    }

    const id = select( 'crowdsignal/dashboard' ).getLastUpdatedProjectId();
    redirect( `/project/${ id }` );
    return id;
} );
```

It could possibly be slimmed down some more, but I just want to give an example for context.

In the state layer, I introduced a number of changes compared to the current state of `@crowdsignal/dashboard` and #141.  
`initializeEditor()` will now load the current project data into the editor state which from that point on becomes completely independent of `state.projects`, unless `initializeEditor()` is called again, in which case any unsaved changes would also be wiped out.  
So the big difference is `@crowdsignal/editor-data` always contains the complete project data, where the previous `state.editor` branch would only contain the changes if any have been made. This makes any data manipulation much easier as we do not have to do it in relation to the original data in order to be able to merge it later - an important step as our API doesn't allow for updating pages individually.  
But in order not to submit the complete project on every update which might cause unwanted side-effects, I added a `changes` reducer which tracks which parts of the projects will need to be sent depending on actions fired since the last save.

# Testing

Tests are still in WIP.