### PR TITLE
Add a new project wizard dialog

### DIFF
--- a/apps/dashboard/src/components/app/styles.js
+++ b/apps/dashboard/src/components/app/styles.js
@@ -5,6 +5,18 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 export const pageStyles = css`
+	@font-face {
+		font-family: Recoleta;
+		font-weight: normal;
+		src: url( 'https://crowdsignal.com/wp-content/themes/a8c/crowd-signal/assets/fonts/recoleta-regular-webfont.woff' );
+	}
+
+	@font-face {
+		font-family: Recoleta;
+		font-weight: bold;
+		src: url( 'https://crowdsignal.com/wp-content/themes/a8c/crowd-signal/assets/fonts/recoleta-bold-webfont.woff' );
+	}
+
 	html {
 		display: table;
 		margin: 0;

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { map, noop } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
@@ -13,6 +13,7 @@ import { Global } from '@emotion/core';
  */
 import * as crowdsignalBlocks from '@crowdsignal/block-editor';
 import HeaderMeta from '../header-meta';
+import NewProjectWizard from '../new-project-wizard';
 import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 import AutoSubmitButton from './auto-submit-button';
@@ -37,6 +38,8 @@ import {
 registerBlocks();
 
 const Editor = ( { project, theme = 'leven' } ) => {
+	const [ showWizard, setShowWizard ] = useState( ! project.id );
+
 	const { updateEditorTitle } = useDispatch( STORE_NAME );
 
 	const {
@@ -45,8 +48,14 @@ const Editor = ( { project, theme = 'leven' } ) => {
 		loadBlocks,
 		saveBlocks,
 		restoreDraft,
+		setProjectTemplate,
 		version,
 	} = useEditorContent( project );
+
+	const handleSelectTemplate = ( projectTemplate ) => {
+		setProjectTemplate( projectTemplate );
+		setShowWizard( false );
+	};
 
 	const settings = useMemo(
 		() => ( {
@@ -80,8 +89,11 @@ const Editor = ( { project, theme = 'leven' } ) => {
 				projectId={ project.id }
 			/>
 
-			<PageNavigation />
+			{ showWizard && (
+				<NewProjectWizard onSelect={ handleSelectTemplate } />
+			) }
 
+			<PageNavigation />
 			<EditorWrapper
 				as={ IsolatedBlockEditor }
 				key={ editorId }

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -3,12 +3,12 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
  */
 import HeaderMeta from '../header-meta';
+import { blankProjectTemplate } from '../new-project-wizard/templates';
 import { STORE_NAME } from '../../data';
 import BlockEditor from './editor';
 import EditorLoadingPlaceholder from './loading-placeholder';
@@ -16,32 +16,7 @@ import EditorLoadingPlaceholder from './loading-placeholder';
 const Editor = ( { projectId, theme } ) => {
 	const [ project, isLoading ] = useSelect( ( select ) => {
 		if ( ! projectId ) {
-			return [
-				{
-					draftContent: {
-						pages: [
-							[],
-							[
-								{
-									attributes: {
-										content: __(
-											'Thank you!',
-											'dashboard'
-										),
-										level: 2,
-										textAlign: 'center',
-									},
-									clientId: uuid(),
-									innerBlocks: [],
-									isValid: true,
-									name: 'core/heading',
-								},
-							],
-						],
-					},
-				},
-				false,
-			];
+			return [ blankProjectTemplate.project, false ];
 		}
 
 		return [

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -36,12 +36,8 @@ export const useEditorContent = ( project ) => {
 	] );
 
 	useEffect( () => {
-		if ( ! project ) {
-			return;
-		}
-
 		initializeEditor(
-			project.id,
+			project.id || 0,
 			project.title,
 			isPublic( project ) && ! forceDraft
 				? project.publicContent.pages
@@ -93,12 +89,21 @@ export const useEditorContent = ( project ) => {
 		setReady( false );
 	};
 
+	const setProjectTemplate = ( projectTemplate ) => {
+		initializeEditor( 0, undefined, projectTemplate.draftContent.pages );
+
+		// Force IsolatedBlockEditor to reload
+		setEditorId( `${ editorId }*` );
+		setReady( false );
+	};
+
 	return {
 		editorId,
 		confirmationPage,
 		loadBlocks,
 		saveBlocks,
 		restoreDraft,
+		setProjectTemplate,
 		version: forceDraft ? 'draft' : 'auto',
 	};
 };

--- a/apps/dashboard/src/components/new-project-wizard/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import TemplatePreview from './template-preview';
+import * as projectTemplates from './templates';
+
+/**
+ * Style dependencies
+ */
+import {
+	ProjectWizardDialog,
+	ProjectWizardHeader,
+	ProjectWizardHeaderNote,
+	ProjectWizardTemplateGrid,
+	ProjectWizardWrapper,
+} from './styles';
+
+const NewProjectWizard = ( { onSelect } ) => {
+	return (
+		<ProjectWizardWrapper>
+			<ProjectWizardDialog id="crowdsignal-new-project-wizard">
+				<ProjectWizardHeader>
+					{ __( 'What would you like to build today?', 'dashboard' ) }
+				</ProjectWizardHeader>
+				<ProjectWizardHeaderNote>
+					{ __(
+						'Pick a template and make it your own or start with a blank page.',
+						'dashboard'
+					) }
+				</ProjectWizardHeaderNote>
+
+				<ProjectWizardTemplateGrid>
+					{ map( projectTemplates, ( template ) => (
+						<TemplatePreview
+							key={ template.name }
+							template={ template }
+							onSelect={ onSelect }
+						/>
+					) ) }
+				</ProjectWizardTemplateGrid>
+			</ProjectWizardDialog>
+		</ProjectWizardWrapper>
+	);
+};
+
+export default NewProjectWizard;

--- a/apps/dashboard/src/components/new-project-wizard/styles/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const ProjectWizardWrapper = styled.div`
+	align-items: center;
+	background-color: var( --color-backdrop );
+	box-sizing: border-box;
+	display: flex;
+	justify-content: center;
+	padding: 100px;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	top: 0;
+	z-index: 1000;
+`;
+
+export const ProjectWizardDialog = styled.div`
+	background-color: var( --color-surface );
+	box-shadow: 5px 5px 15px var( --color-shadow );
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	max-width: 1600px;
+	padding: 80px 160px;
+`;
+
+export const ProjectWizardHeader = styled.h2`
+	color: var( --color-text );
+	font-family: 'Recoleta';
+	font-size: 42px;
+	font-weight: 400;
+	margin: 0;
+`;
+
+export const ProjectWizardHeaderNote = styled.p`
+	color: var( --color-text-subtle );
+	font-size: 16px;
+	margin-bottom: 40px;
+`;
+
+export const ProjectWizardTemplateGrid = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	grid-gap: 24px;
+`;

--- a/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const TemplatePreviewWrapper = styled.div`
+	align-items: flex-start;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+`;
+
+export const TemplatePreviewFrame = styled.button`
+	background-color: var( --color-surface );
+	background-color: var( --color-page-background );
+	border: 1px solid var( --color-border );
+	border-radius: 2px;
+	box-sizing: border-box;
+	cursor: pointer;
+	height: 250px;
+	margin-bottom: 16px;
+	position: relative;
+	overflow: hidden;
+	width: 100%;
+
+	.block-editor-block-preview__content > iframe {
+		border: 0;
+		max-width: initial;
+	}
+`;
+
+export const TemplatePreviewName = styled.h3`
+	color: var( --color-text );
+	font-size: 16px;
+	font-weight: bold;
+	margin-bottom: 8px;
+`;
+
+export const TemplatePreviewDescription = styled.p`
+	color: var( --color-text-subtle );
+	font-size: 16px;
+	margin: 0;
+`;

--- a/apps/dashboard/src/components/new-project-wizard/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/template-preview.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { BlockPreview } from '@wordpress/block-editor';
+
+/**
+ * Style dependencies
+ */
+import {
+	TemplatePreviewDescription,
+	TemplatePreviewFrame,
+	TemplatePreviewName,
+	TemplatePreviewWrapper,
+} from './styles/template-preview';
+
+const TemplatePreview = ( { onSelect, template } ) => {
+	const handleSelect = () => onSelect( template.project );
+
+	const PreviewComponent = template.preview;
+
+	return (
+		<TemplatePreviewWrapper>
+			<TemplatePreviewFrame onClick={ handleSelect }>
+				{ PreviewComponent && <PreviewComponent /> }
+
+				{ ! PreviewComponent && (
+					<BlockPreview
+						blocks={ template.project.draftContent.pages[ 0 ] }
+						viewportWidth={ 1200 }
+					/>
+				) }
+			</TemplatePreviewFrame>
+
+			<TemplatePreviewName>{ template.name }</TemplatePreviewName>
+			<TemplatePreviewDescription>
+				{ template.description }
+			</TemplatePreviewDescription>
+		</TemplatePreviewWrapper>
+	);
+};
+
+export default TemplatePreview;

--- a/apps/dashboard/src/components/new-project-wizard/templates/blank.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/blank.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import { v4 as uuid } from 'uuid';
+
+const BlankProjectPreviewWrapper = styled.div`
+	align-items: center;
+	box-sizing: border-box;
+	display: flex;
+	height: 100%;
+	justify-content: center;
+	width: 100%;
+`;
+
+const BlankProjectStartButton = styled.div`
+	border: 1px solid var( --color-border );
+	border-radius: 2px;
+	box-sizing: border-box;
+	background-color: var( --color-surface );
+	padding: 8px 32px;
+`;
+
+export const blankProjectTemplate = {
+	name: __( 'Empty Canvas', 'dashboard' ),
+	description: __(
+		'Setup your own form structure and design from scratch.',
+		'dashboard'
+	),
+	project: {
+		draftContent: {
+			pages: [
+				[],
+				[
+					{
+						attributes: {
+							content: __( 'Thank you!', 'dashboard' ),
+							level: 2,
+							textAlign: 'center',
+						},
+						clientId: uuid(),
+						innerBlocks: [],
+						isValid: true,
+						name: 'core/heading',
+					},
+				],
+			],
+		},
+	},
+	preview: () => (
+		<BlankProjectPreviewWrapper>
+			<BlankProjectStartButton>
+				{ __( 'Start from scratch', 'dashboard' ) }
+			</BlankProjectStartButton>
+		</BlankProjectPreviewWrapper>
+	),
+};

--- a/apps/dashboard/src/components/new-project-wizard/templates/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/index.js
@@ -1,0 +1,2 @@
+export * from './blank';
+export * from './product-feedback';

--- a/apps/dashboard/src/components/new-project-wizard/templates/product-feedback.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/product-feedback.js
@@ -1,0 +1,574 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { v4 as uuid } from 'uuid';
+
+export const productFeedbackTemplate = {
+	name: __( 'Product Feedback', 'dashboard' ),
+	description: __( 'Judge or be judged.', 'dashboard' ),
+	project: {
+		draftContent: {
+			pages: [
+				[
+					{
+						clientId: '85685df3-e5c6-42e8-aec1-7295ae3f3207',
+						name: 'core/spacer',
+						isValid: true,
+						attributes: {
+							height: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '0c55ba3f-ac80-4bb8-9285-d4112e5f547b',
+						name: 'core/columns',
+						isValid: true,
+						attributes: {
+							isStackedOnMobile: true,
+						},
+						innerBlocks: [
+							{
+								clientId:
+									'4046f8a9-0d6d-42aa-8c34-ff7d0e0efbae',
+								name: 'core/column',
+								isValid: true,
+								attributes: {
+									verticalAlignment: 'center',
+								},
+								innerBlocks: [
+									{
+										clientId:
+											'8c630506-15a0-45bf-9579-9305c75156ce',
+										name: 'core/heading',
+										isValid: true,
+										attributes: {
+											textAlign: 'left',
+											content:
+												'<strong>Welcome</strong>!',
+											level: 1,
+											anchor: 'welcome',
+											textColor: 'black',
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'e5279603-5ff3-4158-905e-28bdf40d037a',
+										name: 'core/paragraph',
+										isValid: true,
+										attributes: {
+											content: ' ',
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'd23f8ecb-f6a5-4a06-802c-9bee9707bc7b',
+										name: 'core/paragraph',
+										isValid: true,
+										attributes: {
+											align: 'left',
+											content:
+												'The following questions will ask for your feedback on our product. Your answers will help us understand the strengths and weaknesses of our service.',
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'4c7ae9fb-3b5b-4aad-b6a7-dbf9e94b5c33',
+										name: 'core/paragraph',
+										isValid: true,
+										attributes: {
+											content: '',
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'1287bc24-47ba-43ca-814a-fe7660913ee4',
+										name: 'core/paragraph',
+										isValid: true,
+										attributes: {
+											content:
+												'Thank you for spending 5 minutes with us.',
+											dropCap: false,
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'32272dbf-f14f-4ab7-a80d-8e3655f0a801',
+										name: 'core/spacer',
+										isValid: true,
+										attributes: {
+											height: 152,
+										},
+										innerBlocks: [],
+									},
+									{
+										clientId:
+											'840092aa-a519-4048-81f4-ad3f7d1c5272',
+										name: 'core/group',
+										isValid: true,
+										attributes: {
+											tagName: 'div',
+										},
+										innerBlocks: [
+											{
+												clientId:
+													'97e3e1a7-e05d-443f-964a-3b914a408f23',
+												name:
+													'crowdsignal-forms/submit-button',
+												isValid: true,
+												attributes: {
+													label: "Let's start",
+												},
+												innerBlocks: [],
+											},
+										],
+									},
+								],
+							},
+							{
+								clientId:
+									'335deb00-d372-46c8-a01a-14d41c15ba02',
+								name: 'core/column',
+								isValid: true,
+								attributes: {
+									verticalAlignment: 'center',
+								},
+								innerBlocks: [
+									{
+										clientId:
+											'c562e183-2c7a-4ac1-a037-0baae99de522',
+										name: 'core/image',
+										isValid: true,
+										attributes: {
+											url:
+												'https://i1.wp.com/files.polldaddy.com/bfb8591ecb6a562b2a496cc2a3ceab60-621788830532a.jpg',
+											alt: 'DvS2Zy5U8AAP3gC',
+											caption: '',
+											href:
+												'https://i1.wp.com/files.polldaddy.com/bfb8591ecb6a562b2a496cc2a3ceab60-621788830532a.jpg',
+											sizeSlug: 'full',
+											linkDestination: 'media',
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					},
+					{
+						clientId: 'b3ade5db-ec56-409f-b89a-d4076927c765',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							content: ' ',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+				],
+				[
+					{
+						clientId: '7c4c60ae-bf59-4a4d-bd82-1d6c484611bf',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							content: '',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'df727dd0-30c0-4cb0-a937-6d05325410f6',
+						name: 'crowdsignal-forms/multiple-choice-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							question:
+								'What emoji describes best your experience with ACME?',
+							mandatory: false,
+							allowOther: false,
+							minimumChoices: 0,
+							maximumChoices: 1,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							className: 'is-style-button',
+						},
+						innerBlocks: [
+							{
+								clientId:
+									'6c6a7660-25d1-43fd-abd9-5a9aedc4cdf8',
+								name: 'core/image',
+								isValid: true,
+								attributes: {
+									url:
+										'https://i1.wp.com/files.polldaddy.com/eb85a0eaa558dd7b87295239c28f3c46-62177c8e84365.png',
+									alt: 'image',
+									caption: '',
+									href:
+										'https://i1.wp.com/files.polldaddy.com/eb85a0eaa558dd7b87295239c28f3c46-62177c8e84365.png',
+									sizeSlug: 'full',
+									linkDestination: 'media',
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						clientId: '158be02a-8517-43d0-9c3a-446002b2d957',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							content: '',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '3554a493-d41f-414e-81f5-3b95267b9fb9',
+						name: 'crowdsignal-forms/submit-button',
+						isValid: true,
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+				[
+					{
+						clientId: 'fabc340c-0f9c-4fe1-bb57-460e36d13e4c',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							content: '',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '26a525ab-95d7-4fc9-b05d-463f76b6dcb9',
+						name: 'crowdsignal-forms/multiple-choice-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							question:
+								'How would you feel if you could no longer use ACME?',
+							mandatory: false,
+							allowOther: false,
+							minimumChoices: 0,
+							maximumChoices: 1,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							className: 'is-style-button',
+						},
+						innerBlocks: [
+							{
+								clientId:
+									'9d11a8e8-1a2b-439f-bd33-7a6f6b0d3959',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Very disappointed',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'4e6fb1db-a035-439b-b6ba-bae726242b6e',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Somewhat disappointed',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'6333d876-3f00-43af-92ab-4c126dbf54ec',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Not disappointed',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'60732056-2a2e-4f28-b1e9-dab31a09e481',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'I no longer use it',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						clientId: '65aab95e-9efe-4534-aac3-2bf6a2bfd1e5',
+						name: 'crowdsignal-forms/text-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							restrictions: [],
+							question:
+								'What would you likely use as an alternative if ACME were no longer available?',
+							note: '',
+							placeholder: '',
+							mandatory: false,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							inputHeight: '80px',
+							width: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '3db3c9dc-3545-4f78-ac62-9aa0150b63de',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							content: '',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '455ca9b8-86e5-478c-83cd-a0450d759f58',
+						name: 'crowdsignal-forms/submit-button',
+						isValid: true,
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+				[
+					{
+						clientId: '34a04466-efda-4112-8b02-6fd733aaee13',
+						name: 'crowdsignal-forms/multiple-choice-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							question:
+								'How main times did you use ACME in the last week?',
+							mandatory: false,
+							allowOther: false,
+							minimumChoices: 0,
+							maximumChoices: 1,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							className: 'is-style-button',
+						},
+						innerBlocks: [
+							{
+								clientId:
+									'df12ccf6-63f4-4e7e-97ae-c28d6b91356f',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Once',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'3dcdd508-7a51-4f62-8aa4-973921a8382a',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Twice',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'fe517984-9fda-421b-a8bb-6d9a869ecca2',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: '3 or more times',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								clientId:
+									'88a9d049-964f-49b1-bce0-53524dd66faa',
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								isValid: true,
+								attributes: {
+									clientId: uuid(),
+									label: 'Every day',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						clientId: 'cfaec325-f689-41a1-86b5-0d48e0d36f95',
+						name: 'crowdsignal-forms/text-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							restrictions: [],
+							question:
+								'Describe how you’re currently using ACME in a few words.',
+							note: '',
+							placeholder: '',
+							mandatory: false,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							inputHeight: '80px',
+							width: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '25a03295-9e9b-4f30-adf8-9cef04483d1f',
+						name: 'crowdsignal-forms/text-question',
+						isValid: true,
+						attributes: {
+							clientId: uuid(),
+							restrictions: [],
+							question: 'Have you encountered any problems?',
+							note: '',
+							placeholder: '',
+							mandatory: false,
+							borderRadius: 5,
+							boxShadow: false,
+							borderWidth: 1,
+							inputHeight: '80px',
+							width: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '8f792b93-ccb0-4d39-b1de-40f956297771',
+						name: 'crowdsignal-forms/submit-button',
+						isValid: true,
+						attributes: {
+							label: 'Submit',
+						},
+						innerBlocks: [],
+					},
+				],
+				[
+					{
+						clientId: 'db42bd8b-9101-470c-bce9-5d88973acca4',
+						name: 'core/spacer',
+						isValid: true,
+						attributes: {
+							height: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '75d68059-6774-4ca6-b134-605a1b9c342c',
+						name: 'core/heading',
+						isValid: true,
+						attributes: {
+							textAlign: 'center',
+							content: 'Thank you!',
+							level: 2,
+							anchor: 'thank-you',
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'f5f55703-391e-4f7b-8b94-15141e4d45af',
+						name: 'core/spacer',
+						isValid: true,
+						attributes: {
+							height: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'f4c5b87d-ec8d-46f5-90a5-6127d43b10ff',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							align: 'center',
+							content: 'Your response has been recorded!',
+							dropCap: false,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'b666cba1-0c1c-4406-af7d-763673b25dfe',
+						name: 'core/spacer',
+						isValid: true,
+						attributes: {
+							height: 232,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: '46be2a3d-4d58-41a1-8688-7f25f2f671b6',
+						name: 'core/separator',
+						isValid: true,
+						attributes: [],
+						innerBlocks: [],
+					},
+					{
+						clientId: 'a9c1ab20-9a5a-40ab-9625-2f22231491e4',
+						name: 'core/spacer',
+						isValid: true,
+						attributes: {
+							height: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						clientId: 'cbe25506-cd23-4aed-947e-07348619ae3a',
+						name: 'core/paragraph',
+						isValid: true,
+						attributes: {
+							align: 'center',
+							content:
+								'POWERED BY <a href="https://crowdsignal.com">CROWDSIGNAL</a>',
+							dropCap: false,
+							fontSize: 'small',
+						},
+						innerBlocks: [],
+					},
+				],
+			],
+		},
+	},
+};

--- a/apps/dashboard/src/data/editor/reducer.js
+++ b/apps/dashboard/src/data/editor/reducer.js
@@ -29,9 +29,18 @@ import { clonePage } from './util';
  * @param  {Object} action Action object.
  * @return {Object}        Updated properties.
  */
+// eslint-disable-next-line complexity
 const changes = ( state = {}, action ) => {
-	if ( action.type === EDITOR_INIT || action.type === EDITOR_SAVE ) {
+	if ( action.type === EDITOR_SAVE ) {
 		return {};
+	}
+
+	if ( action.type === EDITOR_INIT ) {
+		return action.projectId > 0
+			? {}
+			: {
+					content: true,
+			  };
 	}
 
 	if ( action.type === EDITOR_SAVE_ERROR ) {


### PR DESCRIPTION
This patch adds a new dialog component to be displayed when starting new project. As of right now, the dialog only allows for selecting a template but will be expanded in the future.

It's worth noting, displaying the dialog in front of the editor is actually of importance as that ensures all blocks and the theme are loaded. While it is possible to render previews, it's actually a great deal of effort to make that happen.

Note that the templates themselves are yet to be fine tuned in terms of their structure and we'll possibly want to move them out to their own package - like `@crowdsignal/project-templates` - eventually.  
`attributes.clientId` values **must** be generated for all `crowdsignal-forms/` blocks before the template is inserted into the editor. `useClientId()` only works if the page becomes active, so if somebody were to choose a template and immediately publish, it's possible our blocks would be missing client IDs otherwise.

![select-template](https://user-images.githubusercontent.com/8056203/155766611-3f5719ac-5013-497a-9980-53fe1f53e899.png)

Solves c/9cycqiaH-tr.

# Testing

- Go to `/project` - you should see the new project wizard.
- Clicking on a template should auto-populate your new project with that template.
- Selecting a template **should not** trigger an autosave, but it **should** make the editor go into unsaved changes state.
- When opening an existing project, the project wizard should not appear.