### PR TITLE
Add submit page for previews

### DIFF
--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -19,7 +19,7 @@ import {
 import { Form } from '@crowdsignal/form';
 import { useStylesheet } from '@crowdsignal/hooks';
 import { setHostOption } from '@crowdsignal/http';
-import { fetchProjectForm } from '@crowdsignal/rest-api';
+import { fetchProjectForm, submitProjectForm } from '@crowdsignal/rest-api';
 
 const App = ( {
 	projectCode,
@@ -69,6 +69,15 @@ const App = ( {
 			data = {};
 		}
 
+		if ( preview ) {
+			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
+			setHostOption(
+				'https://api.crowdsignal.com',
+				'credentials',
+				'include'
+			);
+		}
+
 		const form = new window.FormData();
 		form.append( 'p', currentPage );
 		form.append( 'r', responseHash );
@@ -78,22 +87,12 @@ const App = ( {
 		);
 
 		return (
-			window
-				.fetch(
-					`https://api.crowdsignal.com/v4/projects/${ projectCode }/form`,
-					{
-						method: 'POST',
-						body: form,
-					}
-				)
-				.then( ( res ) => {
-					if ( ! res.ok ) {
-						throw new Error( res.status );
-					}
-
-					return res.json();
-				} )
-				.then( ( json ) => {
+			submitProjectForm(
+				projectCode,
+				form,
+				preview ? { preview: true } : {}
+			)
+				.then( ( { data: json } ) => {
 					if ( ! json || ! json.content ) {
 						throw new Error( 'Empty response' );
 					}

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -40,8 +40,6 @@ const App = ( {
 	const [ hasResponded, setHasResponded ] = useState( false );
 
 	useEffect( () => {
-		const query = {};
-
 		if ( preview ) {
 			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
 			setHostOption(
@@ -49,8 +47,9 @@ const App = ( {
 				'credentials',
 				'include'
 			);
-			query.preview = true;
 		}
+
+		const query = preview && { preview };
 
 		fetchProjectForm( projectCode, query )
 			.then( ( res ) => {
@@ -80,7 +79,7 @@ const App = ( {
 			form.append( key, data[ key ] )
 		);
 
-		const query = preview ? { preview: true } : {};
+		const query = preview && { preview };
 
 		return (
 			submitProjectForm( projectCode, form, query )

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -40,6 +40,8 @@ const App = ( {
 	const [ hasResponded, setHasResponded ] = useState( false );
 
 	useEffect( () => {
+		const query = {};
+
 		if ( preview ) {
 			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
 			setHostOption(
@@ -47,9 +49,10 @@ const App = ( {
 				'credentials',
 				'include'
 			);
+			query.preview = true;
 		}
 
-		fetchProjectForm( projectCode, preview ? { preview: true } : {} )
+		fetchProjectForm( projectCode, query )
 			.then( ( res ) => {
 				if ( ! res.data || ! res.data.content ) {
 					throw new Error( 'Empty response' );
@@ -77,12 +80,10 @@ const App = ( {
 			form.append( key, data[ key ] )
 		);
 
+		const query = preview ? { preview: true } : {};
+
 		return (
-			submitProjectForm(
-				projectCode,
-				form,
-				preview ? { preview: true } : {}
-			)
+			submitProjectForm( projectCode, form, query )
 				.then( ( { data: json } ) => {
 					if ( ! json || ! json.content ) {
 						throw new Error( 'Empty response' );

--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -69,15 +69,6 @@ const App = ( {
 			data = {};
 		}
 
-		if ( preview ) {
-			setHostOption( 'https://api.crowdsignal.com', 'mode', 'cors' );
-			setHostOption(
-				'https://api.crowdsignal.com',
-				'credentials',
-				'include'
-			);
-		}
-
 		const form = new window.FormData();
 		form.append( 'p', currentPage );
 		form.append( 'r', responseHash );

--- a/packages/rest-api/src/project/index.js
+++ b/packages/rest-api/src/project/index.js
@@ -42,3 +42,13 @@ export const fetchProjectForm = ( projectId, query = {} ) =>
 		method: 'GET',
 		query,
 	} );
+
+export const submitProjectForm = ( projectId, formData, query = {} ) =>
+	http( {
+		host: 'https://api.crowdsignal.com',
+		path: `/v4/projects/${ projectId }/form`,
+		method: 'POST',
+		skipGlobalHeaders: [ 'Content-Type' ],
+		body: formData,
+		query,
+	} );


### PR DESCRIPTION
This PR implements preview submit capabilities for the project-renderer.

A new method has been added to the rest-api package: submitProjectform

NOTE: an issue became evident while working on this PR where the form would submit the entire project data every time. This is being addressed on #164 

Depends on D75489-code

## Test instructions
Create a project with a couple of pages. Draft or Publish it and proceed to open the preview.
You should be able to submit all pages without restriction as long as you are the owner