### PR TITLE
Response validation error handler

### DIFF
--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -40,6 +40,8 @@ const App = ( {
 
 	const [ errors, setErrors ] = useState( [] );
 
+	const formName = `f-${ projectCode }`;
+
 	useEffect( () => {
 		if ( preview ) {
 			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
@@ -139,7 +141,7 @@ const App = ( {
 	return (
 		<Form
 			className="crowdsignal-forms-form"
-			name={ `f-${ projectCode }` }
+			name={ formName }
 			onSubmit={ handleSubmit }
 		>
 			<ContentWrapper className="crowdsignal-forms-form__content">

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -38,6 +38,8 @@ const App = ( {
 
 	const [ hasResponded, setHasResponded ] = useState( false );
 
+	const [ errors, setErrors ] = useState( [] );
+
 	useEffect( () => {
 		if ( preview ) {
 			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
@@ -97,6 +99,7 @@ const App = ( {
 						throw new Error( 'Empty response' );
 					}
 
+					setErrors( json.errors );
 					setContent( json.content );
 					setHasResponded( true );
 					// all the setters should be called here: page, responseHash, content and startTime
@@ -129,7 +132,7 @@ const App = ( {
 			'crowdsignal-forms/text-question': TextQuestion,
 		} );
 
-	if ( hasResponded ) {
+	if ( hasResponded && errors.length === 0 ) {
 		return <ContentWrapper>{ renderContent() }</ContentWrapper>;
 	}
 

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -38,7 +38,7 @@ const App = ( {
 
 	const [ hasResponded, setHasResponded ] = useState( false );
 
-	const [ errors, setErrors ] = useState( [] );
+	const [ hasErrors, setHasErrors ] = useState( false );
 
 	const formName = `f-${ projectCode }`;
 
@@ -80,35 +80,32 @@ const App = ( {
 			form.append( key, data[ key ] )
 		);
 
-		return (
-			window
-				.fetch(
-					`https://api.crowdsignal.com/v4/projects/${ projectCode }/form`,
-					{
-						method: 'POST',
-						body: form,
-					}
-				)
-				.then( ( res ) => {
-					if ( ! res.ok ) {
-						throw new Error( res.status );
-					}
+		return window
+			.fetch(
+				`https://api.crowdsignal.com/v4/projects/${ projectCode }/form`,
+				{
+					method: 'POST',
+					body: form,
+				}
+			)
+			.then( ( res ) => {
+				if ( ! res.ok ) {
+					throw new Error( res.status );
+				}
 
-					return res.json();
-				} )
-				.then( ( json ) => {
-					if ( ! json || ! json.content ) {
-						throw new Error( 'Empty response' );
-					}
+				return res.json();
+			} )
+			.then( ( json ) => {
+				if ( ! json || ! json.content ) {
+					throw new Error( 'Empty response' );
+				}
 
-					setErrors( json.errors );
-					setContent( json.content );
-					setHasResponded( true );
-					// all the setters should be called here: page, responseHash, content and startTime
-				} )
-				// eslint-disable-next-line no-console
-				.catch( ( err ) => console.error( err ) )
-		);
+				const responseWithErrors = ( json.errors || [] ).length > 0;
+				setHasErrors( responseWithErrors );
+				setContent( json.content );
+				setHasResponded( true );
+				return json;
+			} );
 	};
 
 	const baseURL =
@@ -134,7 +131,7 @@ const App = ( {
 			'crowdsignal-forms/text-question': TextQuestion,
 		} );
 
-	if ( hasResponded && errors.length === 0 ) {
+	if ( hasResponded && ! hasErrors ) {
 		return <ContentWrapper>{ renderContent() }</ContentWrapper>;
 	}
 

--- a/packages/blocks/src/multiple-choice-question/index.js
+++ b/packages/blocks/src/multiple-choice-question/index.js
@@ -21,6 +21,7 @@ const MultipleChoiceQuestion = ( { attributes, children, className } ) => {
 		fieldName: `q_${ attributes.clientId }[choice]${
 			attributes.maximumChoices !== 1 ? '[]' : ''
 		}`,
+		fieldClientId: attributes.clientId,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This question is required', 'blocks' );

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -16,6 +16,7 @@ import { useField } from '@crowdsignal/form';
 const TextInput = ( { attributes, className } ) => {
 	const { inputProps, error } = useField( {
 		name: `q_${ attributes.clientId }[text]`,
+		fieldClientId: attributes.clientId,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This field is required', 'blocks' );

--- a/packages/blocks/src/text-question/index.js
+++ b/packages/blocks/src/text-question/index.js
@@ -20,6 +20,7 @@ import {
 const TextQuestion = ( { attributes, className } ) => {
 	const { inputProps, error } = useField( {
 		name: `q_${ attributes.clientId }[text]`,
+		fieldClientId: attributes.clientId,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This question is required', 'blocks' );

--- a/packages/form/src/components/form/index.js
+++ b/packages/form/src/components/form/index.js
@@ -22,8 +22,8 @@ const Form = ( { children, name, onSubmit, ...props } ) => {
 
 	const { startSubmit, stopSubmit } = useDispatch( STORE_NAME );
 
-	const registerValidation = ( fieldName, validation ) =>
-		( validations[ fieldName ] = validation );
+	const registerValidation = ( fieldClientId, validation ) =>
+		( validations[ fieldClientId ] = validation );
 
 	const isFormValid = () =>
 		values( validations ).reduce(

--- a/packages/form/src/components/form/index.js
+++ b/packages/form/src/components/form/index.js
@@ -20,7 +20,9 @@ const Form = ( { children, name, onSubmit, ...props } ) => {
 		[ name ]
 	);
 
-	const { startSubmit, stopSubmit } = useDispatch( STORE_NAME );
+	const { startSubmit, stopSubmit, setFieldError } = useDispatch(
+		STORE_NAME
+	);
 
 	const registerValidation = ( fieldClientId, validation ) =>
 		( validations[ fieldClientId ] = validation );
@@ -40,7 +42,20 @@ const Form = ( { children, name, onSubmit, ...props } ) => {
 
 		startSubmit( name );
 
-		onSubmit( data ).finally( () => stopSubmit( name ) );
+		onSubmit( data )
+			.then( ( res ) => {
+				// if errors come back from submit, evaluate validation errors
+				( res.errors || [] ).forEach( ( error ) => {
+					if ( error.fieldClientId ) {
+						setFieldError(
+							name,
+							error.fieldClientId,
+							error.message
+						);
+					}
+				} );
+			} )
+			.finally( () => stopSubmit( name ) );
 	};
 
 	return (

--- a/packages/form/src/components/form/index.js
+++ b/packages/form/src/components/form/index.js
@@ -27,6 +27,7 @@ const Form = ( { children, name, onSubmit, ...props } ) => {
 	const registerValidation = ( fieldClientId, validation ) =>
 		( validations[ fieldClientId ] = validation );
 
+	// eslint-disable-next-line
 	const isFormValid = () =>
 		values( validations ).reduce(
 			( isValid, validation ) => validation.call() && isValid,
@@ -36,9 +37,9 @@ const Form = ( { children, name, onSubmit, ...props } ) => {
 	const handleSubmit = ( event ) => {
 		event.preventDefault();
 
-		if ( ! isFormValid() ) {
-			return;
-		}
+		// if ( ! isFormValid() ) {
+		// 	return;
+		// }
 
 		startSubmit( name );
 

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -12,16 +12,26 @@ import { Form } from '../components';
 import { STORE_NAME } from '../data';
 import { useValidation } from './use-validation';
 
-export const useField = ( { name: fieldName, type, value, validation } ) => {
+export const useField = ( {
+	name: fieldName,
+	fieldClientId,
+	type,
+	value,
+	validation,
+} ) => {
 	const { name: formName } = useContext( Form.Context );
 
 	const { setFieldValue } = useDispatch( STORE_NAME );
 
-	const { error, validateField } = useValidation( { fieldName, validation } );
+	const { error, validateField } = useValidation( {
+		fieldClientId,
+		validation,
+	} );
 
 	const { value: currentValue } = useSelect(
-		( select ) => select( STORE_NAME ).getFieldData( formName, fieldName ),
-		[ formName, fieldName ]
+		( select ) =>
+			select( STORE_NAME ).getFieldData( formName, fieldClientId ),
+		[ formName, fieldClientId ]
 	);
 
 	const onChange = ( event ) => {
@@ -36,7 +46,7 @@ export const useField = ( { name: fieldName, type, value, validation } ) => {
 				  );
 		}
 
-		setFieldValue( formName, fieldName, newValue );
+		setFieldValue( formName, fieldClientId, newValue );
 		validateField( newValue );
 	};
 

--- a/packages/form/src/hooks/use-validation.js
+++ b/packages/form/src/hooks/use-validation.js
@@ -10,17 +10,17 @@ import { useContext } from '@wordpress/element';
 import { STORE_NAME } from '../data';
 import { Form } from '../components';
 
-export const useValidation = ( { fieldName, validation } ) => {
+export const useValidation = ( { fieldClientId, validation } ) => {
 	const { name: formName, registerValidation } = useContext( Form.Context );
 
 	const { setFieldError } = useDispatch( STORE_NAME );
 
 	const { error, value, formData } = useSelect(
 		( select ) => ( {
-			...select( STORE_NAME ).getFieldData( formName, fieldName ),
+			...select( STORE_NAME ).getFieldData( formName, fieldClientId ),
 			formData: select( STORE_NAME ).getFormData( formName ),
 		} ),
-		[ formName, fieldName ]
+		[ formName, fieldClientId ]
 	);
 
 	const validateField = ( fieldValue ) => {
@@ -31,13 +31,13 @@ export const useValidation = ( { fieldName, validation } ) => {
 		const err = validation( fieldValue, formData );
 
 		if ( err ) {
-			setFieldError( formName, fieldName, err );
+			setFieldError( formName, fieldClientId, err );
 		}
 		return ! err;
 	};
 
 	if ( validation && registerValidation ) {
-		registerValidation( fieldName, () => validateField( value ) );
+		registerValidation( fieldClientId, () => validateField( value ) );
 	}
 
 	return {


### PR DESCRIPTION
The PR tries to address this edgy case of someone actually skipping the frontend validations to successfully submit data that will be rejected by the backend.

Please ignore https://github.com/Automattic/crowdsignal-ui/pull/148/commits/793a6949efed6ed406c4b997837c52c7d4903067 as it's just there for the purpose of delivering un-validated values to the endpoint.

One of the goals already achieved: when the backend sends errors, we should not just *renderContent* (as we currently do), since that breaks the form functionality and also unwraps the form from its container. The introduction of `setHasErrors` on https://github.com/Automattic/crowdsignal-ui/pull/148/commits/39099c011bb5e56d739e828841f7548f3b010c11 (internal state of the project-renderer app) will provide an extra check before simply rendering the returned content.

## Backend errors
The backend is now returning the same page when an error is found and an array of error objects. Right now the errors are composed by:
- fieldClientId
- type: some sort of *const*, ie `ERROR_MANDATORY_MISSING`, `ERROR_QUESTION_SUBMIT`
- message: human readable error message. This one could be ditched and use the `type` above. It will all depend on how we handle translations

## use-validation
This PR includes a big change to how `use-validation` identifies the input. It now carries both `name` and `fieldClientId`. `name` being the required HTML attribute to use on the input and `fieldClientId` the prop used to identify the question block. These changes can be separately seen at https://github.com/Automattic/crowdsignal-ui/pull/148/commits/144192d912c1f394a89736979e91b422780776e5
Are there any downsides to this change?

## Test instructions
Checkout this branch locally and be sure to update your sandbox. Create a project with a mandatory question. Visit the project and answer without fulfilling the mandatory question. 

Errors from backend should now be rendered and form should be still functional.