### PR TITLE
Open the inserter when creating a new project

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -26,7 +26,9 @@ import { ToolbarButton } from './styles/button';
 import { getTheme } from '../../util/theme/themes';
 
 const DocumentSettings = ( { project, onChangeThemeClick } ) => {
-	const { openGeneralSidebar } = useDispatch( 'isolated/editor' );
+	const { openGeneralSidebar, setIsInserterOpened } = useDispatch(
+		'isolated/editor'
+	);
 	const { saveAndUpdateProject, saveEditorChanges } = useDispatch(
 		STORE_NAME
 	);
@@ -40,6 +42,14 @@ const DocumentSettings = ( { project, onChangeThemeClick } ) => {
 		select( STORE_NAME ).getEditorTheme(),
 		select( 'core/block-editor' ).getSelectedBlockClientId(),
 	] );
+
+	useEffect( () => {
+		if ( project.id ) {
+			return;
+		}
+
+		setIsInserterOpened( true );
+	}, [] );
 
 	useEffect( () => {
 		openGeneralSidebar(


### PR DESCRIPTION
This patch will force the inserter panel open when the editor is first opened for a new project.

Solves c/J5XKzxfN-tr.

# Testing

Start a new project - the inserter should be open by default.
When opening an existing project, the inserter should remain closed.