### PR TITLE
update isActive rule

### DIFF
--- a/packages/block-editor/src/text-input/variations.js
+++ b/packages/block-editor/src/text-input/variations.js
@@ -29,7 +29,7 @@ export default [
 			__( 'e-mail', 'block-editor' ),
 		],
 		isActive: ( blockAttributes, variationAttributes ) =>
-			blockAttributes.title === variationAttributes.title,
+			blockAttributes.label === variationAttributes.label,
 	},
 
 	{
@@ -52,6 +52,6 @@ export default [
 			__( 'web address', 'block-editor' ),
 		],
 		isActive: ( blockAttributes, variationAttributes ) =>
-			blockAttributes.title === variationAttributes.title,
+			blockAttributes.label === variationAttributes.label,
 	},
 ];


### PR DESCRIPTION
Issue: when adding an email input form to a project that also has other text input form variations, all input form variations were transformed to email blocks.

This was a display issue as the blocks continue to function as intended, but the inspector shows the metadata for the email block.

Cause: The isActive callback was comparing the title attribute, which is not actually an attribute, so the function always evaluated to true.

Fix: Changed the comparison to an actual attribute (Label).

Testing:
Checkout this branch and load up the editor at crowdsignal.localhost:9000/project

Create a new project and add all 3 input blocks (text, email, url)

Check each block's properties in the sidebar to make sure they match the blocks.