### PR TITLE
Update Editor to prevent side effects from new Themes

### DIFF
--- a/apps/dashboard/src/components/editor/styles/editor.js
+++ b/apps/dashboard/src/components/editor/styles/editor.js
@@ -135,6 +135,10 @@ export const EditorWrapper = styled.div`
 				}
 			}
 		}
+
+		a {
+			color: var( --color-primary-50 );
+		}
 	}
 
 	.editor__project-visibility-popover .components-popover__content {

--- a/apps/dashboard/src/components/project-navigation/style.scss
+++ b/apps/dashboard/src/components/project-navigation/style.scss
@@ -18,5 +18,6 @@
 
 	.page-header {
 		letter-spacing: initial;
+		font-family: inherit;
 	}
 }

--- a/packages/block-editor/src/text-input/attributes.js
+++ b/packages/block-editor/src/text-input/attributes.js
@@ -23,7 +23,7 @@ export default {
 	},
 	inputHeight: {
 		type: 'number',
-		default: 40,
+		default: '',
 	},
 	inputWidth: {
 		type: 'string',

--- a/packages/block-editor/src/text-input/sidebar.js
+++ b/packages/block-editor/src/text-input/sidebar.js
@@ -27,7 +27,7 @@ export default ( { attributes, setAttributes } ) => {
 		} );
 
 	const handleChangeNumericAttribute = ( key ) => ( value ) =>
-		handleChangeAttribute( key )( parseInt( value ) );
+		handleChangeAttribute( key )( parseInt( value ) || '' );
 
 	return (
 		<InspectorControls>

--- a/packages/components/src/editable-page-header/style.scss
+++ b/packages/components/src/editable-page-header/style.scss
@@ -13,16 +13,18 @@
 }
 
 .editable-page-header__input {
-	background-color: transparent;
-	border: 0;
-	color: var(--color-text);
-	display: inline-flex;
-	font-size: 24px;
-	font-weight: 700;
-	heght: 40px;
-	line-height: 40px;
-	margin: 0;
-	outline: 0;
-	padding: 0;
-	width: 100%;
+	&[type="text"], &[type="text"]:focus {
+		background-color: transparent;
+		border: 0;
+		color: var(--color-text);
+		display: inline-flex;
+		font-size: 24px;
+		font-weight: 700;
+		height: 40px;
+		line-height: 40px;
+		margin: 0;
+		outline: 0;
+		padding: 0;
+		width: 100%;
+	}
 }

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -87,6 +87,10 @@
 		color: inherit;
 	}
 
+	.block-editor-inserter__panel-title {
+		font-family: inherit;
+	}
+
 	& :where(.wp-block)[data-align=right] > * {
 		float: right;
 	}

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -83,6 +83,10 @@
 		margin-right: auto;
 	}
 
+	.components-search-control__input {
+		color: inherit;
+	}
+
 	& :where(.wp-block)[data-align=right] > * {
 		float: right;
 	}


### PR DESCRIPTION
## Summary

This PR updates a few Editor CSS styles to increase their specificity and prevent side effects from new themes implementation.

Bonus: Removes the default input height and allows it to be empty. 
The default min-height is defined on the block's style. Removing the default attribute value will allow the themes to override the styles when necessary.

## Test Instructions

* Open or create a new project
* On the Editor, take a look at the styles of the Header, Right and Left sidebars
* The layout should look unaffected
* Add a Text Input form and change its input height on the block's settings
* Save the project and reload the page
* Go to the Text Input settings again and clear the input height property
* You should be able to save the project and the block should now use the default input height defined on the styles