### PR TITLE
Include confirmation page in editor page navigation

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -42,7 +42,8 @@
     "isolated-block-editor": "git://github.com/Automattic/isolated-block-editor.git#2.9.0",
     "lodash": "^4.17.21",
     "react-beautiful-dnd": "^13.1.0",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.16.7",

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -4,7 +4,7 @@
 import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { map, noop, tap } from 'lodash';
+import { map, noop } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
 import { Global } from '@emotion/core';
 
@@ -49,16 +49,22 @@ const Editor = ( { project, theme = 'leven' } ) => {
 	} = useEditorContent( project );
 
 	const settings = useMemo(
-		() =>
-			tap( { ...editorSettings }, ( { iso } ) => {
-				if ( confirmationPage ) {
-					iso.blocks.disallowBlocks = [
-						...iso.blocks.disallowBlocks,
-						...map( crowdsignalBlocks, 'name' ),
-					];
-				}
-			} ),
-		[ editorId ]
+		() => ( {
+			...editorSettings,
+			iso: {
+				...editorSettings.iso,
+				blocks: {
+					...editorSettings.iso.blocks,
+					disallowBlocks: [
+						...editorSettings.iso.blocks.disallowBlocks,
+						...( confirmationPage
+							? map( crowdsignalBlocks, 'name' )
+							: [] ),
+					],
+				},
+			},
+		} ),
+		[ confirmationPage ]
 	);
 
 	return (

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -2,14 +2,16 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { noop } from 'lodash';
+import { map, noop, tap } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
 import { Global } from '@emotion/core';
 
 /**
  * Internal dependencies
  */
+import * as crowdsignalBlocks from '@crowdsignal/block-editor';
 import HeaderMeta from '../header-meta';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
@@ -38,12 +40,26 @@ const Editor = ( { project, theme = 'leven' } ) => {
 	const { updateEditorTitle } = useDispatch( STORE_NAME );
 
 	const {
+		confirmationPage,
 		editorId,
 		loadBlocks,
 		saveBlocks,
 		restoreDraft,
 		version,
 	} = useEditorContent( project );
+
+	const settings = useMemo(
+		() =>
+			tap( { ...editorSettings }, ( { iso } ) => {
+				if ( confirmationPage ) {
+					iso.blocks.disallowBlocks = [
+						...iso.blocks.disallowBlocks,
+						...map( crowdsignalBlocks, 'name' ),
+					];
+				}
+			} ),
+		[ editorId ]
+	);
 
 	return (
 		<EditorLayout className="editor">
@@ -63,7 +79,7 @@ const Editor = ( { project, theme = 'leven' } ) => {
 			<EditorWrapper
 				as={ IsolatedBlockEditor }
 				key={ editorId }
-				settings={ editorSettings }
+				settings={ settings }
 				onSaveBlocks={ saveBlocks }
 				onLoad={ loadBlocks }
 				onError={ noop }

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -18,7 +19,25 @@ const Editor = ( { projectId } ) => {
 			return [
 				{
 					draftContent: {
-						pages: [ [] ],
+						pages: [
+							[],
+							[
+								{
+									attributes: {
+										content: __(
+											'Thank you!',
+											'dashboard'
+										),
+										level: 2,
+										textAlign: 'center',
+									},
+									clientId: uuid(),
+									innerBlocks: [],
+									isValid: true,
+									name: 'core/heading',
+								},
+							],
+						],
 					},
 				},
 				false,

--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, pages as pagesIcon, plus } from '@wordpress/icons';
-import { map, range } from 'lodash';
+import { map, noop, range, slice } from 'lodash';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 
 /**
@@ -19,6 +19,7 @@ import { STORE_NAME } from '../../data';
 import {
 	PageNavigationAddButton,
 	PageNavigationHeader,
+	PageNavigationSectionHeader,
 	PageNavigationWrapper,
 } from './styles/page-navigation';
 
@@ -75,7 +76,7 @@ const PageNavigation = () => {
 				<Droppable droppableId="crowdsignal/page-navigation">
 					{ ( { droppableProps, innerRef, placeholder } ) => (
 						<div ref={ innerRef } { ...droppableProps }>
-							{ map( pages, ( page, index ) => (
+							{ map( slice( pages, 0, -1 ), ( page, index ) => (
 								<Draggable
 									key={ `page-${ index }` }
 									disableInteractiveElementBlocking={ true }
@@ -92,7 +93,7 @@ const PageNavigation = () => {
 												provided.dragHandleProps
 											}
 											disablePageActions={
-												pages.length === 1
+												pages.length <= 2
 											}
 											isActive={ index === currentPage }
 											isDragging={ snapshot.isDragging }
@@ -114,6 +115,20 @@ const PageNavigation = () => {
 			<PageNavigationAddButton onClick={ handleAddPage }>
 				<Icon icon={ plus } />
 			</PageNavigationAddButton>
+
+			<PageNavigationSectionHeader>
+				{ __( 'Confirmation', 'dashboard' ) }
+			</PageNavigationSectionHeader>
+
+			<PagePreview
+				disablePageActions={ true }
+				isActive={ currentPage === pages.length - 1 }
+				label="-"
+				page={ pages[ pages.length - 1 ] }
+				pageIndex={ pages.length - 1 }
+				onDelete={ noop }
+				onSelect={ handleSelectPage }
+			/>
 		</PageNavigationWrapper>
 	);
 };

--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -37,8 +37,8 @@ const PageNavigation = () => {
 	] );
 
 	const handleAddPage = () => {
-		insertEditorPage( pages.length, [] );
-		setEditorCurrentPage( pages.length );
+		insertEditorPage( pages.length - 1, [] );
+		setEditorCurrentPage( pages.length - 1 );
 	};
 
 	const handleMovePage = ( {

--- a/apps/dashboard/src/components/editor/page-preview.js
+++ b/apps/dashboard/src/components/editor/page-preview.js
@@ -24,6 +24,7 @@ const PagePreview = (
 		dragHandleProps,
 		isActive,
 		isDragging,
+		label,
 		onDelete,
 		onSelect,
 		page,
@@ -47,7 +48,9 @@ const PagePreview = (
 			{ ...draggableProps }
 		>
 			<PagePreviewButton onClick={ handleSelect } { ...dragHandleProps }>
-				<PagePreviewPageNumber>{ pageIndex + 1 }</PagePreviewPageNumber>
+				<PagePreviewPageNumber>
+					{ label || pageIndex + 1 }
+				</PagePreviewPageNumber>
 
 				<PagePreviewFrame>
 					<BlockPreview blocks={ page } viewportWidth={ 1200 } />

--- a/apps/dashboard/src/components/editor/styles/page-navigation.js
+++ b/apps/dashboard/src/components/editor/styles/page-navigation.js
@@ -49,3 +49,13 @@ export const PageNavigationAddButton = styled.button`
 	margin: 16px 16px 0 63px;
 	width: 100px;
 `;
+
+export const PageNavigationSectionHeader = styled.span`
+	color: var( --color-text-subtle );
+	display: flex;
+	font-size: 11px;
+	margin-top: 32px;
+	padding: 0 16px 0 64px;
+	text-transform: uppercase;
+	width: 100%;
+`;

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -22,11 +22,13 @@ export const useEditorContent = ( project ) => {
 	const { initializeEditor, updateEditorPage } = useDispatch( STORE_NAME );
 
 	const [
+		confirmationPage,
 		currentPage,
 		currentPageContent,
 		editorProjectId,
 		isEditorContentSaved,
 	] = useSelect( ( select ) => [
+		select( STORE_NAME ).isEditingConfirmationPage(),
 		select( STORE_NAME ).getEditorCurrentPageIndex(),
 		select( STORE_NAME ).getEditorCurrentPage(),
 		select( STORE_NAME ).getEditorProjectId(),
@@ -91,6 +93,7 @@ export const useEditorContent = ( project ) => {
 
 	return {
 		editorId,
+		confirmationPage,
 		loadBlocks,
 		saveBlocks,
 		restoreDraft,

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -51,10 +51,12 @@ export const useEditorContent = ( project ) => {
 
 	useEffect( () => {
 		setEditorId(
-			`crowdsignal-editor-${ editorProjectId }-${ currentPage }`
+			`crowdsignal-editor-${ editorProjectId }-${ currentPage }${
+				confirmationPage ? 'confirm' : ''
+			}`
 		);
 		setReady( false );
-	}, [ editorProjectId, currentPage ] );
+	}, [ editorProjectId, confirmationPage, currentPage ] );
 
 	useEffect( () => {
 		if ( isEditorContentSaved ) {

--- a/apps/dashboard/src/data/editor/selectors.js
+++ b/apps/dashboard/src/data/editor/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { serialize, parse } from '@wordpress/blocks';
-import { get, isEmpty, map, some } from 'lodash';
+import { get, isEmpty, map, slice, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,6 +42,15 @@ export const getEditorPages = ( state ) => state.editor.pages;
  * @return {number}       Current page index.
  */
 export const getEditorCurrentPageIndex = ( state ) => state.editor.currentPage;
+
+/**
+ * Returns true if the page currently being edited is the confirmation page.
+ *
+ * @param  {Object}  state App state.
+ * @return {boolean}       True when editing the confirmation page.
+ */
+export const isEditingConfirmationPage = ( state ) =>
+	getEditorCurrentPageIndex( state ) === getEditorPages( state ).length - 1;
 
 /**
  * Returns the currently edited page.
@@ -94,7 +103,10 @@ export const isEditorContentPublishable = ( state ) => {
 				containsSubmitButton( block.innerBlocks )
 		);
 
-	return ! some( pages, ( page ) => ! containsSubmitButton( page ) );
+	return ! some(
+		slice( pages, 0, -1 ),
+		( page ) => ! containsSubmitButton( page )
+	);
 };
 
 /**


### PR DESCRIPTION
This PR adds the capability to edit the project confirmation page in the block editor. The page sits in its own dedicated 'confirmation' section of the page navigation sidebar - like discussed with @digitalwaveride.

The way it's implemented, we treat the last page of the project's content as its confirmation page. This means from now on, every new project includes two pages by default.  
The confirmation page cannot be deleted, reordered and generally doesn't offer any of the functions regular pages might have.

![crowdsignal localhost_9000_project](https://user-images.githubusercontent.com/8056203/153948761-7eab0894-4420-4edb-8c84-f7a1d6d59e9f.png)

Solves c/8Svmd41d-tr.

# Testing

- Create a new project, it should contain a blank page as well as a confirmation page with default text.
- Question, input and submit button blocks should be unavailable when editing the confirmation page.
- It shouldn't be possible to reorder, swap or delete the confirmation page.
- The confirmation page shouldn't be taken into account when checking if every page contains at least one submit button.