### PR TITLE
Update MC Answer button to use outline style

### DIFF
--- a/packages/block-editor/src/multiple-choice-answer/edit-button.js
+++ b/packages/block-editor/src/multiple-choice-answer/edit-button.js
@@ -40,6 +40,7 @@ const EditButtonAnswer = ( {
 			style={ {
 				width,
 			} }
+			outline
 		>
 			<ButtonContent>
 				{ multipleChoice && <FormCheckbox type="checkbox" /> }

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -40,14 +40,18 @@ const Button = ( {
 	attributes,
 	children,
 	className,
+	outline,
 	style = {},
 	...props
 } ) => (
 	<StyledButtonWrapper
 		className={ classnames(
-			'crowdsignal-forms-button',
 			className,
-			'wp-block-button'
+			'crowdsignal-forms-button',
+			'wp-block-button',
+			{
+				'is-style-outline': outline,
+			}
 		) }
 	>
 		<StyledButton

--- a/packages/blocks/src/multiple-choice-answer/button.js
+++ b/packages/blocks/src/multiple-choice-answer/button.js
@@ -39,7 +39,7 @@ const ButtonAnswer = ( {
 			style={ {
 				width,
 			} }
-			outline
+			outline={ ! inputProps.checked }
 		>
 			<ButtonContent>
 				<FormCheckbox { ...inputProps } />

--- a/packages/blocks/src/multiple-choice-answer/button.js
+++ b/packages/blocks/src/multiple-choice-answer/button.js
@@ -39,6 +39,7 @@ const ButtonAnswer = ( {
 			style={ {
 				width,
 			} }
+			outline
 		>
 			<ButtonContent>
 				<FormCheckbox { ...inputProps } />

--- a/packages/theme-compatibility/src/twentynineteen/base.scss
+++ b/packages/theme-compatibility/src/twentynineteen/base.scss
@@ -1,3 +1,5 @@
+@import 'buttons';
+
 html {
 	font-size: 22px;
 }

--- a/packages/theme-compatibility/src/twentynineteen/buttons.scss
+++ b/packages/theme-compatibility/src/twentynineteen/buttons.scss
@@ -1,0 +1,70 @@
+/* Buttons styles */
+.crowdsignal-forms-form__content .wp-block-button .wp-block-button__link {
+	transition: background 150ms ease-in-out;
+	border-width: 2px;
+	border-style: solid;
+	font-size: 0.88889em;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	line-height: 1.2;
+	box-sizing: border-box;
+	font-weight: bold;
+	text-decoration: none;
+	padding: 0.76rem 1rem;
+	outline: none;
+}
+
+.crowdsignal-forms-form__content .wp-block-button .wp-block-button__link:not(.has-background) {
+	background-color: #0073aa;
+	border-color: currentColor;
+}
+
+.crowdsignal-forms-form__content .wp-block-button .wp-block-button__link:not(.has-text-color) {
+	color: white;
+}
+
+.crowdsignal-forms-form__content .wp-block-button .wp-block-button__link:hover {
+	color: white;
+	background: #111;
+	cursor: pointer;
+}
+
+.crowdsignal-forms-form__content .wp-block-button .wp-block-button__link:focus {
+	color: white;
+	background: #111;
+	outline: thin dotted;
+	outline-offset: -4px;
+}
+
+.crowdsignal-forms-form__content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+	border-radius: 5px;
+}
+
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link,
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:active {
+	transition: all 150ms ease-in-out;
+	border-width: 2px;
+	border-style: solid;
+}
+
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+	background: transparent;
+}
+
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+	color: #0073aa;
+	border-color: currentColor;
+}
+
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+	color: white;
+	border-color: #111;
+}
+
+.crowdsignal-forms-form__content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+	color: #111;
+}


### PR DESCRIPTION
## Summary

Currently, all buttons are treated equally. 

The button styling of the answer options needs to differ from the Submit button. 
 Otherwise, the main CTA is not obvious enough.  

Ref: c/vRbB6nCJ-tr

## Test Instructions

* Open or create a project and add an MC Question block
* You should see the answers buttons using an outline style

## Screenshots

![image](https://user-images.githubusercontent.com/7811225/158818661-eaefebc9-6987-49f8-b4e2-08fe7ccde40a.png)
