### PR TITLE
Switch sidebar tabs depending on if any blocks are currently selected

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -29,13 +29,16 @@ const DocumentSettings = ( { project } ) => {
 		STORE_NAME
 	);
 
-	const canPublish = useSelect( ( select ) =>
-		select( STORE_NAME ).isEditorContentPublishable()
-	);
+	const [ canPublish, selectedBlockClientId ] = useSelect( ( select ) => [
+		select( STORE_NAME ).isEditorContentPublishable(),
+		select( 'core/block-editor' ).getSelectedBlockClientId(),
+	] );
 
 	useEffect( () => {
-		openGeneralSidebar( 'edit-post/document' );
-	}, [] );
+		openGeneralSidebar(
+			!! selectedBlockClientId ? 'edit-post/block' : 'edit-post/document'
+		);
+	}, [ selectedBlockClientId ] );
 
 	const updateProjectVisibility = ( event ) => {
 		if ( event.target.value === 'private' ) {


### PR DESCRIPTION
This patch adds a feature where the sidebar will toggle between `Document` and `Block` tabs depending on if any blocks are currently selected.

Solves c/1jlmCWMA-tr.

# Testing

Go to the editor and verify the sidebar works as described.