### PR TITLE
Force block border style when in error state

### DIFF
--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -22,7 +22,7 @@ const Input = styled.input`
 	box-sizing: border-box;
 
 	${ FormInputWrapper }.is-error & {
-		border-color: var( --color-error );
+		border: 1px solid var( --color-error ) !important;
 	}
 `;
 

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -27,7 +27,7 @@ const StyledQuestionWrapper = styled.div`
 	}
 
 	&.is-error {
-		border-color: var( --color-error );
+		border: 1px solid var( --color-error ) !important;
 	}
 
 	${ ErrorMessage.className } {


### PR DESCRIPTION
## Summary

At the current state, the block styles for the error state can be overridden by the border settings.
We need to make sure that the block error state keeps its styles no matter the user border selection.

## Test instructions

* Open or create a project and a few blocks;
* Change blocks' settings to require an answer and add some border style;
* Save and go to preview;
* Hit the submit button without filling the required blocks;
* The block's error state should override selected border settings;