### PR TITLE
Fix cover block preview

### DIFF
--- a/apps/dashboard/src/components/editor/styles/editor.js
+++ b/apps/dashboard/src/components/editor/styles/editor.js
@@ -13,6 +13,13 @@ export const editorGlobalStyles = css`
 	html.interface-interface-skeleton__html-container {
 		width: 100% !important;
 	}
+
+	html.block-editor-block-preview__content-iframe
+		.is-root-container.block-editor-block-list__layout {
+		// Value chosen to match
+		// https://github.com/WordPress/gutenberg/blob/200a5d700e19d9f5978877cd299d582b1480a8d2/packages/block-editor/src/components/block-preview/auto.js#L20
+		max-height: 2000px;
+	}
 `;
 
 export const EditorLayout = styled.div`


### PR DESCRIPTION
This patch fixes page and template previews for full size cover blocks.  
The cover block uses `min-height: 100vh` property to resize itself which works in the browser but was causing issues in the previews where `vh` is based on the current iframe size which is based on the current iframe content - which leads to a race condition and infinite resizing of the iframe.

By putting a cap on the preview height we can prevent it. I choose the same number as used internally by `<BlockPreview />` - unfortunately their fix doesn't quite work in this case.

Note: Because of this, the preview doesn't quite match the editor content in this case but it should be close enough for what it needs to be.

# Testing

- Add a cover block and upload an image. (Or start by adding an image block and converting it to a cover block).
- Select 'Toggle Full Height' from the toolbar and observe the page preview.
- The block should resize just once and stay there compared to continuous enlargement that happened previously.