### PR TITLE
Update MC Question block sidebar behavior

### DIFF
--- a/packages/block-editor/src/multiple-choice-question/sidebar.js
+++ b/packages/block-editor/src/multiple-choice-question/sidebar.js
@@ -12,15 +12,57 @@ import BorderSettings from '../components/border-settings';
 import ColorSettings from '../components/color-settings';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
-	const handleChangeAttribute = ( key ) => ( value ) =>
+	const handleChangeMandatory = ( isMandatory ) => {
 		setAttributes( {
-			[ key ]: value,
+			mandatory: isMandatory,
 		} );
 
-	const handleChangeNumberAttribute = ( key ) => ( value ) =>
+		if ( isMandatory && attributes.minimumChoices < 1 ) {
+			setAttributes( {
+				minimumChoices: 1,
+			} );
+		} else if ( ! isMandatory ) {
+			setAttributes( {
+				minimumChoices: 0,
+			} );
+		}
+	};
+
+	const handleMinChoices = ( value ) => {
+		if ( value < 0 ) {
+			return;
+		}
+
 		setAttributes( {
-			[ key ]: parseInt( value, 10 ),
+			minimumChoices: parseInt( value ),
 		} );
+
+		setAttributes( {
+			mandatory: value >= 1,
+		} );
+
+		if ( value > attributes.maximumChoices ) {
+			setAttributes( {
+				maximumChoices: parseInt( value ),
+			} );
+		}
+	};
+
+	const handleMaxChoices = ( value ) => {
+		if ( value < 1 ) {
+			return;
+		}
+
+		setAttributes( {
+			maximumChoices: parseInt( value ),
+		} );
+
+		if ( value < attributes.minimumChoices ) {
+			setAttributes( {
+				minimumChoices: parseInt( value ),
+			} );
+		}
+	};
 
 	return (
 		<InspectorControls>
@@ -31,7 +73,7 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 				<ToggleControl
 					label={ __( 'An answer is required' ) }
 					checked={ attributes.mandatory }
-					onChange={ handleChangeAttribute( 'mandatory' ) }
+					onChange={ handleChangeMandatory }
 				/>
 
 				{ attributes.mandatory && (
@@ -39,9 +81,7 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 						label={ __( 'Min. choices', 'blocks' ) }
 						type="number"
 						value={ attributes.minimumChoices }
-						onChange={ handleChangeNumberAttribute(
-							'minimumChoices'
-						) }
+						onChange={ handleMinChoices }
 					/>
 				) }
 
@@ -49,7 +89,7 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 					label={ __( 'Max. choices', 'blocks' ) }
 					type="number"
 					value={ attributes.maximumChoices }
-					onChange={ handleChangeNumberAttribute( 'maximumChoices' ) }
+					onChange={ handleMaxChoices }
 				/>
 			</PanelBody>
 

--- a/packages/block-editor/src/multiple-choice-question/sidebar.js
+++ b/packages/block-editor/src/multiple-choice-question/sidebar.js
@@ -10,46 +10,18 @@ import { __ } from '@wordpress/i18n';
  */
 import BorderSettings from '../components/border-settings';
 import ColorSettings from '../components/color-settings';
+import { isEmpty } from 'lodash';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
 	const handleChangeMandatory = ( isMandatory ) => {
 		setAttributes( {
 			mandatory: isMandatory,
+			minimumChoices: isMandatory ? 1 : 0,
 		} );
-
-		if ( isMandatory && attributes.minimumChoices < 1 ) {
-			setAttributes( {
-				minimumChoices: 1,
-			} );
-		} else if ( ! isMandatory ) {
-			setAttributes( {
-				minimumChoices: 0,
-			} );
-		}
-	};
-
-	const handleMinChoices = ( value ) => {
-		if ( value < 0 ) {
-			return;
-		}
-
-		setAttributes( {
-			minimumChoices: parseInt( value ),
-		} );
-
-		setAttributes( {
-			mandatory: value >= 1,
-		} );
-
-		if ( value > attributes.maximumChoices ) {
-			setAttributes( {
-				maximumChoices: parseInt( value ),
-			} );
-		}
 	};
 
 	const handleMaxChoices = ( value ) => {
-		if ( value < 1 ) {
+		if ( ! isEmpty( value ) && value < 1 ) {
 			return;
 		}
 
@@ -75,15 +47,6 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 					checked={ attributes.mandatory }
 					onChange={ handleChangeMandatory }
 				/>
-
-				{ attributes.mandatory && (
-					<TextControl
-						label={ __( 'Min. choices', 'blocks' ) }
-						type="number"
-						value={ attributes.minimumChoices }
-						onChange={ handleMinChoices }
-					/>
-				) }
 
 				<TextControl
 					label={ __( 'Max. choices', 'blocks' ) }

--- a/packages/block-editor/src/multiple-choice-question/toolbar.js
+++ b/packages/block-editor/src/multiple-choice-question/toolbar.js
@@ -21,8 +21,8 @@ const multipleChoiceControls = [
 	{
 		icon: MultipleChoiceIcon,
 		title: __( 'Multiple choice', 'block-editor' ),
-		value: 0,
-		isActive: ( { maximumChoices } ) => maximumChoices !== 1,
+		value: 2,
+		isActive: ( { maximumChoices } ) => maximumChoices > 1,
 	},
 ];
 

--- a/packages/block-editor/src/multiple-choice-question/toolbar.js
+++ b/packages/block-editor/src/multiple-choice-question/toolbar.js
@@ -22,7 +22,7 @@ const multipleChoiceControls = [
 		icon: MultipleChoiceIcon,
 		title: __( 'Multiple choice', 'block-editor' ),
 		value: 2,
-		isActive: ( { maximumChoices } ) => maximumChoices > 1,
+		isActive: ( { maximumChoices } ) => maximumChoices !== 1,
 	},
 ];
 


### PR DESCRIPTION
## Summary

The purpose of this PR is to improve the sidebar behavior of the MC Question block when interacting with the fields: `An answer is required`, `Min. Choinces`, `Max Choices`.
Interacting with those fields will change the MC block attributes to be consistent with the selection.

Examples:

* Changing the `Max Choices` field to >= 2 will turn the block into a `Multiple Choice` question;
* Changing the `Max Choices` to 1 will make it a `Single Choice` question;
* `Max Choices` can't be less than 1;
* `Max Choices` can't be lower than `Min Choices`;
* `Min Choices` can't be greater than `Max Choices`
* `Min Choices` can't be less than 0;
* Changing `Min Choices` to 0 will make the question not required;

## Test Instructions

* Open or create a new project and add an MC Question block;
* Play with the `Required`, `Min Choices` and `Max Choices` fields and check if they are consistent;
* You can use the rules described above as a starting point;
