### PR TITLE
Add alignment controls to Submit Button

### DIFF
--- a/packages/block-editor/src/submit-button/attributes.js
+++ b/packages/block-editor/src/submit-button/attributes.js
@@ -18,4 +18,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/submit-button/edit.js
+++ b/packages/block-editor/src/submit-button/edit.js
@@ -3,13 +3,14 @@
  */
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@crowdsignal/blocks';
 import Sidebar from './sidebar';
-import classnames from 'classnames';
+import Toolbar from './toolbar';
 
 const SubmitButton = ( props ) => {
 	const { attributes, className, onReplace, setAttributes } = props;
@@ -18,13 +19,17 @@ const SubmitButton = ( props ) => {
 
 	const classes = classnames(
 		className,
-		'crowdsignal-forms-submit-button-block'
+		'crowdsignal-forms-submit-button-block',
+		{
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
+		}
 	);
 
 	return (
 		<>
+			<Toolbar { ...props } />
 			<Sidebar { ...props } />
-
+			<span>{ attributes.alignment }</span>
 			<Button
 				attributes={ attributes }
 				as={ RichText }

--- a/packages/block-editor/src/submit-button/edit.js
+++ b/packages/block-editor/src/submit-button/edit.js
@@ -29,7 +29,7 @@ const SubmitButton = ( props ) => {
 		<>
 			<Toolbar { ...props } />
 			<Sidebar { ...props } />
-			<span>{ attributes.alignment }</span>
+
 			<Button
 				attributes={ attributes }
 				as={ RichText }

--- a/packages/block-editor/src/submit-button/index.js
+++ b/packages/block-editor/src/submit-button/index.js
@@ -26,6 +26,9 @@ const settings = {
 	icon: <SubmitButtonIcon />,
 	edit: EditSubmitButton,
 	attributes,
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
 	example: {
 		attributes: {
 			label: __( 'Submit', 'block-editor' ),

--- a/packages/block-editor/src/submit-button/toolbar.js
+++ b/packages/block-editor/src/submit-button/toolbar.js
@@ -1,0 +1,17 @@
+import { BlockControls, JustifyContentControl } from '@wordpress/block-editor';
+
+const SubmitButtonToolbar = ( { attributes, setAttributes } ) => {
+	return (
+		<BlockControls group="block">
+			<JustifyContentControl
+				value={ attributes.justification }
+				onChange={ ( value ) => {
+					setAttributes( { justification: value } );
+				} }
+				allowedControls={ [ 'left', 'center', 'right' ] }
+			/>
+		</BlockControls>
+	);
+};
+
+export default SubmitButtonToolbar;

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -10,8 +10,16 @@ import classnames from 'classnames';
 import { useColorStyles } from '@crowdsignal/styles';
 
 const StyledButtonWrapper = styled.div`
-	display: block;
+	display: flex;
 	margin-bottom: 16px;
+
+	&.justify-center {
+		justify-content: center;
+	}
+
+	&.justify-right {
+		justify-content: flex-end;
+	}
 `;
 
 const StyledButton = styled.button`

--- a/packages/blocks/src/submit-button/index.js
+++ b/packages/blocks/src/submit-button/index.js
@@ -37,6 +37,8 @@ const SubmitButton = ( { attributes, className } ) => {
 		'crowdsignal-forms-submit-button-block',
 		{
 			'is-loading': isSubmitting,
+			[ `align${ attributes.align }` ]: attributes.align,
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -22,7 +22,7 @@
 
 #crowdsignal-dashboard .block-editor-block-list__layout.is-root-container,
 .block-editor-block-preview__content-iframe .block-editor-block-list__layout.is-root-container {
-	.wp-block {
+	> .wp-block, [data-align] {
 		margin-left: auto;
 		margin-right: auto;
 	}
@@ -32,11 +32,11 @@
 		max-width: 720px;
 	}
 
-	.wp-block[data-align='wide'] {
+	[data-align='wide'] {
 		max-width: 1080px;
 	}
 
-	.wp-block[data-align='full'] {
+	[data-align='full'] {
 		max-width: none;
 	}
 


### PR DESCRIPTION
## Summary

As per the title, we want to allow changing the Submit block position on the screen.

Ref: c/K1z3iQJN-tr

![image](https://user-images.githubusercontent.com/7811225/158658487-3798821e-e2df-426a-bb36-88473af0fa21.png)

![image](https://user-images.githubusercontent.com/7811225/158658590-669f0dc4-5194-45ec-a6c0-608629cfd2b4.png)


## Test Instructions
* On a project, select a Submit Button and use the alignment controls to change the block position