### PR TITLE
Fix themes on page previews

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -111,7 +111,7 @@ const Editor = ( { project } ) => {
 				/>
 			) }
 
-			<PageNavigation />
+			<PageNavigation key={ `nav_${ editorTheme }` } />
 			<EditorWrapper
 				as={ IsolatedBlockEditor }
 				key={ editorId }

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -37,7 +37,7 @@ export const PagePreviewButton = styled.button`
 
 export const PagePreviewFrame = styled.div`
 	background-color: var( --color-surface );
-	background-color: var( --color-page-background );
+	background-color: var( --wp--custom--color--background );
 	border: 1px solid var( --color-border );
 	border-radius: 2px;
 	box-sizing: border-box;

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -8,7 +8,7 @@
 	--crowdsignal-forms-question-background-color: #fff;
 	--crowdsignal-forms-submit-button-background-color: #ff302c;
 	--color-text: #444;
-	--color-page-background: #f7f7f6;
+	--wp--custom--color--background: #f7f7f6;
 }
 
 body {


### PR DESCRIPTION
This is a partial fix for themes not updating on page previews. This patch will force the page navigation column to re-render if the current theme changes.  
This fixes the issue for themes but unfortunately other issues where certain block styles might not load correctly inside the preview. It's also not an ideal experience as it takes a few seconds for all previews to re-render from scratch so it's definitely noticeable.

The core issue is related to Gutenberg itself not allowing the preview styles to be updated once the preview is rendered ([link](https://github.com/WordPress/gutenberg/blob/f2161e246b9fdd9a2a56e7552b0b28050f1a5302/packages/block-editor/src/components/iframe/index.js#L230)).  
A proper fix would involve creating our own Preview component which does allow for this which would allow us to address remaining edge cases as well as provide a much smoother experience.

# Testing

Try changing themes using the theme modal in the editor. Page previews should be updated with the theme styles.