### PR TITLE
Reset useClientID registry when restoring drafts

### DIFF
--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -7,6 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { useClientId } from '@crowdsignal/hooks';
 import { isPublic } from '@crowdsignal/project';
 import { STORE_NAME } from '../../data';
 import { NOTICE_UNPUBLISHED } from './notice';
@@ -93,7 +94,9 @@ export const useEditorContent = ( project ) => {
 
 		// Force IsolatedBlockEditor to reload
 		setEditorId( `${ editorId }*` );
+
 		setReady( false );
+		useClientId.resetRegistry();
 	};
 
 	const setProjectTemplate = ( projectTemplate ) => {

--- a/packages/hooks/src/use-client-id/index.js
+++ b/packages/hooks/src/use-client-id/index.js
@@ -9,7 +9,7 @@ import { v4 as uuid } from 'uuid';
  *
  * @type {Object}
  */
-const crowdsignalClientIds = {};
+let crowdsignalClientIds = {};
 
 const useClientId = ( { attributes, clientId: blockId, setAttributes } ) => {
 	useEffect( () => {
@@ -29,6 +29,10 @@ const useClientId = ( { attributes, clientId: blockId, setAttributes } ) => {
 
 		setAttributes( { clientId } );
 	}, [] );
+};
+
+useClientId.resetRegistry = () => {
+	crowdsignalClientIds = {};
 };
 
 export default useClientId;


### PR DESCRIPTION
This is an attempt to fix the issues with blocks' `attributes.clientId` being unnecessarily overwritten when switching to drafts for published projects.

The issue boils down to `block.clientId` being unreliable - when the content is loaded, the existing values are replaced with generated ones. It seems the same process takes place when you restore a draft (but interestingly not when you switch pages even though it's technically the same 🤷 ) so resetting the registry allows for `block.clientId` to change in those instances while retaining the same `attributes.clientId`.

Now, this does kind of work but like I said, it's a little inconsistent when it comes to switching pages and since I can't figure out why, we have to assume at some point it could fail.  
The permanent way to deal with this would be to limit `useClientId` to the scope of a single page - allowing attributes.clientId` to be duplicated across multiple pages which would also make `regenerateClientIds` in the editor state obsolete. The catch is this would require updates to the backend to deal with it - including managing existing records.

# Testing

- Create a project, add some questions, hit publish.
- Reload the page, `attributes.clientId` for the questions should stay the same.
- Make some more changes and hit save draft.
- Reload the page, `attributes.clientId` for the question should stay the same.
- Hit restore draft, `attributes.clientId` for the questions should stay the same.
- Switch between pages, `attributes.clientId` for the questions should stay the same.
- Try duplicating or copy&pasting a question from one page to another. The new copy should get a new `attributes.clientId`.