### PR TITLE
Add query string to iframe URL for Project Results

### DIFF
--- a/apps/dashboard/src/components/results/index.js
+++ b/apps/dashboard/src/components/results/index.js
@@ -25,6 +25,9 @@ const Results = ( { projectId } ) => {
 
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
+	const queryString = window.location.toString().split( '?' )[ 1 ];
+	const params = queryString ? `?${ queryString }` : '';
+
 	const updateProjectTitle = ( title ) =>
 		saveAndUpdateProject( projectId, { title } );
 
@@ -41,7 +44,7 @@ const Results = ( { projectId } ) => {
 					/>
 
 					<IFrame
-						src={ `/surveys/${ projectId }/report/overview` }
+						src={ `/surveys/${ projectId }/report/overview${ params }` }
 						width="100%"
 					/>
 				</>

--- a/apps/dashboard/src/components/results/index.js
+++ b/apps/dashboard/src/components/results/index.js
@@ -25,9 +25,6 @@ const Results = ( { projectId } ) => {
 
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
-	const queryString = window.location.toString().split( '?' )[ 1 ];
-	const params = queryString ? `?${ queryString }` : '';
-
 	const updateProjectTitle = ( title ) =>
 		saveAndUpdateProject( projectId, { title } );
 
@@ -44,7 +41,7 @@ const Results = ( { projectId } ) => {
 					/>
 
 					<IFrame
-						src={ `/surveys/${ projectId }/report/overview${ params }` }
+						src={ `/surveys/${ projectId }/report/overview${ window.location.search }` }
 						width="100%"
 					/>
 				</>


### PR DESCRIPTION
When exporting projects to Google or another async export method, there was no notice to the user to wait for the email.  In Surveys this is handled by a little banner that shows up when the user returns to the Reports page.  Projects uses the same reports page, but it's in an iFrame and the banner did not display.

This PR passes the query string from the browser to the iFrame, which then lets the iframe render the notification banner.

Testing:
Apply this PR, then open or create a project at crowdsignal.locahost.  Click the report and then add ?msg=google to the url in the address bar.

Localhost can't render the iframe because it goes to app.crowdsignal.com and it doesn't work.  But, you can see the destination URL in the yarn error messages once the attempt times out.

If you know of a way to get the iframe to show up locally, I'm all ears, but otherwise the final test will need to be after this is deployed to production