### PR TITLE
Update/Close Share Modal When Clicked Outside

### DIFF
--- a/apps/dashboard/src/components/share-modal/index.js
+++ b/apps/dashboard/src/components/share-modal/index.js
@@ -32,37 +32,44 @@ const SharedModalFooterNote = styled.div`
 	padding: 160px 0;
 `;
 
-const ShareModal = ( { project, onClose } ) => (
-	<ModalWrapper>
-		<ShareModalDialog id="crowdsignal-share-modal">
-			<ModalNavigation>
-				<ModalCloseButton onClick={ onClose } />
-			</ModalNavigation>
-			<ModalHeader>
-				{ __( 'Share and collect responses', 'dashboard' ) }
-			</ModalHeader>
-			<ModalHeaderNote>
-				{ __( "It's time to collect some signals.", 'dashboard' ) }
-			</ModalHeaderNote>
-			<ModalTemplateGrid>
-				<ShareLink link={ project.permalink } />
-			</ModalTemplateGrid>
-			<SharedModalFooterNote>
-				<span>
-					{ __(
-						'More channels for sharing and embedding your forms are coming soon.',
-						'dashboard'
-					) }
-				</span>
-				<span>
-					{ __(
-						'Thank you for using this beta version!',
-						'dashboard'
-					) }
-				</span>
-			</SharedModalFooterNote>
-		</ShareModalDialog>
-	</ModalWrapper>
-);
+const ShareModal = ( { project, onClose } ) => {
+	const onWrapperClickHandler = ( event ) => {
+		if ( event.target === event.currentTarget ) {
+			onClose();
+		}
+	};
+	return (
+		<ModalWrapper onClick={ onWrapperClickHandler }>
+			<ShareModalDialog id="crowdsignal-share-modal">
+				<ModalNavigation>
+					<ModalCloseButton onClick={ onClose } />
+				</ModalNavigation>
+				<ModalHeader>
+					{ __( 'Share and collect responses', 'dashboard' ) }
+				</ModalHeader>
+				<ModalHeaderNote>
+					{ __( "It's time to collect some signals.", 'dashboard' ) }
+				</ModalHeaderNote>
+				<ModalTemplateGrid>
+					<ShareLink link={ project.permalink } />
+				</ModalTemplateGrid>
+				<SharedModalFooterNote>
+					<span>
+						{ __(
+							'More channels for sharing and embedding your forms are coming soon.',
+							'dashboard'
+						) }
+					</span>
+					<span>
+						{ __(
+							'Thank you for using this beta version!',
+							'dashboard'
+						) }
+					</span>
+				</SharedModalFooterNote>
+			</ShareModalDialog>
+		</ModalWrapper>
+	);
+};
 
 export default ShareModal;


### PR DESCRIPTION
Per c/jzUXOAT8-tr This pr will cause the Share modal to close when a user clicks outside the modal (on to the project editor screen behind the modal).

Big thanks to @jcheringer for the assist.  We discussed whether this would better work as an inline function on the modal wrapper, or by the current method of building the modal as part of the function that determines whether or not the user clicks on the project or the modal.  (Bubbling is hard, y'all!)

I'm not sure if there's a more react-centric way of doing this, so I'd love to hear opinions :)

Testing instructions:

Checkout and run the PR.
Create or edit a Project (the project will need to be published)
Click on Sharing within the editor tab to see the modal.
Click outside the modal to see if it closes
Make sure that clicking the modal itself does not close the modal.