### PR TITLE
Use allowBlocks instead of disallowBlocks

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -18,14 +18,31 @@ setCategories( [
 export const editorSettings = {
 	iso: {
 		blocks: {
-			disallowBlocks: [
-				'core/audio',
-				'core/calendar',
-				'core/cover',
-				'core/embed',
-				'core/file',
-				'core/media-text',
-				'core/shortcode',
+			allowBlocks: [
+				'core/buttons',
+				'core/code',
+				'core/columns',
+				'core/group',
+				'core/heading',
+				'core/html',
+				'core/image',
+				'core/list',
+				'core/paragraph',
+				'core/preformatted',
+				'core/pullquote',
+				'core/quote',
+				'core/row',
+				'core/separator',
+				'core/spacer',
+				'core/table',
+				'core/verse',
+				'core/video',
+
+				'crowdsignal-forms/multiple-choice-question',
+				'crowdsignal-forms/multiple-choice-answer',
+				'crowdsignal-forms/submit-button',
+				'crowdsignal-forms/text-input',
+				'crowdsignal-forms/text-question',
 			],
 		},
 		defaultPreferences: {


### PR DESCRIPTION
This patch updates the editor to use a list of allowed vs. disallowed blocks. This will help us prevent any surprises if new core blocks are added - we don't necessarily want all of them to a be available in the inserter.

The list of currently allowed core blocks:

- buttons
- code
- columns
- group
- heading
- html
- image
- list
- paragraph
- preformatted
- pullquote
- quote
- row
- separator
- spacer
- table
- verse
- video

Solves c/8nwOD9BI-tr.

# Testing

Open the project editor for a new or existing projects and verify only the blocks listed above (and Crowdsignal blocks) are available in the inserter.