### PR TITLE
Add Blockbase Theme

### DIFF
--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -14,8 +14,10 @@
 	color: var(--color-neutral-40);
 }
 
-.crowdsignal-forms-text-input-block__wrapper, .crowdsignal-forms-text-question-block textarea {
-	color: var(--color-neutral-40);
+.block-editor-writing-flow {
+	.crowdsignal-forms-text-input-block__wrapper, .crowdsignal-forms-text-question-block textarea {
+		color: var(--color-neutral-40);
+	}
 }
 
 #crowdsignal-dashboard .block-editor-block-list__layout.is-root-container,

--- a/packages/theme-compatibility/src/blockbase/base.scss
+++ b/packages/theme-compatibility/src/blockbase/base.scss
@@ -1,0 +1,5 @@
+.crowdsignal-forms-question-wrapper {
+	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
+	border-radius: var(--wp--custom--form--border--radius);
+	box-shadow: var(--wp--custom--form--color--box-shadow);
+}

--- a/packages/theme-compatibility/src/blockbase/editor.scss
+++ b/packages/theme-compatibility/src/blockbase/editor.scss
@@ -1,0 +1,6 @@
+@import 'base';
+
+.editor .iso-editor .block-editor-writing-flow {
+	font-size: var(--wp--preset--font-size--normal);
+	line-height: var(--wp--custom--body--typography--line-height);
+}

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = {
 		'twentynineteen-editor': './src/twentynineteen/editor.scss',
 		'twentytwentytwo': './src/twentytwentytwo/base.scss',
 		'twentytwentytwo-editor': './src/twentytwentytwo/editor.scss',
+		'blockbase': './src/blockbase/base.scss',
+		'blockbase-editor': './src/blockbase/editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'dist' ),


### PR DESCRIPTION
## Summary

This PR has the necessary adjustments added to the `theme-compatibility` package in order to support the `Blockbase` theme.

Depends On: D76036-code

Ref: c/8ZcbZgys-tr

## Test Instructions
* Open or create a new project and add some blocks
* On the Editor and on the Project Renderer, add the following param to the URL: `?theme=blockbase`
* You should see both pages using the new theme style