### PR TITLE
Revert "Attempt to cast int on number-ish param match"

### DIFF
--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	fromPairs,
-	isNumber,
-	isUndefined,
-	keys,
-	map,
-	split,
-	trimStart,
-	zipObject,
-} from 'lodash';
+import { fromPairs, isUndefined, map, split, trimStart } from 'lodash';
 import RouteParser from 'route-parser';
 
 /**
@@ -91,12 +82,6 @@ export const hasLocalTarget = ( element, includePattern ) => {
  */
 export const matchRoute = ( pattern, path ) => {
 	const route = new RouteParser( pattern );
-	const match = route.match( path );
 
-	return zipObject(
-		keys( match ),
-		map( match, ( param ) =>
-			isNumber( param ) ? parseInt( param, 10 ) : param
-		)
-	);
+	return route.match( path );
 };


### PR DESCRIPTION
Reverts Automattic/crowdsignal-ui#167.

Unfortunately, that PR caused a regression in the router where it now returns `{}` instead of `null` if a route doesn't match the pattern.
Causing dependent code to 'think' it does match.

# Testing

The router should go back to working correctly - test it by trying to access project resutls at `/project/:projectId/results`.