### PR TITLE
Update themes list to include 2022 dark

### DIFF
--- a/apps/dashboard/src/util/theme/themes.js
+++ b/apps/dashboard/src/util/theme/themes.js
@@ -20,7 +20,7 @@ export const themes = [
 		slug: 'twentytwentytwo',
 		name: 'Twenty Twenty-Two',
 		image:
-			'https://i0.wp.com/s2.wp.com/wp-content/themes/pub/twentytwentytwo/screenshot.png',
+			'https://app.crowdsignal.com/themes/twentytwentytwo/screenshot.png',
 	},
 	{
 		slug: 'blockbase',
@@ -33,6 +33,12 @@ export const themes = [
 		name: 'Quadrat',
 		image:
 			'https://i0.wp.com/s2.wp.com/wp-content/themes/pub/quadrat/screenshot.png',
+	},
+	{
+		slug: 'twentytwentytwo-dark',
+		name: 'Twenty Twenty-Two Dark',
+		image:
+			'https://i0.wp.com/s2.wp.com/wp-content/themes/pub/twentytwentytwo/screenshot.png',
 	},
 ];
 


### PR DESCRIPTION
## Summary

On #185 we created a dark version of the `Twenty Twenty Two` theme.
This PR is necessary to update the `Twenty Twenty Two` light preview image and list the dark version as one of the possible themes.

Depends on: D77170-code

## Test Instructions
* Open o create a Project
* Click the Change Theme button on the right sidebar
* You should see and be able to choose between the two 2022 versions

## Screenshots
![image](https://user-images.githubusercontent.com/7811225/159285235-97459713-64dd-48d5-a362-fe8d2692bdd4.png)


