### PR TITLE
Reset scroll position after submitting a page

### DIFF
--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -101,6 +101,7 @@ const App = ( {
 					setHasResponded( json.done );
 					setResponseHash( json.r );
 					setCurrentPage( parseInt( json.p, 10 ) );
+					window.scrollTo( 0, 0 );
 				} )
 				// eslint-disable-next-line no-console
 				.catch( ( err ) => console.error( err ) )


### PR DESCRIPTION
## Summary

This PR should address the issue where the scroll position is maintained after submitting long project pages.

Ref: c/7GyQhL54-tr

## Testing
* Create a project with at least two long pages. Both pages need to have a scrollbar
* On the Project Renderer, submit the first page
* You should be moved to the top of the next page