### PR TITLE
Add a back-to-dashboard button in the project wizard

### DIFF
--- a/apps/dashboard/src/components/new-project-wizard/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/index.js
@@ -22,7 +22,7 @@ import * as projectTemplates from './templates';
 /**
  * Style dependencies
  */
-import { ProjectWizardDialog } from './styles';
+import { BackButton, ProjectWizardDialog } from './styles';
 
 const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 	const editorTheme = useSelect( ( select ) =>
@@ -32,6 +32,10 @@ const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 	return (
 		<ModalWrapper>
 			<ProjectWizardDialog id="crowdsignal-new-project-wizard">
+				<BackButton href="/dashboard">
+					{ __( 'Back to dashboard', 'dashboard' ) }
+				</BackButton>
+
 				<div>
 					<ActiveTheme onChangeThemeClick={ onChangeThemeClick } />
 				</div>

--- a/apps/dashboard/src/components/new-project-wizard/styles/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/index.js
@@ -17,3 +17,19 @@ export const ProjectWizardDialog = styled( ModalDialog )`
 	flex-direction: row;
 	align-items: flex-end;
 `;
+
+export const BackButton = styled.a`
+	color: var( --color-text-subtle );
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica,
+		Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+	font-size: 14px;
+	padding: 16px;
+	position: absolute;
+	top: 10px;
+	right: 10px;
+	text-decoration: none;
+
+	&:hover {
+		color: var( --color-text-subtle );
+	}
+`;


### PR DESCRIPTION
This patch adds a 'back to dashboard' button in the new project wizard which will let you exit straight back to the dashboard.

![Screen Shot 2022-03-25 at 5 42 09 PM](https://user-images.githubusercontent.com/8056203/160164000-7c6733fe-58d1-4eca-b09f-6f30702dcd74.png)

# Testing

- Go to `/project`, the template modal should now feature the back to the dashboard button.
- Clicking the button should redirect back to `/dashboard`.