### PR TITLE
Implement a toggle animation for the page navigation column

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -43,6 +43,7 @@
     "lodash": "^4.17.21",
     "react-beautiful-dnd": "^13.1.0",
     "react-helmet": "^6.1.0",
+    "react-transition-group": "^4.4.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -2,10 +2,13 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, pages as pagesIcon, plus } from '@wordpress/icons';
+import classnames from 'classnames';
 import { map, noop, range, slice } from 'lodash';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { Transition } from 'react-transition-group';
 
 /**
  * Internal dependencies
@@ -24,6 +27,8 @@ import {
 } from './styles/page-navigation';
 
 const PageNavigation = () => {
+	const [ expanded, setExpanded ] = useState( true );
+
 	const {
 		deleteEditorPage,
 		insertEditorPage,
@@ -65,11 +70,23 @@ const PageNavigation = () => {
 
 	const handleSelectPage = ( pageIndex ) => setEditorCurrentPage( pageIndex );
 
+	const toggleExpanded = () => setExpanded( ! expanded );
+
+	const classes = classnames( {
+		'is-expanded': expanded,
+	} );
+
 	return (
-		<PageNavigationWrapper>
-			<PageNavigationHeader>
+		<PageNavigationWrapper className={ classes }>
+			<PageNavigationHeader onClick={ toggleExpanded }>
 				<Icon icon={ pagesIcon } />
-				{ __( 'Pages', 'dashboard' ) }
+				<Transition in={ expanded } timeout={ 300 }>
+					{ ( state ) => (
+						<span className={ state }>
+							{ __( 'Pages', 'dashboard' ) }
+						</span>
+					) }
+				</Transition>
 			</PageNavigationHeader>
 
 			<DragDropContext onDragEnd={ handleMovePage }>
@@ -82,6 +99,7 @@ const PageNavigation = () => {
 									disableInteractiveElementBlocking={ true }
 									draggableId={ `page-${ index }` }
 									index={ index }
+									isDragDisabled={ ! expanded }
 								>
 									{ ( provided, snapshot ) => (
 										<PagePreview
@@ -96,6 +114,7 @@ const PageNavigation = () => {
 												pages.length <= 2
 											}
 											isActive={ index === currentPage }
+											isExpanded={ expanded }
 											isDragging={ snapshot.isDragging }
 											page={ page }
 											pageIndex={ index }

--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -135,14 +135,19 @@ const PageNavigation = () => {
 				<Icon icon={ plus } />
 			</PageNavigationAddButton>
 
-			<PageNavigationSectionHeader>
-				{ __( 'Confirmation', 'dashboard' ) }
-			</PageNavigationSectionHeader>
+			<Transition in={ expanded } timeout={ 300 }>
+				{ ( state ) => (
+					<PageNavigationSectionHeader className={ state }>
+						{ __( 'Confirmation', 'dashboard' ) }
+					</PageNavigationSectionHeader>
+				) }
+			</Transition>
 
 			<PagePreview
 				disablePageActions={ true }
 				isActive={ currentPage === pages.length - 1 }
-				label="-"
+				isExpanded={ expanded }
+				label="CP"
 				page={ pages[ pages.length - 1 ] }
 				pageIndex={ pages.length - 1 }
 				onDelete={ noop }

--- a/apps/dashboard/src/components/editor/page-preview.js
+++ b/apps/dashboard/src/components/editor/page-preview.js
@@ -5,6 +5,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 import { forwardRef } from '@wordpress/element';
 import { Icon, trash } from '@wordpress/icons';
 import classnames from 'classnames';
+import { Transition } from 'react-transition-group';
 
 /**
  * Style dependencies
@@ -23,6 +24,7 @@ const PagePreview = (
 		draggableProps,
 		dragHandleProps,
 		isActive,
+		isExpanded,
 		isDragging,
 		label,
 		onDelete,
@@ -39,6 +41,7 @@ const PagePreview = (
 	const classes = classnames( {
 		'is-active': isActive,
 		'is-dragging': isDragging,
+		'is-expanded': isExpanded,
 	} );
 
 	return (
@@ -52,9 +55,16 @@ const PagePreview = (
 					{ label || pageIndex + 1 }
 				</PagePreviewPageNumber>
 
-				<PagePreviewFrame>
-					<BlockPreview blocks={ page } viewportWidth={ 1200 } />
-				</PagePreviewFrame>
+				<Transition in={ isExpanded } timeout={ 300 }>
+					{ ( state ) => (
+						<PagePreviewFrame className={ state }>
+							<BlockPreview
+								blocks={ page }
+								viewportWidth={ 1200 }
+							/>
+						</PagePreviewFrame>
+					) }
+				</Transition>
 			</PagePreviewButton>
 
 			{ ! disablePageActions && (

--- a/apps/dashboard/src/components/editor/page-preview.js
+++ b/apps/dashboard/src/components/editor/page-preview.js
@@ -67,7 +67,7 @@ const PagePreview = (
 				</Transition>
 			</PagePreviewButton>
 
-			{ ! disablePageActions && (
+			{ ! disablePageActions && isExpanded && (
 				<DeleteButton
 					disabled={ disablePageActions }
 					onClick={ handleDelete }

--- a/apps/dashboard/src/components/editor/styles/editor.js
+++ b/apps/dashboard/src/components/editor/styles/editor.js
@@ -4,6 +4,11 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 
+/**
+ * Internal dependencies
+ */
+import { PageNavigationWrapper } from './page-navigation';
+
 export const editorGlobalStyles = css`
 	html.interface-interface-skeleton__html-container {
 		width: 100% !important;
@@ -27,10 +32,16 @@ export const EditorWrapper = styled.div`
 	max-height: 100%;
 	position: absolute;
 	bottom: 0;
-	left: 180px;
+	left: 88px;
 	right: 0;
 	top: 65px;
-	width: calc( 100% - 180px );
+	transition: left 0.3s, width 0.3s;
+	width: calc( 100% - 88px );
+
+	${ PageNavigationWrapper }.is-expanded + div > & {
+		left: 180px;
+		width: calc( 100% - 180px );
+	}
 
 	.interface-interface-skeleton__content
 		> .components-notice-list

--- a/apps/dashboard/src/components/editor/styles/page-navigation.js
+++ b/apps/dashboard/src/components/editor/styles/page-navigation.js
@@ -14,14 +14,22 @@ export const PageNavigationWrapper = styled.div`
 	bottom: 0;
 	left: 0;
 	top: 65px;
-	width: 180px;
+	transition: width 0.3s;
+	width: 88px;
+
+	&.is-expanded {
+		width: 180px;
+	}
 `;
 
-export const PageNavigationHeader = styled.div`
+export const PageNavigationHeader = styled.button`
 	align-items: center;
+	background-color: transparent;
+	border: 0;
 	border-bottom: 1px solid var( --color-border );
 	box-sizing: border-box;
 	color: var( --color-text-subtle );
+	cursor: pointer;
 	display: flex;
 	font-size: 11px;
 	margin-bottom: 8px;
@@ -32,6 +40,22 @@ export const PageNavigationHeader = styled.div`
 
 	svg {
 		margin-right: 16px;
+	}
+
+	span {
+		opacity: 0;
+		transition: opacity 0.1s, width 0.1s;
+		width: 0;
+
+		&.entered {
+			opacity: 1;
+			width: auto;
+		}
+	}
+
+	span.entered {
+		opacity: 1;
+		width: auto;
 	}
 `;
 
@@ -46,8 +70,14 @@ export const PageNavigationAddButton = styled.button`
 	display: flex;
 	height: 40px;
 	justify-content: center;
-	margin: 16px 16px 0 63px;
-	width: 100px;
+	margin: 16px 24px;
+	transition: margin 0.3s, width 0.3s;
+	width: 40px;
+
+	${ PageNavigationWrapper }.is-expanded & {
+		margin: 16px 16px 0 63px;
+		width: 100px;
+	}
 `;
 
 export const PageNavigationSectionHeader = styled.span`

--- a/apps/dashboard/src/components/editor/styles/page-navigation.js
+++ b/apps/dashboard/src/components/editor/styles/page-navigation.js
@@ -7,6 +7,8 @@ export const PageNavigationWrapper = styled.div`
 	background-color: var( --color-surface );
 	border-right: 1px solid var( --color-border );
 	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
 		Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
 		'Segoe UI Symbol';
@@ -52,11 +54,6 @@ export const PageNavigationHeader = styled.button`
 			width: auto;
 		}
 	}
-
-	span.entered {
-		opacity: 1;
-		width: auto;
-	}
 `;
 
 export const PageNavigationAddButton = styled.button`
@@ -84,8 +81,21 @@ export const PageNavigationSectionHeader = styled.span`
 	color: var( --color-text-subtle );
 	display: flex;
 	font-size: 11px;
-	margin-top: 32px;
+	height: 0;
+	margin-top: 8px;
+	overflow: hidden;
+	opacity: 0;
 	padding: 0 16px 0 64px;
 	text-transform: uppercase;
+	transition: height 0.3s, margin-top: 0.3s, opacity 0.1s;
 	width: 100%;
+
+	&.entered {
+		opacity: 1;
+	}
+
+	${ PageNavigationWrapper }.is-expanded & {
+		height: 20px;
+		margin-top: 32px;
+	}
 `;

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -23,9 +23,16 @@ export const PagePreviewButton = styled.button`
 	cursor: pointer;
 	display: flex;
 	flex-direction: row;
-	justify-content: flex-end;
-	padding: 8px 16px 0 32px;
+	height: 56px;
+	justify-content: flex-start;
+	padding: 8px 32px;
+	transition: height 0.3s, padding-right 0.3s;
 	width: 100%;
+
+	${ PagePreviewWrapper }.is-expanded & {
+		height: 96px;
+		padding-right: 123px;
+	}
 `;
 
 export const PagePreviewFrame = styled.div`
@@ -35,9 +42,23 @@ export const PagePreviewFrame = styled.div`
 	border-radius: 2px;
 	box-sizing: border-box;
 	height: 80px;
-	position: relative;
+	position: absolute;
+	right: 16px;
+	top: 8px;
 	overflow: hidden;
+	transition: opacity 0.3s, transform 0.3s;
 	width: 100px;
+
+	&.exiting,
+	&.exited {
+		opacity: 0;
+		transform: scale( 0.3 );
+	}
+
+	&.entering,
+	&.entered {
+		opacity: 1;
+	}
 
 	${ PagePreviewWrapper }.is-active & {
 		box-shadow: 0 0 0 2px var( --color-primary );
@@ -50,12 +71,13 @@ export const PagePreviewFrame = styled.div`
 `;
 
 export const PagePreviewPageNumber = styled.span`
-	flex: 1;
 	color: var( --color-text-subtle );
 	display: flex;
+	flex: 1;
 	font-size: 11px;
 	font-weight: bold;
-	justify-content: flex-start;
+	justify-content: center;
+	transition: flex 0.3s;
 
 	${ PagePreviewWrapper }.is-active & {
 		color: var( --color-primary );
@@ -63,6 +85,10 @@ export const PagePreviewPageNumber = styled.span`
 
 	${ PagePreviewWrapper }.is-dragging & {
 		opacity: 0;
+	}
+
+	${ PagePreviewWrapper }.is-expanded & {
+		flex: 0;
 	}
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,14 +1205,14 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.15.4":
+"@babel/runtime@^7.8.7":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -8557,6 +8557,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-scroll-into-view@^1.2.1:
   version "1.2.1"
@@ -17010,6 +17018,16 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-transition-group@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-use-gesture@^9.0.0:
   version "9.1.3"


### PR DESCRIPTION
This PR implements the toggle and animation for triggering the page navigation column. The collapsed state only features the page numbers.

Collapsed:

![Screen Shot 2022-02-11 at 10 42 53 PM](https://user-images.githubusercontent.com/8056203/153674384-2f706576-aeac-44e4-bcbe-6f09c28c6e85.png)

Expanded:

![Screen Shot 2022-02-11 at 10 36 37 PM](https://user-images.githubusercontent.com/8056203/153674238-3e47a2ba-28f3-4437-b7d5-92cf8886e82d.png)


Solves c/N1eM8RnL-tr.

# Testing

Clicking the 'Pages' toggle on top of the page navigation column will should collapse/expand it depending on current state.