### PR TITLE
Add frontend tracking events

### DIFF
--- a/apps/dashboard/public/index.html
+++ b/apps/dashboard/public/index.html
@@ -12,6 +12,7 @@
 
 	<script src="https://app.crowdsignal.com/js/react/react.development.js"></script>
 	<script src="https://app.crowdsignal.com/js/react/react-dom.development.js"></script>
+	<script src="https://stats.wp.com/w.js"></script>
 	<script src="/main.js"></script>
 </body>
 </html>

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -13,7 +13,7 @@ import { blankProjectTemplate } from '../new-project-wizard/templates';
 import { STORE_NAME } from '../../data';
 import BlockEditor from './editor';
 import EditorLoadingPlaceholder from './loading-placeholder';
-import { trackEditorLoaded } from '../../util/tracking';
+import { trackEditorLoad } from '../../util/tracking';
 
 const Editor = ( { projectId } ) => {
 	const [ project, isLoading ] = useSelect(
@@ -36,7 +36,7 @@ const Editor = ( { projectId } ) => {
 	);
 
 	useEffect( () => {
-		trackEditorLoaded( currentUser, projectId );
+		trackEditorLoad( currentUser, projectId );
 	}, [ currentUser ] );
 
 	if ( isLoading ) {

--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import { blankProjectTemplate } from '../new-project-wizard/templates';
 import { STORE_NAME } from '../../data';
 import BlockEditor from './editor';
 import EditorLoadingPlaceholder from './loading-placeholder';
+import { trackEditorLoaded } from '../../util/tracking';
 
 const Editor = ( { projectId } ) => {
 	const [ project, isLoading ] = useSelect(
@@ -27,6 +29,15 @@ const Editor = ( { projectId } ) => {
 		},
 		[ projectId ]
 	);
+
+	const currentUser = useSelect(
+		( select ) => select( STORE_NAME ).getCurrentUser(),
+		[]
+	);
+
+	useEffect( () => {
+		trackEditorLoaded( currentUser, projectId );
+	}, [ currentUser ] );
 
 	if ( isLoading ) {
 		return (

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -11,7 +11,7 @@ import { useClientId } from '@crowdsignal/hooks';
 import { isPublic } from '@crowdsignal/project';
 import { STORE_NAME } from '../../data';
 import { NOTICE_UNPUBLISHED } from './notice';
-import { trackThemeChanged } from '../../util/tracking';
+import { trackThemeChange } from '../../util/tracking';
 
 export const useEditorContent = ( project ) => {
 	const [ forceDraft, setForceDraft ] = useState( false );
@@ -122,7 +122,7 @@ export const useEditorContent = ( project ) => {
 			saveEditorChanges();
 		}
 
-		trackThemeChanged( currentUser, theme, project.id );
+		trackThemeChange( currentUser, theme, project.id );
 	};
 
 	return {

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -11,6 +11,7 @@ import { useClientId } from '@crowdsignal/hooks';
 import { isPublic } from '@crowdsignal/project';
 import { STORE_NAME } from '../../data';
 import { NOTICE_UNPUBLISHED } from './notice';
+import { trackThemeChanged } from '../../util/tracking';
 
 export const useEditorContent = ( project ) => {
 	const [ forceDraft, setForceDraft ] = useState( false );
@@ -34,6 +35,7 @@ export const useEditorContent = ( project ) => {
 		editorProjectId,
 		isEditorContentSaved,
 		editorTheme,
+		currentUser,
 	] = useSelect( ( select ) => [
 		select( STORE_NAME ).isEditingConfirmationPage(),
 		select( STORE_NAME ).getEditorCurrentPageIndex(),
@@ -41,6 +43,7 @@ export const useEditorContent = ( project ) => {
 		select( STORE_NAME ).getEditorProjectId(),
 		select( STORE_NAME ).isEditorContentSaved(),
 		select( STORE_NAME ).getEditorTheme(),
+		select( STORE_NAME ).getCurrentUser(),
 	] );
 
 	useEffect( () => {
@@ -118,6 +121,8 @@ export const useEditorContent = ( project ) => {
 		if ( autoSave ) {
 			saveEditorChanges();
 		}
+
+		trackThemeChanged( currentUser, theme, project.id );
 	};
 
 	return {

--- a/apps/dashboard/src/data/accounts/actions.js
+++ b/apps/dashboard/src/data/accounts/actions.js
@@ -5,6 +5,7 @@ import { ACCOUNT_SIGNAL_COUNT_UPDATE, ACCOUNT_UPDATE } from '../action-types';
 
 export const updateAccount = (
 	accountId,
+	partnerUserId,
 	type,
 	userIds,
 	domain,
@@ -13,6 +14,7 @@ export const updateAccount = (
 	type: ACCOUNT_UPDATE,
 	accountType: type,
 	accountId,
+	partnerUserId,
 	domain,
 	signalLimit,
 	userIds,

--- a/apps/dashboard/src/data/accounts/reducer.js
+++ b/apps/dashboard/src/data/accounts/reducer.js
@@ -41,6 +41,14 @@ const signalLimit = ( state = 0, action ) => {
 	return state;
 };
 
+const partnerUserId = ( state = 0, action ) => {
+	if ( action.type === ACCOUNT_UPDATE ) {
+		return action.partnerUserId;
+	}
+
+	return state;
+};
+
 const signalCount = ( state = 0, action ) => {
 	if ( action.type === ACCOUNT_SIGNAL_COUNT_UPDATE ) {
 		return action.count;
@@ -56,6 +64,7 @@ export default keyedReducer(
 		signalCount,
 		signalLimit,
 		type,
+		partnerUserId,
 		users,
 	} )
 );

--- a/apps/dashboard/src/data/accounts/selectors.js
+++ b/apps/dashboard/src/data/accounts/selectors.js
@@ -11,3 +11,6 @@ export const getAccountDomain = ( state, accountId ) =>
 
 export const getAccountSignalCount = ( state, accountId ) =>
 	get( state, [ 'accounts', accountId, 'signalCount' ], 0 );
+
+export const getAccountPartnerUserId = ( state, accountId ) =>
+	get( state, [ 'accounts', accountId, 'partnerUserId' ], 0 );

--- a/apps/dashboard/src/data/ui/resolvers.js
+++ b/apps/dashboard/src/data/ui/resolvers.js
@@ -29,6 +29,7 @@ function* getCurrentUser() {
 
 		yield updateAccount(
 			account.id,
+			account.partnerUserId,
 			account.type,
 			account.users,
 			account.domain,

--- a/apps/dashboard/src/data/users/selectors.js
+++ b/apps/dashboard/src/data/users/selectors.js
@@ -46,6 +46,7 @@ export const getUser = ( state, userId ) => {
 	}
 
 	return {
+		userId,
 		accountType: getUserAccountType( state, userId ),
 		profile: getUserProfile( state, userId ),
 		signalCount: getUserSignalCount( state, userId ),

--- a/apps/dashboard/src/data/users/selectors.js
+++ b/apps/dashboard/src/data/users/selectors.js
@@ -6,7 +6,11 @@ import { get, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getAccountSignalCount, getAccountType } from '../accounts/selectors';
+import {
+	getAccountSignalCount,
+	getAccountType,
+	getAccountPartnerUserId,
+} from '../accounts/selectors';
 
 export const getUserAccountId = ( state, userId ) =>
 	get( state, [ 'users', userId, 'account' ], 0 );
@@ -16,6 +20,9 @@ export const getUserAccountType = ( state, userId ) =>
 
 export const getUserSignalCount = ( state, userId ) =>
 	getAccountSignalCount( state, getUserAccountId( state, userId ) );
+
+export const getUserPartnerId = ( state, userId ) =>
+	getAccountPartnerUserId( state, getUserAccountId( state, userId ) );
 
 export const getUserProfile = ( state, userId ) =>
 	get( state, [ 'users', userId, 'profile' ], {} );
@@ -47,6 +54,7 @@ export const getUser = ( state, userId ) => {
 
 	return {
 		userId,
+		partnerUserId: getUserPartnerId( state, userId ),
 		accountType: getUserAccountType( state, userId ),
 		profile: getUserProfile( state, userId ),
 		signalCount: getUserSignalCount( state, userId ),

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -29,7 +29,7 @@ export const trackEditorLoad = ( user, projectId ) => {
 	const currentDate = new Date().setHours( 0, 0, 0, 0 );
 
 	if ( user && lastEditorLoadDate < currentDate ) {
-		trackEvent( user, 'crowdsignal_nex_editor_load', {
+		trackEvent( user, 'crowdsignal_project_editor_load', {
 			project_id: projectId,
 		} );
 		localStorage.setItem( EDITOR_LOADED_KEY, currentDate );
@@ -37,7 +37,7 @@ export const trackEditorLoad = ( user, projectId ) => {
 };
 
 export const trackThemeChange = ( user, theme, projectId ) => {
-	trackEvent( user, 'crowdsignal_nex_theme_change', {
+	trackEvent( user, 'crowdsignal_project_theme_change', {
 		theme,
 		project_id: projectId,
 	} );

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -21,7 +21,7 @@ export const trackEvent = ( user, event, properties ) => {
 	] );
 };
 
-export const trackEditorLoaded = ( user, projectId ) => {
+export const trackEditorLoad = ( user, projectId ) => {
 	const EDITOR_LOADED_KEY = 'editor_last_loaded_date';
 	const lastEditorLoad =
 		Number( localStorage.getItem( EDITOR_LOADED_KEY ) ) || 0;
@@ -36,7 +36,7 @@ export const trackEditorLoaded = ( user, projectId ) => {
 	}
 };
 
-export const trackThemeChanged = ( user, theme, projectId ) => {
+export const trackThemeChange = ( user, theme, projectId ) => {
 	trackEvent( user, 'crowdsignal_nex_theme_change', {
 		theme,
 		project_id: projectId,

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -1,0 +1,40 @@
+/* global localStorage */
+
+export const trackEvent = ( user, event, properties ) => {
+	if ( ! user ) {
+		return;
+	}
+
+	window._tkq = window._tkq || [];
+	window._tkq.push( [ 'identifyUser', user.userId, user.profile.username ] );
+	window._tkq.push( [
+		'recordEvent',
+		event,
+		{
+			user_id: user.userId,
+			...properties,
+		},
+	] );
+};
+
+export const trackEditorLoaded = ( user, projectId ) => {
+	const EDITOR_LOADED_KEY = 'editor_last_loaded_date';
+	const lastEditorLoad =
+		Number( localStorage.getItem( EDITOR_LOADED_KEY ) ) || 0;
+	const lastEditorLoadDate = new Date( lastEditorLoad );
+	const currentDate = new Date().setHours( 0, 0, 0, 0 );
+
+	if ( user && lastEditorLoadDate < currentDate ) {
+		trackEvent( user, 'crowdsignal_nex_editor_loaded', {
+			project_id: projectId,
+		} );
+		localStorage.setItem( EDITOR_LOADED_KEY, currentDate );
+	}
+};
+
+export const trackThemeChanged = ( user, theme, projectId ) => {
+	trackEvent( user, 'crowdsignal_nex_theme_changed', {
+		theme,
+		project_id: projectId,
+	} );
+};

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -6,7 +6,11 @@ export const trackEvent = ( user, event, properties ) => {
 	}
 
 	window._tkq = window._tkq || [];
-	window._tkq.push( [ 'identifyUser', user.userId, user.profile.username ] );
+	window._tkq.push( [
+		'identifyUser',
+		user.partnerUserId,
+		user.profile.username,
+	] );
 	window._tkq.push( [
 		'recordEvent',
 		event,

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -29,7 +29,7 @@ export const trackEditorLoaded = ( user, projectId ) => {
 	const currentDate = new Date().setHours( 0, 0, 0, 0 );
 
 	if ( user && lastEditorLoadDate < currentDate ) {
-		trackEvent( user, 'crowdsignal_nex_editor_loaded', {
+		trackEvent( user, 'crowdsignal_nex_editor_load', {
 			project_id: projectId,
 		} );
 		localStorage.setItem( EDITOR_LOADED_KEY, currentDate );
@@ -37,7 +37,7 @@ export const trackEditorLoaded = ( user, projectId ) => {
 };
 
 export const trackThemeChanged = ( user, theme, projectId ) => {
-	trackEvent( user, 'crowdsignal_nex_theme_changed', {
+	trackEvent( user, 'crowdsignal_nex_theme_change', {
 		theme,
 		project_id: projectId,
 	} );


### PR DESCRIPTION
## Summary

This PR includes two Tracks events we identified to be triggered on the frontend.
It also includes a few changes to the dashboard store to receive the WP UserId, necessary to correctly show the user in the Tracks tools.

The events: 
* `crowdsignal_project_editor_load`
* `crowdsignal_project_theme_change`

There should be another event for when the user adds a Crowdsignal block, but at the moment, we could find an efficient way to do that. It'll be handled on c/n965HLz3-tr

Depends on: D78238-code

Ref: c/YyuRhT6E-tr

## Test Instructions

* Open or create a project
* The event `crowdsignal_project_editor_load` should be fired only once a day. 
* It'll create a registry (`editor_last_loaded_date`) in the localStorage to keep track of when to trigger the event.
* Change the theme. 
* It should trigger the event `crowdsignal_project_theme_change`
* Open the [Tracks Live](https://mc.a8c.com/tracks/live/?eventname=crowdsignal_project_%25) and check if the events appear there. It might take more than 5 minutes for the events to show there.