### PR TITLE
Fix publish button

### DIFF
--- a/apps/dashboard/src/data/editor/actions.js
+++ b/apps/dashboard/src/data/editor/actions.js
@@ -47,15 +47,12 @@ export const setEditorCurrentPage = ( pageIndex ) => ( {
 export function* saveEditorChanges( options = {} ) {
 	const projectId = select( STORE_NAME ).getEditorProjectId();
 	const changes = select( STORE_NAME ).getEditorChanges();
-	const data = select( STORE_NAME ).getEditorUpdatedProjectData();
+	const data = select( STORE_NAME ).getEditorUpdatedProjectData( {
+		public: options.public,
+	} );
 
 	yield { type: EDITOR_SAVE };
 	yield { type: EDITOR_AUTOSAVE_TIMER_CANCEL };
-
-	if ( options.public ) {
-		data.publicContent = data.draftContent;
-		data.public = true;
-	}
 
 	try {
 		yield saveAndUpdateProject( projectId, data );

--- a/apps/dashboard/src/data/editor/selectors.js
+++ b/apps/dashboard/src/data/editor/selectors.js
@@ -120,19 +120,26 @@ export const getEditorTitle = ( state ) => state.editor.title;
 /**
  * Returns a partial project containing all the changes made since the last save.
  *
- * @param  {Object} state App state.
- * @return {Object}       Partial project.
+ * @param  {Object}  state          App state.
+ * @param  {Object}  options        Options.
+ * @param  {boolean} options.public Set to true if the project should include to-be-published changes.
+ * @return {Object}                 Partial project.
  */
-export const getEditorUpdatedProjectData = ( state ) => {
+export const getEditorUpdatedProjectData = ( state, options = {} ) => {
 	const changes = getEditorChanges( state );
 	const data = {};
 
-	if ( changes.content ) {
+	if ( changes.content || options.public ) {
 		data.draftContent = {
 			pages: map( getEditorPages( state ), ( page ) =>
 				parse( serialize( page ) )
 			),
 		};
+	}
+
+	if ( options.public ) {
+		data.publicContent = data.draftContent;
+		data.public = true;
 	}
 
 	if ( changes.title ) {


### PR DESCRIPTION
This patch fixes project publishing which was suffering from a regression causing it not to do anything if all changes have already been saved previously.

I did this by bumping up the logic for appending the public data from the action generator to `getEditorUpdatedProjectData` which I guess makes sense considering what it's used for/how its named.

Solves c/sZ0d1Kct/-tr.

# Testing

- Create a project, wait for all changes to save, hit 'publish'. Your project should be published correctly.
- Open an existing draft project, hit 'publish'. Your project should be published correctly.