### PR TITLE
Add Twenty-TwentyTwo theme

### DIFF
--- a/packages/styles/src/reset.js
+++ b/packages/styles/src/reset.js
@@ -33,6 +33,7 @@ export const resetStyles = ( { shadowRoot = false } ) => css`
 		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
 			Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
 			'Segoe UI Symbol';
+		font-size: 100%;
 	}
 
 	iframe {

--- a/packages/theme-compatibility/src/twentytwentytwo/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/base.scss
@@ -1,0 +1,3 @@
+html {
+	font-size: 16px;
+}

--- a/packages/theme-compatibility/src/twentytwentytwo/editor.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/editor.scss
@@ -1,0 +1,7 @@
+@import 'base';
+
+.editor .iso-editor .block-editor-writing-flow {
+	color: var(--wp--preset--color--foreground);
+	font-size: var(--wp--preset--font-size--medium);
+	line-height: var(--wp--custom--typography--line-height--normal);
+}

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -16,6 +16,8 @@ module.exports = {
 		'leven-editor': './src/leven/editor.scss',
 		'twentynineteen': './src/twentynineteen/base.scss',
 		'twentynineteen-editor': './src/twentynineteen/editor.scss',
+		'twentytwentytwo': './src/twentytwentytwo/base.scss',
+		'twentytwentytwo-editor': './src/twentytwentytwo/editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'dist' ),


### PR DESCRIPTION
## Summary

This PR has the necessary adjustments added to the `theme-compatibility` package in order to support the `twenty-twentytwo` theme.

Depends On: D75966-code

Ref: c/UXGxxjdm-tr

## Test Instructions
* Open or create a new project and add some blocks
* On the Editor and on the Project Renderer, add the following param to the URL: `?theme=twentytwentytwo`
* You should see both pages using the new theme style