### PR TITLE
Show confirmation when overriding public content

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -29,9 +29,7 @@ const DocumentSettings = ( { project, onChangeThemeClick } ) => {
 	const { openGeneralSidebar, setIsInserterOpened } = useDispatch(
 		'isolated/editor'
 	);
-	const { saveAndUpdateProject, saveEditorChanges } = useDispatch(
-		STORE_NAME
-	);
+	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const [
 		canPublish,
@@ -63,7 +61,7 @@ const DocumentSettings = ( { project, onChangeThemeClick } ) => {
 			return;
 		}
 
-		saveEditorChanges( { public: true } );
+		saveAndUpdateProject( project.id, { public: true } );
 	};
 
 	const visibility = isPublic( project )

--- a/apps/dashboard/src/components/editor/publish-button.js
+++ b/apps/dashboard/src/components/editor/publish-button.js
@@ -40,10 +40,6 @@ const PublishButton = ( {
 		isSaved &&
 		! isSaving;
 
-	const handleOnPublish = () => {
-		onPublish( ! isPublic( project ) );
-	};
-
 	if ( canRestoreDraft || isLatestVersion ) {
 		return null;
 	}
@@ -54,7 +50,7 @@ const PublishButton = ( {
 			className="is-crowdsignal"
 			variant={ isPublic( project ) ? 'tertiary' : 'primary' }
 			disabled={ isSaving || ! canPublish }
-			onClick={ handleOnPublish }
+			onClick={ onPublish }
 			onMouseEnter={ toggleNotice }
 			onMouseLeave={ toggleNotice }
 		>

--- a/apps/dashboard/src/components/editor/toolbar.js
+++ b/apps/dashboard/src/components/editor/toolbar.js
@@ -31,10 +31,24 @@ const Toolbar = ( { project, onShareClick } ) => {
 		select( STORE_NAME ).isEditorContentSaved(),
 	] );
 
-	const publishProject = ( firstPublish = false ) => {
+	const publishProject = () => {
+		if ( hasUnpublishedChanges( project ) && project.publicContent ) {
+			// eslint-disable-next-line
+			const confirmed = window.confirm(
+				__(
+					'Warning! This project was already published. Deleting or changing questions or form blocks may cause the loss of existing responses. Are you sure you want to proceed?',
+					'dashboard'
+				)
+			);
+
+			if ( ! confirmed ) {
+				return;
+			}
+		}
+
 		saveEditorChanges( { public: true } );
 
-		if ( firstPublish ) {
+		if ( ! isPublic( project ) ) {
 			onShareClick();
 		}
 	};

--- a/packages/project/src/index.js
+++ b/packages/project/src/index.js
@@ -22,7 +22,7 @@
  * @property {string}                permalink     Project URL.
  * @property {boolean}               public        True when project is public.
  * @property {ProjectContent | null} publicContent Project's last published content.
- * @property {string}                publicTheme   Project's public theme.
+ * @property {string | null}         publicTheme   Project's public theme.
  * @property {string}                slug          Project slug.
  * @property {string}                title         Project title.
  */


### PR DESCRIPTION
## Summary

This PR includes the changes to show a confirmation popup whenever the user is publishing or updating content that will override the `publicContent` a might cause data loss.

**Important**: It also includes a suggested UI change to make it easier to track when we should show the confirmation popup.
WIth this change, the Visibility toggle button will only change the project visibility and won't publish project's draft content when switching from private to public.

Depends on: D78067-code

Ref: c/fy6hLLMM-tr

## Test Instructions
* Open or create a project
* Play with the Publish/Update button and the Visibility toggle
* You should see a confirmation popup whenever the content you're publishing is overriding the content already published.