### PR TITLE
Update Results tab to load the project

### DIFF
--- a/apps/dashboard/src/components/results/index.js
+++ b/apps/dashboard/src/components/results/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,6 +13,16 @@ import ProjectNavigation from '../project-navigation';
 import { STORE_NAME } from '../../data';
 
 const Results = ( { projectId } ) => {
+	const [ project, isLoading ] = useSelect(
+		( select ) => {
+			return [
+				select( STORE_NAME ).getProject( projectId ),
+				select( STORE_NAME ).isProjectLoading( projectId ),
+			];
+		},
+		[ projectId ]
+	);
+
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const updateProjectTitle = ( title ) =>
@@ -22,16 +32,20 @@ const Results = ( { projectId } ) => {
 		<div className="results">
 			<HeaderMeta title={ __( `Project Results`, 'dashboard' ) } />
 
-			<ProjectNavigation
-				activeTab={ ProjectNavigation.Tab.RESULTS }
-				projectId={ projectId }
-				onChangeTitle={ updateProjectTitle }
-			/>
+			{ project && ! isLoading && (
+				<>
+					<ProjectNavigation
+						activeTab={ ProjectNavigation.Tab.RESULTS }
+						projectId={ projectId }
+						onChangeTitle={ updateProjectTitle }
+					/>
 
-			<IFrame
-				src={ `/surveys/${ projectId }/report/overview` }
-				width="100%"
-			/>
+					<IFrame
+						src={ `/surveys/${ projectId }/report/overview` }
+						width="100%"
+					/>
+				</>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

When clicking the `Results` link on the Crowdsignal dashboard or opening the results URL directly (`/project/[project_id]/results`), the project title is shown as `Untitled Project`.

This is happening because the project information is loaded only when the `Editor` tab is accessed.
We need to make sure to also load the project from the Results tab.

Ref: c/9YeCJuUx-tr

## Test Instructions
* Open a project using the results URL directly: `/project/[project_id]/results`
* The project should be loaded with the Results tab active and the project title should be displayed correctly