### PR TITLE
Set project renderer's bottom padding to 80px

### DIFF
--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -84,7 +84,7 @@
 	}
 
 	@include break-medium {
-		padding: 64px 0 32px;
+		padding: 64px 0 80px;
 
 		> *:not(.crowdsignal-forms-question-wrapper) {
 			margin-bottom: 32px;


### PR DESCRIPTION
This patch adjusts the project's renderer default bottom padding to 80px.

Solves c/bvbpKxxD-tr.

# Testing

Verify the padding is updated.