### PR TITLE
Refactor editor settings to not use iso.blocks.disallowBlocks property

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -4,14 +4,13 @@
 import { useDispatch } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { map, noop } from 'lodash';
+import { cloneDeep, filter, noop, tap } from 'lodash';
 import IsolatedBlockEditor from 'isolated-block-editor'; // eslint-disable-line import/default
 import { Global } from '@emotion/core';
 
 /**
  * Internal dependencies
  */
-import * as crowdsignalBlocks from '@crowdsignal/block-editor';
 import HeaderMeta from '../header-meta';
 import NewProjectWizard from '../new-project-wizard';
 import ProjectNavigation from '../project-navigation';
@@ -57,23 +56,18 @@ const Editor = ( { project, theme = 'leven' } ) => {
 		setShowWizard( false );
 	};
 
-	const settings = useMemo(
-		() => ( {
-			...editorSettings,
-			iso: {
-				...editorSettings.iso,
-				blocks: {
-					...editorSettings.iso.blocks,
-					disallowBlocks: [
-						...( confirmationPage
-							? map( crowdsignalBlocks, 'name' )
-							: [] ),
-					],
-				},
-			},
-		} ),
-		[ confirmationPage ]
-	);
+	const settings = useMemo( () => {
+		if ( ! confirmationPage ) {
+			return editorSettings;
+		}
+
+		return tap( cloneDeep( editorSettings ), ( { iso } ) => {
+			iso.blocks.allowBlocks = filter(
+				iso.blocks.allowBlocks,
+				( block ) => ! block.match( /^crowdsignal\-forms\/.+/ )
+			);
+		} );
+	}, [ confirmationPage ] );
 
 	return (
 		<EditorLayout className="editor">


### PR DESCRIPTION
This fix replaces `iso.blocks.disallowBlocks` with `iso.block.allowBlocks` in `editor/editor.js` to hide our question blocks on the confirmation page.  
It seems that using `disallowBlocks` at all causes that to take precedence over `allowBlocks` and unwanted blocks appear again. With this fix applied, that should no longer be the case.

# Testing

Apply the patch and verify only the blocks on our allow list are displayed in the editor inserter.
No Crowdsignal question or submit button blocks should be available when on the confirmation page.