### PR TITLE
Add TwentyNineteen Theme

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -13,7 +13,7 @@ import { STORE_NAME } from '../../data';
 import BlockEditor from './editor';
 import EditorLoadingPlaceholder from './loading-placeholder';
 
-const Editor = ( { projectId } ) => {
+const Editor = ( { projectId, theme } ) => {
 	const [ project, isLoading ] = useSelect( ( select ) => {
 		if ( ! projectId ) {
 			return [
@@ -59,7 +59,7 @@ const Editor = ( { projectId } ) => {
 		);
 	}
 
-	return <BlockEditor project={ project } />;
+	return <BlockEditor project={ project } theme={ theme } />;
 };
 
 export default Editor;

--- a/packages/theme-compatibility/src/twentynineteen/base.scss
+++ b/packages/theme-compatibility/src/twentynineteen/base.scss
@@ -1,0 +1,48 @@
+.crowdsignal-forms-form {
+	line-height: 1.5;
+
+	&__content {
+		input[type="text"] {
+			min-height: 45px;
+		}
+	}
+}
+
+input, .crowdsignal-forms-question-wrapper {
+	border: 1px solid #CCC;
+}
+
+button, input, select, optgroup, textarea {
+	line-height: initial;
+}
+
+.wp-block-button {
+	&:not(.is-style-squared) .wp-block-button__link {
+		border-radius: 5px;
+	}
+
+	&:not(.is-style-outline) .wp-block-button__link {
+		background: #0073aa;
+	}
+
+	.wp-block-button__link {
+		line-height: 1.8;
+		font-size: 0.88889em;
+		font-weight: bold;
+
+		&:hover {
+			color: white;
+			background: #111;
+			cursor: pointer;
+		}
+
+		&:not(.has-text-color) {
+			color: #fff;
+		}
+	}
+}
+
+.crowdsignal-forms-button__button {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+

--- a/packages/theme-compatibility/src/twentynineteen/base.scss
+++ b/packages/theme-compatibility/src/twentynineteen/base.scss
@@ -1,3 +1,6 @@
+html {
+	font-size: 22px;
+}
 .crowdsignal-forms-form {
 	line-height: 1.5;
 
@@ -26,7 +29,8 @@ button, input, select, optgroup, textarea {
 	}
 
 	.wp-block-button__link {
-		line-height: 1.8;
+		line-height: 1.2;
+		padding: 0.76rem 1rem;
 		font-size: 0.88889em;
 		font-weight: bold;
 

--- a/packages/theme-compatibility/src/twentynineteen/editor.scss
+++ b/packages/theme-compatibility/src/twentynineteen/editor.scss
@@ -9,7 +9,7 @@ h1, h2 {
 .iso-editor .block-editor-writing-flow {
 	font-size: 22px;
 	font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
-	line-height: 1.8;
+	line-height: 1.5;
 	color: #111;
 	-webkit-font-smoothing: antialiased;
 
@@ -17,6 +17,10 @@ h1, h2 {
 		&:before {
 			display: block;
 		}
+	}
+
+	p {
+		line-height: 1.5;
 	}
 }
 

--- a/packages/theme-compatibility/src/twentynineteen/editor.scss
+++ b/packages/theme-compatibility/src/twentynineteen/editor.scss
@@ -1,0 +1,23 @@
+@import 'base';
+
+h1, h2 {
+	&:before {
+		display: none;
+	}
+}
+
+.iso-editor .block-editor-writing-flow {
+	font-size: 22px;
+	font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+	line-height: 1.8;
+	color: #111;
+	-webkit-font-smoothing: antialiased;
+
+	h1, h2 {
+		&:before {
+			display: block;
+		}
+	}
+}
+
+

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -14,6 +14,8 @@ module.exports = {
 		'crowdsignal-editor': './src/crowdsignal/editor.scss',
 		'leven': './src/leven/base.scss',
 		'leven-editor': './src/leven/editor.scss',
+		'twentynineteen': './src/twentynineteen/base.scss',
+		'twentynineteen-editor': './src/twentynineteen/editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'dist' ),


### PR DESCRIPTION
## Summary

This PR has the necessary adjustments added to the `theme-compatibility` package in order to support the `twentynineteen` theme.

Depends On: D75386-code

Ref: c/0AYpIWq4-tr


## Test Instructions
* Open or create a new project and add some blocks
* On the Editor and on the Project Renderer, add the following param to the URL: `?theme=twentynineteen`
* You should see both pages using the new theme style