### PR TITLE
Create a Twenty Twenty Two dark theme

### DIFF
--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -45,6 +45,10 @@
 			margin-top: 0;
 			margin-bottom: 0;
 		}
+
+		&:not(:first-child) {
+			margin-left: var(--wp--style--block-gap, 2em);
+		}
 	}
 
 	.crowdsignal-forms-question-wrapper {

--- a/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
@@ -1,0 +1,22 @@
+@import '../twentytwentytwo/base';
+
+body {
+	--wp--preset--color--foreground: #FFF;
+	--wp--preset--color--background: #000;
+	--wp--custom--input--focus--color: #b4b4b4
+}
+
+.crowdsignal-forms-text-input-block, .crowdsignal-forms-text-question-block {
+	input, textarea {
+		color: var(--wp--preset--color--foreground);
+		background-color: transparent;
+	}
+}
+
+.crowdsignal-forms-button__button {
+	color: var(--wp--preset--color--foreground);
+}
+
+.crowdsignal-forms-question-wrapper {
+	border-color: var(--wp--preset--color--foreground);
+}

--- a/packages/theme-compatibility/src/twentytwentytwo-dark/editor.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo-dark/editor.scss
@@ -1,0 +1,2 @@
+@import 'base';
+@import '../twentytwentytwo/editor';

--- a/packages/theme-compatibility/src/twentytwentytwo/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/base.scss
@@ -3,16 +3,12 @@ html {
 }
 
 body {
-	--wp--preset--color--foreground: #FFF;
-	--wp--preset--color--background: #000;
-	--wp--custom--input--focus--color: #b4b4b4
+	--wp--custom--input--focus--color: #010101;
 }
 
 .crowdsignal-forms-text-input-block, .crowdsignal-forms-text-question-block {
 	input, textarea {
-		color: var(--wp--preset--color--foreground);
-		background-color: transparent;
-		border-width: 2px;
+		border-width: 1px;
 		border-style: solid;
 		outline: none;
 
@@ -22,12 +18,6 @@ body {
 	}
 }
 
-.crowdsignal-forms-button__button {
-	color: var(--wp--preset--color--foreground);
-}
-
 .crowdsignal-forms-question-wrapper {
 	border-radius: 0;
-	border-width: 2px;
-	border-color: var(--wp--preset--color--foreground);
 }

--- a/packages/theme-compatibility/src/twentytwentytwo/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/base.scss
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-	--wp--preset--color--foreground: #DCDCDE;
+	--wp--preset--color--foreground: #FFF;
 	--wp--preset--color--background: #000;
 	--wp--custom--input--focus--color: #b4b4b4
 }

--- a/packages/theme-compatibility/src/twentytwentytwo/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/base.scss
@@ -1,3 +1,33 @@
 html {
 	font-size: 16px;
 }
+
+body {
+	--wp--preset--color--foreground: #DCDCDE;
+	--wp--preset--color--background: #000;
+	--wp--custom--input--focus--color: #b4b4b4
+}
+
+.crowdsignal-forms-text-input-block, .crowdsignal-forms-text-question-block {
+	input, textarea {
+		color: var(--wp--preset--color--foreground);
+		background-color: transparent;
+		border-width: 2px;
+		border-style: solid;
+		outline: none;
+
+		&:focus {
+			border-color: var(--wp--custom--input--focus--color);
+		}
+	}
+}
+
+.crowdsignal-forms-button__button {
+	color: var(--wp--preset--color--foreground);
+}
+
+.crowdsignal-forms-question-wrapper {
+	border-radius: 0;
+	border-width: 2px;
+	border-color: var(--wp--preset--color--foreground);
+}

--- a/packages/theme-compatibility/src/twentytwentytwo/editor.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/editor.scss
@@ -5,3 +5,13 @@
 	font-size: var(--wp--preset--font-size--medium);
 	line-height: var(--wp--custom--typography--line-height--normal);
 }
+
+// This is necessary to fix block alignment on previews
+.block-editor-block-preview__content-iframe {
+	body > .is-root-container > .wp-block-cover {
+		// The theme is using !important on a style definition.
+		// To override it we also need !important
+		margin-left: auto !important;
+		margin-right: auto !important;
+	}
+}

--- a/packages/theme-compatibility/webpack.config.js
+++ b/packages/theme-compatibility/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = {
 		'twentynineteen-editor': './src/twentynineteen/editor.scss',
 		'twentytwentytwo': './src/twentytwentytwo/base.scss',
 		'twentytwentytwo-editor': './src/twentytwentytwo/editor.scss',
+		'twentytwentytwo-dark': './src/twentytwentytwo-dark/base.scss',
+		'twentytwentytwo-dark-editor': './src/twentytwentytwo-dark/editor.scss',
 		'blockbase': './src/blockbase/base.scss',
 		'blockbase-editor': './src/blockbase/editor.scss',
 		'quadrat': './src/quadrat/base.scss',


### PR DESCRIPTION
## Summary

We want a `Twenty Twenty Two` dark version.

Depends on: D76911-code

## Test Instructions
* Open or create a new project
* Add the theme parameter to the URL: `?theme=twentytwentytwo-dark`
* You should see the theme using a dark background and white text color

## Screenshots

![image](https://user-images.githubusercontent.com/7811225/158671652-3ef87291-9d7d-4e3c-a4c4-e2bb01d714bd.png)