### PR TITLE
update/Get rid of more menu

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -61,6 +61,7 @@ export const editorSettings = {
 			navigation: true,
 			toc: false,
 		},
+		moreMenu: false,
 	},
 	editor: {
 		alignWide: true,


### PR DESCRIPTION
We had the "more" settings menu active (the 3 dot menu) but had nothing to go into it since we don't support the actions in the native menu.

Declaring a false value for that menu in the settings.js file hides the menu on the editor.

Testing instructions:

Apply and go to the project editor.  Confirm there's no 3 dot menu to the right of the settings gear icon.