### PR TITLE
Add page navigation drag&drop

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -41,6 +41,7 @@
     "classnames": "^2.2.5",
     "isolated-block-editor": "git://github.com/Automattic/isolated-block-editor.git#2.9.0",
     "lodash": "^4.17.21",
+    "react-beautiful-dnd": "^13.1.0",
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {

--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -78,6 +78,7 @@ const PageNavigation = () => {
 							{ map( pages, ( page, index ) => (
 								<Draggable
 									key={ `page-${ index }` }
+									disableInteractiveElementBlocking={ true }
 									draggableId={ `page-${ index }` }
 									index={ index }
 								>

--- a/apps/dashboard/src/components/editor/page-preview.js
+++ b/apps/dashboard/src/components/editor/page-preview.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { BlockPreview } from '@wordpress/block-editor';
-import { Icon, trash } from '@wordpress/icons';
+import { forwardRef } from '@wordpress/element';
+import { Icon, handle, trash } from '@wordpress/icons';
 import classnames from 'classnames';
 
 /**
@@ -11,29 +12,48 @@ import classnames from 'classnames';
 import {
 	DeleteButton,
 	PagePreviewButton,
+	PagePreviewDragHandle,
 	PagePreviewFrame,
 	PagePreviewPageNumber,
 	PagePreviewWrapper,
 } from './styles/page-preview';
 
-const PagePreview = ( {
-	disablePageActions,
-	isActive,
-	onDelete,
-	onSelect,
-	page,
-	pageIndex,
-} ) => {
-	const handleSelect = () => onSelect( pageIndex );
+const PagePreview = (
+	{
+		disablePageActions,
+		draggableProps,
+		dragHandleProps,
+		isActive,
+		isDragging,
+		onDelete,
+		onSelect,
+		page,
+		pageIndex,
+	},
+	ref
+) => {
+	const handleSelect = () => {
+		onSelect( pageIndex );
+		return true;
+	};
 
 	const handleDelete = () => onDelete( pageIndex );
 
 	const classes = classnames( {
 		'is-active': isActive,
+		'is-dragging': isDragging,
 	} );
 
 	return (
-		<PagePreviewWrapper className={ classes }>
+		<PagePreviewWrapper
+			ref={ ref }
+			className={ classes }
+			{ ...draggableProps }
+		>
+			<PagePreviewDragHandle { ...dragHandleProps }>
+				<Icon icon={ handle } size={ 12 } />
+			</PagePreviewDragHandle>
+
 			<PagePreviewButton onClick={ handleSelect }>
 				<PagePreviewPageNumber>{ pageIndex + 1 }</PagePreviewPageNumber>
 
@@ -54,4 +74,4 @@ const PagePreview = ( {
 	);
 };
 
-export default PagePreview;
+export default forwardRef( PagePreview );

--- a/apps/dashboard/src/components/editor/page-preview.js
+++ b/apps/dashboard/src/components/editor/page-preview.js
@@ -3,7 +3,7 @@
  */
 import { BlockPreview } from '@wordpress/block-editor';
 import { forwardRef } from '@wordpress/element';
-import { Icon, handle, trash } from '@wordpress/icons';
+import { Icon, trash } from '@wordpress/icons';
 import classnames from 'classnames';
 
 /**
@@ -12,7 +12,6 @@ import classnames from 'classnames';
 import {
 	DeleteButton,
 	PagePreviewButton,
-	PagePreviewDragHandle,
 	PagePreviewFrame,
 	PagePreviewPageNumber,
 	PagePreviewWrapper,
@@ -32,10 +31,7 @@ const PagePreview = (
 	},
 	ref
 ) => {
-	const handleSelect = () => {
-		onSelect( pageIndex );
-		return true;
-	};
+	const handleSelect = () => onSelect( pageIndex );
 
 	const handleDelete = () => onDelete( pageIndex );
 
@@ -50,11 +46,7 @@ const PagePreview = (
 			className={ classes }
 			{ ...draggableProps }
 		>
-			<PagePreviewDragHandle { ...dragHandleProps }>
-				<Icon icon={ handle } size={ 12 } />
-			</PagePreviewDragHandle>
-
-			<PagePreviewButton onClick={ handleSelect }>
+			<PagePreviewButton onClick={ handleSelect } { ...dragHandleProps }>
 				<PagePreviewPageNumber>{ pageIndex + 1 }</PagePreviewPageNumber>
 
 				<PagePreviewFrame>

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -15,21 +15,6 @@ export const PagePreviewWrapper = styled.div`
 	}
 `;
 
-export const PagePreviewDragHandle = styled.div`
-	align-items: center;
-	display: none;
-	padding: 0 5px;
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 0px;
-	z-index: 10;
-
-	${ PagePreviewWrapper }:hover & {
-		display: flex;
-	}
-`;
-
 export const PagePreviewButton = styled.button`
 	align-items: center;
 	background: transparent;

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -15,6 +15,21 @@ export const PagePreviewWrapper = styled.div`
 	}
 `;
 
+export const PagePreviewDragHandle = styled.div`
+	align-items: center;
+	display: none;
+	padding: 0 5px;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0px;
+	z-index: 10;
+
+	${ PagePreviewWrapper }:hover & {
+		display: flex;
+	}
+`;
+
 export const PagePreviewButton = styled.button`
 	align-items: center;
 	background: transparent;
@@ -59,6 +74,10 @@ export const PagePreviewPageNumber = styled.span`
 
 	${ PagePreviewWrapper }.is-active & {
 		color: var( --color-primary );
+	}
+
+	${ PagePreviewWrapper }.is-dragging & {
+		opacity: 0;
 	}
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.14.5", "@babel/template@^7.16.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -3949,6 +3956,14 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -4102,6 +4117,16 @@
   integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
   dependencies:
     "@types/react" "^16"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.22"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
+  integrity sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
@@ -7811,6 +7836,13 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
@@ -13930,6 +13962,11 @@ memize@^1.1.0:
   resolved "https://registry.yarnpkg.com/memize/-/memize-1.1.0.tgz#4a5a684ac6992a13b1299043f3e49b1af6a0b0d3"
   integrity sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -16614,6 +16651,11 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -16717,6 +16759,19 @@ react-autosize-textarea@^7.1.0:
     autosize "^4.0.2"
     line-height "^0.3.1"
     prop-types "^15.5.6"
+
+react-beautiful-dnd@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
+  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-colorful@^5.1.2, react-colorful@^5.3.1:
   version "5.5.1"
@@ -16865,6 +16920,18 @@ react-portal@^4.1.5:
   integrity sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==
   dependencies:
     prop-types "^15.5.8"
+
+react-redux@^7.2.0:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -17234,7 +17301,7 @@ redux-undo@^1.0.1:
   resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.1.tgz#8d989d6c326e6718f4471042e90a5b8b6f3317eb"
   integrity sha512-0yFPT+FUgwxCEiS0Mg5T1S4tkgjR8h6sJRY9CW4EMsbJOf1SxO289TbJmlzhRouCHacdDF+powPjrjLHoJYxWQ==
 
-redux@^4.1.0, redux@^4.1.1:
+redux@^4.0.0, redux@^4.0.4, redux@^4.1.0, redux@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
@@ -19263,6 +19330,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-invariant@^1.0.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
 tiny-lr@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This patch adds drag&drop functionality to page navigation.

~Unfortunately, there's a small caveat in that the entire 'page' preview is a button and already has a function (selecting a page), hence it's not possible for to serve as a drag&drop handle as well.  
In order for it to work, I added a small handle that appears on the left when you hover over a page, but we'll likely need to come up with a more streamlined way to integrate that. cc @digitalwaveride~

Solves c/rkfdI2Dm-tr.

# Testing

- Open a project with multiple pages or create one.
- You should be able to drag and drop different pages and reorder them that way.
- Reordering pages should trigger autosave.
- Refresh the page and make sure the reordered content has been saved correctly.