### PR TITLE
Add parseTagProps for exceptional treatment on props by tag

### DIFF
--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -62,7 +62,7 @@ const parseNodes = ( nodes ) =>
 			name: toLower( node.tagName ),
 			children: parseNodes( node.childNodes ),
 			props: {
-				...parseTagProps( toLower( node.tagName ), attributes ),
+				...parseTagProps( node.tagName, attributes ),
 				className,
 				style: parseStyles( style ),
 				key: uniqueId( KEY_PREFIX ),

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -56,8 +56,9 @@ const parseTagProps = ( tagName, props ) => {
 		) {
 			props.controls = 'controls';
 		}
-		return props;
 	}
+
+	return props;
 };
 
 /**

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -44,6 +44,25 @@ const parseStyles = ( styleString ) => {
 /**
  * Parses DOM nodes into an array of objects to be used to create React elements.
  *
+ * @param  {string}  tagName HTML tag
+ * @param  {Object}  props object
+ * @return {Object}  Props object
+ */
+const parseTagProps = ( tagName, props ) => {
+	if ( tagName === 'AUDIO' ) {
+		if (
+			typeof props.controls !== 'undefined' &&
+			props.controls !== false
+		) {
+			props.controls = 'controls';
+		}
+		return props;
+	}
+};
+
+/**
+ * Parses DOM nodes into an array of objects to be used to create React elements.
+ *
  * @param  {HTMLCollection} nodes
  * @return {Array}                Array of objects describing the elements to be created.
  */
@@ -69,26 +88,6 @@ const parseNodes = ( nodes ) =>
 			},
 		};
 	} );
-
-/**
- * Parses DOM nodes into an array of objects to be used to create React elements.
- *
- * @param  {string} tagName
- * @param {Object}  props object.
- * @return {Object}  Props object.
- */
-const parseTagProps = ( tagName, props ) => {
-	switch ( tagName ) {
-		case 'audio':
-			if (
-				typeof props.controls !== 'undefined' &&
-				props.controls !== false
-			) {
-				props.controls = 'controls';
-			}
-	}
-	return props;
-};
 
 /**
  * Appends the innerBlocks value to the correct element based on the block.

--- a/packages/blocks/src/render-blocks.js
+++ b/packages/blocks/src/render-blocks.js
@@ -62,13 +62,33 @@ const parseNodes = ( nodes ) =>
 			name: toLower( node.tagName ),
 			children: parseNodes( node.childNodes ),
 			props: {
-				...attributes,
+				...parseTagProps( toLower( node.tagName ), attributes ),
 				className,
 				style: parseStyles( style ),
 				key: uniqueId( KEY_PREFIX ),
 			},
 		};
 	} );
+
+/**
+ * Parses DOM nodes into an array of objects to be used to create React elements.
+ *
+ * @param  {string} tagName
+ * @param {Object}  props object.
+ * @return {Object}  Props object.
+ */
+const parseTagProps = ( tagName, props ) => {
+	switch ( tagName ) {
+		case 'audio':
+			if (
+				typeof props.controls !== 'undefined' &&
+				props.controls !== false
+			) {
+				props.controls = 'controls';
+			}
+	}
+	return props;
+};
 
 /**
  * Appends the innerBlocks value to the correct element based on the block.


### PR DESCRIPTION
This PR adds a props parser amidst the rendering process.

This allows for place to give some props special treatment. The particular case in this PR being the `<audio>` tag, which requires a `controls` prop to be passed on or it would not render at all (by design).

The `core/audio` block does add this `controls` prop, but as a boolean prop it is assumed `true` by its mere presence on HTML markup. This doesn't play nice with React's createElement or other parsing mechanisms as the prop arrives as `controls: ''` effectively evaluating to false or not being parsed at all.

For this and other cases, we can start adding exceptions via `parseTagProps`.

## Test instructions
Enable `core/audio` by commenting the entry on `apps/dashboard/src/components/editor/settings.js` line 22:
```
// 'core/audio'
```

Use the editor to create an audio block, upload a wav/mp3/ogg from your computer. Visit the public view of the project, you'll notice the audio block is not there (yet if you inspect the page, you'll see the markup without the `controls` prop)

Checkout `add/tag-props-parser` and visit the public view of the  project again. This time you should see the audio block.