### PR TITLE
Allow page navigation to scroll when it extends past the window

### DIFF
--- a/apps/dashboard/src/components/editor/page-navigation.js
+++ b/apps/dashboard/src/components/editor/page-navigation.js
@@ -21,6 +21,7 @@ import { STORE_NAME } from '../../data';
  */
 import {
 	PageNavigationAddButton,
+	PageNavigationContent,
 	PageNavigationHeader,
 	PageNavigationSectionHeader,
 	PageNavigationWrapper,
@@ -90,71 +91,88 @@ const PageNavigation = () => {
 				</Transition>
 			</PageNavigationHeader>
 
-			<DragDropContext onDragEnd={ handleMovePage }>
-				<Droppable droppableId="crowdsignal/page-navigation">
-					{ ( { droppableProps, innerRef, placeholder } ) => (
-						<div ref={ innerRef } { ...droppableProps }>
-							{ map( slice( pages, 0, -1 ), ( page, index ) => (
-								<Draggable
-									key={ `page-${ index }` }
-									disableInteractiveElementBlocking={ true }
-									draggableId={ `page-${ index }` }
-									index={ index }
-									isDragDisabled={ ! expanded }
-								>
-									{ ( provided, snapshot ) => (
-										<PagePreview
-											ref={ provided.innerRef }
-											draggableProps={
-												provided.draggableProps
+			<PageNavigationContent>
+				<DragDropContext onDragEnd={ handleMovePage }>
+					<Droppable droppableId="crowdsignal/page-navigation">
+						{ ( { droppableProps, innerRef, placeholder } ) => (
+							<div ref={ innerRef } { ...droppableProps }>
+								{ map(
+									slice( pages, 0, -1 ),
+									( page, index ) => (
+										<Draggable
+											key={ `page-${ index }` }
+											disableInteractiveElementBlocking={
+												true
 											}
-											dragHandleProps={
-												provided.dragHandleProps
-											}
-											disablePageActions={
-												pages.length <= 2
-											}
-											isActive={ index === currentPage }
-											isExpanded={ expanded }
-											isDragging={ snapshot.isDragging }
-											page={ page }
-											pageIndex={ index }
-											onSelect={ handleSelectPage }
-											onDelete={ deleteEditorPage }
-											onDuplicate={ duplicateEditorPage }
-										/>
-									) }
-								</Draggable>
-							) ) }
+											draggableId={ `page-${ index }` }
+											index={ index }
+											isDragDisabled={ ! expanded }
+										>
+											{ ( provided, snapshot ) => (
+												<PagePreview
+													ref={ provided.innerRef }
+													draggableProps={
+														provided.draggableProps
+													}
+													dragHandleProps={
+														provided.dragHandleProps
+													}
+													disablePageActions={
+														pages.length <= 2
+													}
+													isActive={
+														index === currentPage
+													}
+													isExpanded={ expanded }
+													isDragging={
+														snapshot.isDragging
+													}
+													page={ page }
+													pageIndex={ index }
+													onSelect={
+														handleSelectPage
+													}
+													onDelete={
+														deleteEditorPage
+													}
+													onDuplicate={
+														duplicateEditorPage
+													}
+												/>
+											) }
+										</Draggable>
+									)
+								) }
 
-							{ placeholder }
-						</div>
+								{ placeholder }
+							</div>
+						) }
+					</Droppable>
+				</DragDropContext>
+
+				<PageNavigationAddButton onClick={ handleAddPage }>
+					<Icon icon={ plus } />
+				</PageNavigationAddButton>
+
+				<Transition in={ expanded } timeout={ 300 }>
+					{ ( state ) => (
+						<PageNavigationSectionHeader className={ state }>
+							{ __( 'Confirmation', 'dashboard' ) }
+						</PageNavigationSectionHeader>
 					) }
-				</Droppable>
-			</DragDropContext>
+				</Transition>
 
-			<PageNavigationAddButton onClick={ handleAddPage }>
-				<Icon icon={ plus } />
-			</PageNavigationAddButton>
-
-			<Transition in={ expanded } timeout={ 300 }>
-				{ ( state ) => (
-					<PageNavigationSectionHeader className={ state }>
-						{ __( 'Confirmation', 'dashboard' ) }
-					</PageNavigationSectionHeader>
-				) }
-			</Transition>
-
-			<PagePreview
-				disablePageActions={ true }
-				isActive={ currentPage === pages.length - 1 }
-				isExpanded={ expanded }
-				label="CP"
-				page={ pages[ pages.length - 1 ] }
-				pageIndex={ pages.length - 1 }
-				onDelete={ noop }
-				onSelect={ handleSelectPage }
-			/>
+				<PagePreview
+					disablePageActions={ true }
+					isActive={ currentPage === pages.length - 1 }
+					isExpanded={ expanded }
+					label={ pages.length }
+					page={ pages[ pages.length - 1 ] }
+					pageIndex={ pages.length - 1 }
+					onDelete={ noop }
+					onSelect={ handleSelectPage }
+				/>
+			</PageNavigationContent>
 		</PageNavigationWrapper>
 	);
 };

--- a/apps/dashboard/src/components/editor/styles/page-navigation.js
+++ b/apps/dashboard/src/components/editor/styles/page-navigation.js
@@ -34,7 +34,6 @@ export const PageNavigationHeader = styled.button`
 	cursor: pointer;
 	display: flex;
 	font-size: 11px;
-	margin-bottom: 8px;
 	padding: 0 16px 0 32px;
 	height: 61px;
 	text-transform: uppercase;
@@ -56,6 +55,17 @@ export const PageNavigationHeader = styled.button`
 	}
 `;
 
+export const PageNavigationContent = styled.div`
+	box-sizing: border-box;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	overflow-x: hidden;
+	overflow-y: auto;
+	padding-top: 8px;
+	width: 100%;
+`;
+
 export const PageNavigationAddButton = styled.button`
 	align-items: center;
 	background-color: transparent;
@@ -65,9 +75,9 @@ export const PageNavigationAddButton = styled.button`
 	color: var( --color-text );
 	cursor: pointer;
 	display: flex;
-	height: 40px;
 	justify-content: center;
 	margin: 16px 24px;
+	min-height: 40px;
 	transition: margin 0.3s, width 0.3s;
 	width: 40px;
 
@@ -81,8 +91,8 @@ export const PageNavigationSectionHeader = styled.span`
 	color: var( --color-text-subtle );
 	display: flex;
 	font-size: 11px;
-	height: 0;
 	margin-top: 8px;
+	min-height: 20px;
 	overflow: hidden;
 	opacity: 0;
 	padding: 0 16px 0 64px;


### PR DESCRIPTION
This patch addresses some of the issues related to the editor's page navigation column:

- When the previews exceed window height, the column should become scrollable.
- Fixes an issue when certain elements of the column resize or collapse vertically.
- Only the previews part of the column is scrollable, the header stays in place.
- Confirmation page now features a regular page number instead of `CP`.

Solves c/5ZNsBrIL-tr and c/PxdeY3RU-tr.

# Testing

Open the editor and verify the page navigation column works as described on smaller screen sizes.