### PR TITLE
Fix Embed block alignment on Project Renderer

### DIFF
--- a/packages/blocks/src/core-embed/index.js
+++ b/packages/blocks/src/core-embed/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { renderToString, useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
 
@@ -39,8 +39,7 @@ const CoreEmbed = ( { attributes } ) => {
 
 	const classes = classnames( className, 'wp-block-embed', {
 		'is-type-video': 'video' === type,
-		alignfull: attributes.align === 'full',
-		alignwide: attributes.align === 'wide',
+		[ `align${ attributes.align }` ]: ! isNil( attributes.align ),
 	} );
 
 	const html = 'photo' === type ? getPhotoHTML( preview ) : preview.html;

--- a/packages/blocks/src/core-embed/index.js
+++ b/packages/blocks/src/core-embed/index.js
@@ -39,6 +39,8 @@ const CoreEmbed = ( { attributes } ) => {
 
 	const classes = classnames( className, 'wp-block-embed', {
 		'is-type-video': 'video' === type,
+		alignfull: attributes.align === 'full',
+		alignwide: attributes.align === 'wide',
 	} );
 
 	const html = 'photo' === type ? getPhotoHTML( preview ) : preview.html;

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -104,6 +104,14 @@ body {
 			margin-top: var(--cs--block--alignfull-margin-top);
 		}
 	}
+
+	> .alignright {
+		float: right;
+	}
+
+	> .alignleft {
+		float: left;
+	}
 }
 
 .crowdsignal-forms-button.wp-block-button.is-style-outline {


### PR DESCRIPTION
## Summary

This PR fixes the Embed blocks alignments, especially on the Project Renderer.

Ref: c/pD0jsWqy-tr

## Testing

* Open or create a project and add some Embed blocks
* Play with the block's alignments
* They should work properly

Note that left and right alignments use `float` (as WP) so content may overlap.