### PR TITLE
Remove clientId internal DB

### DIFF
--- a/apps/dashboard/src/data/projects/resolvers.js
+++ b/apps/dashboard/src/data/projects/resolvers.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { fetchProject } from '@crowdsignal/rest-api';
 import { dispatchAsync } from '../actions';
 import { loadProject, loadProjectError, updateProject } from './actions';
+import { resetDraftContentClientIds } from './util';
 
 function* getProject( projectId ) {
 	if ( ! projectId ) {
@@ -19,8 +20,8 @@ function* getProject( projectId ) {
 
 	try {
 		const response = yield dispatchAsync( fetchProject, [ projectId ] );
-
-		yield updateProject( projectId, response.data );
+		const data = resetDraftContentClientIds( response.data );
+		yield updateProject( projectId, data );
 	} catch ( error ) {
 		yield loadProjectError( projectId, __( 'Failed to load project.' ) );
 	}

--- a/apps/dashboard/src/data/projects/util.js
+++ b/apps/dashboard/src/data/projects/util.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import { v4 as uuid } from 'uuid';
+
+const resetClientIds = ( collection ) => {
+	return map( collection, ( block ) => {
+		return {
+			...block,
+			clientId: uuid(),
+			innerBlocks: resetClientIds( block.innerBlocks ),
+		};
+	} );
+};
+
+export const resetPagesClientIds = ( pages ) =>
+	map( pages, ( page ) => resetClientIds( page ) );
+
+export const resetDraftContentClientIds = ( project ) => {
+	if ( project.publicContent && project.draftContent.pages ) {
+		// eslint-disable-next-line
+		console.log( 'resetting IDs' );
+		project.draftContent.pages = resetPagesClientIds(
+			project.draftContent.pages
+		);
+	}
+	return project;
+};

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -73,6 +73,7 @@ const EditTextInput = ( props ) => {
 					className="crowdsignal-forms-text-input-block__wrapper"
 				/>
 			</ResizableBox>
+			<pre>{ JSON.stringify( props, 0, 2 ) }</pre>
 		</FormInputWrapper>
 	);
 };


### PR DESCRIPTION
This PR is a PoC trying to figure out the need for an internal storage of `clientId`/`attributes.clientId` pairs.

## The problem
When blocks are created, `useClientId` hook will check if the block has an `attribute.clientId`. If it does, we store it on a runtime dictionary object: `crowdsignalClientIds[ block.attributes.clientId ] = block.clientId`.

If we have NOT previously stored such `attribute.clientId`, we assign it a new one. This causes the same block on draft and public content to hold different `attributes.clientId` values and, in turn, confuse the backend when one is replaced by the other and published again (question is not properly identified so a new one is created and the old one left orphan).

## The PoC (not sure if it's a solution)
~~Removing this storage and check (see the diff on the files) will make sure that if a block comes in with a `attributes.clientId` value set, just retain it and move on.~~

For lack of more insightful knowledge of the inner works of the editor, I created this PR to try it out. It also includes a printout of the text-input block props so to visually check if the `attributes.clientId` value has changed between publish/updates.

After a call with @ice9js we figured we might get a hold on the `attributes.clientId` while resetting the (unused for us) block's `clientId`.

This PR includes a new function to process only the draft content pages (if there's public content present) and reset the block's `clientId` prop. As this happens before any render, it shouldn't be a problem for the editor (?).
We also discussed the possibility of completely removing the prop, but after a quick test, removing the `clientId` prop from the blocks results in an empty editor after attempting a restore operation.

Right now the effect of the `clientId` reset can be seen by comparing the prop on publicContent and draftContent (the prop matches). But, upon restore, the problem persists as the content is moved to `editor.pages` state.

## Test instructions
Checkout and create a new project. Add a Text Input Form block. See that all its props are printed at the bottom of the block. Take note of the `attributes.clientId`. Publish the project. See that `attributes.clientId` value has NOT changed.
Now make a change and let it save the draft. Reload the page so you get the notification about "unpublished changes".
Continue to check the `attributes.clientId` value. Restoring the content should work as expected and, still, `attributes.clientId` should remain the same
