### PR TITLE
README files: Add development instructions, fix some typo and an URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # Crowdsignal UI
 
 This repository contains the front-end code for Crowdsignal.com
+
+
+## Development
+
+### Install dependencies
+
+```sh
+yarn
+```
+
+### Start development
+
+```sh
+yarn start
+```
+
+### Run storybook
+
+To leverage Storybook running on `http://localhost:8000` run
+
+```sh
+yarn storybook
+```
+
+### Generate release build
+
+```sh
+yarn build
+```
+
+

--- a/apps/feedback-widget/README.md
+++ b/apps/feedback-widget/README.md
@@ -7,7 +7,7 @@ Embed the feedback widget on your page and collect feedback with Crowdsignal.com
 Add the following JS snippet to enable the feedback widget to your page. Make sure to replace `surveyId` with a valid feedback survey ID.
 
 ```html
-<script src="https://app.crowdsignal.com/js/feedback-1.0.0.js"></script>
+<script src="https://app.crowdsignal.com/js/dashboard-feedback.js"></script>
 <script>
     crowdsignal.FeedbackWidget( surveyId );
 </script>

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -38,7 +38,7 @@ test/
 # Local package.json
 package.json
 
-# Make sure to include a radme file describing the package
+# Make sure to include a README.md file describing the package
 README.md
 
 # Any build settings specific to the package/app

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -57,3 +57,4 @@ yarn workspace @crowdsignal/feedback-widget run build
 ## Dev dependencies
 
 All development dependencies should be added to the root `package.json`. Thanks to `yarn` workspaces they will be available in any package inside the repo.
+


### PR DESCRIPTION
* Introduced development instructions to main README file
* Addresses a typo on `docs/repository-structure.md`
* Updates feedback widget's URL in its readme.