### PR TITLE
Add Quadrat Theme

### DIFF
--- a/packages/theme-compatibility/src/quadrat/base.scss
+++ b/packages/theme-compatibility/src/quadrat/base.scss
@@ -1,0 +1,22 @@
+:root{
+	--custom--placeholder--color: #d1c7c7cc;
+}
+
+::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+	color: var(--custom--placeholder--color);
+	opacity: 1; /* Firefox */
+}
+
+:-ms-input-placeholder { /* Internet Explorer 10-11 */
+	color: var(--custom--placeholder--color);;
+}
+
+::-ms-input-placeholder { /* Microsoft Edge */
+	color: var(--custom--placeholder--color);
+}
+
+body {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	--wp--custom--form--padding: 14px 7px;
+}

--- a/packages/theme-compatibility/src/quadrat/editor.scss
+++ b/packages/theme-compatibility/src/quadrat/editor.scss
@@ -16,3 +16,17 @@
 	font-size: var(--wp--preset--font-size--normal);
 	line-height: var(--wp--custom--body--typography--line-height);
 }
+
+.block-editor-block-list__insertion-point-indicator,
+.block-editor-default-block-appender .block-editor-inserter__toggle.components-button.has-icon,
+.block-editor-default-block-appender .block-editor-inserter__toggle.components-button.has-icon:hover,
+.block-editor-block-list__insertion-point-inserter .block-editor-inserter__toggle.components-button.has-icon,
+.block-editor-block-list__insertion-point-inserter .block-editor-inserter__toggle.components-button.has-icon:hover,
+{
+	background-color: var(--color-neutral-5);
+	color: var(--color-neutral-100);
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block:not([contenteditable]):focus::after {
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--color-neutral-5);
+}

--- a/packages/theme-compatibility/src/quadrat/editor.scss
+++ b/packages/theme-compatibility/src/quadrat/editor.scss
@@ -1,0 +1,18 @@
+@import 'base';
+
+.block-editor-writing-flow {
+	.crowdsignal-forms-text-input-block__wrapper, .crowdsignal-forms-text-question-block textarea {
+		color: var(--custom--placeholder--color);
+
+		&:focus {
+			color: var(--custom--placeholder--color);
+		}
+	}
+}
+
+.editor .iso-editor .block-editor-writing-flow {
+	color: var(--wp--custom--color--foreground);
+	font-family: var(--wp--preset--font-family--dm-sans);
+	font-size: var(--wp--preset--font-size--normal);
+	line-height: var(--wp--custom--body--typography--line-height);
+}

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -20,6 +20,8 @@ module.exports = {
 		'twentytwentytwo-editor': './src/twentytwentytwo/editor.scss',
 		'blockbase': './src/blockbase/base.scss',
 		'blockbase-editor': './src/blockbase/editor.scss',
+		'quadrat': './src/quadrat/base.scss',
+		'quadrat-editor': './src/quadrat/editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname, 'dist' ),


### PR DESCRIPTION
## Summary

This PR has the necessary adjustments added to the `theme-compatibility` package in order to support the `Quadrat` theme.

Depends On: D76192-code

Ref: c/9zxwdwaP-tr

## Test Instructions
* Open or create a new project and add some blocks
* On the Editor and on the Project Renderer, add the following param to the URL: `?theme=quadrat`
* You should see both pages using the new theme style