### PR TITLE
Fix missing editor settings key crashing the editor

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -56,7 +56,6 @@ const Editor = ( { project, theme = 'leven' } ) => {
 				blocks: {
 					...editorSettings.iso.blocks,
 					disallowBlocks: [
-						...editorSettings.iso.blocks.disallowBlocks,
 						...( confirmationPage
 							? map( crowdsignalBlocks, 'name' )
 							: [] ),


### PR DESCRIPTION
This patch fixes a small regression introduced in #149 where a change to `editorSettings` structure has caused the editor to crash due to other changes that have been added since.

# Testing

The editor should no longer crash when you try to go to `/project` or `/project/:projectId`.