### PR TITLE
Move Question Wrapper default border styles

### DIFF
--- a/packages/block-editor/src/components/border-settings/index.js
+++ b/packages/block-editor/src/components/border-settings/index.js
@@ -16,7 +16,7 @@ const BorderSettings = ( { attributes, setAttributes, initialOpen } ) => {
 
 	const handleChangeNumberAttribute = ( key ) => ( value ) =>
 		setAttributes( {
-			[ key ]: parseInt( value, 10 ),
+			[ key ]: parseInt( value ) || value,
 		} );
 
 	return (

--- a/packages/block-editor/src/components/border-settings/index.js
+++ b/packages/block-editor/src/components/border-settings/index.js
@@ -16,7 +16,7 @@ const BorderSettings = ( { attributes, setAttributes, initialOpen } ) => {
 
 	const handleChangeNumberAttribute = ( key ) => ( value ) =>
 		setAttributes( {
-			[ key ]: parseInt( value ) || value,
+			[ key ]: parseInt( value, 10 ) || value,
 		} );
 
 	return (

--- a/packages/block-editor/src/multiple-choice-question/attributes.js
+++ b/packages/block-editor/src/multiple-choice-question/attributes.js
@@ -33,6 +33,7 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
+		default: '',
 	},
 	boxShadow: {
 		type: 'boolean',
@@ -40,6 +41,7 @@ export default {
 	},
 	borderWidth: {
 		type: 'number',
+		default: '',
 	},
 	gradient: {
 		type: 'string',

--- a/packages/block-editor/src/multiple-choice-question/attributes.js
+++ b/packages/block-editor/src/multiple-choice-question/attributes.js
@@ -33,7 +33,6 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
-		default: 5,
 	},
 	boxShadow: {
 		type: 'boolean',
@@ -41,7 +40,6 @@ export default {
 	},
 	borderWidth: {
 		type: 'number',
-		default: 1,
 	},
 	gradient: {
 		type: 'string',

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -33,7 +33,6 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
-		default: 5,
 	},
 	boxShadow: {
 		type: 'boolean',
@@ -41,7 +40,6 @@ export default {
 	},
 	borderWidth: {
 		type: 'number',
-		default: 1,
 	},
 	fontFamily: {
 		type: 'string',

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -33,6 +33,7 @@ export default {
 	},
 	borderRadius: {
 		type: 'number',
+		default: '',
 	},
 	boxShadow: {
 		type: 'boolean',
@@ -40,6 +41,7 @@ export default {
 	},
 	borderWidth: {
 		type: 'number',
+		default: '',
 	},
 	fontFamily: {
 		type: 'string',

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -11,7 +11,9 @@ import { useBorderStyles, useColorStyles } from '@crowdsignal/styles';
 import { ErrorMessage } from '../index';
 
 const StyledQuestionWrapper = styled.div`
+	border-radius: 5px;
 	border-style: solid;
+	border-width: 1px;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary

The purpose of this PR is to move MC Question and Text Question default `borderRadius` and `borderWidth` attributes to the CSS of the Question Wrapper.
This will allow us to override the default border styles for the new themes.
If the user changes the block settings, this will be added to the Block's `style` attribute, hence having higher priority. 

## Test Instructions

* Open or create a new project
* Add an MC Question and a Text Question block
* The default styles for the blocks should look the same as before those changes.
