### PR TITLE
Fix current page indicator when re-ordering pages

### DIFF
--- a/apps/dashboard/src/data/editor/reducer.js
+++ b/apps/dashboard/src/data/editor/reducer.js
@@ -110,6 +110,10 @@ const currentPage = ( state = 0, action ) => {
 		return state - 1;
 	}
 
+	if ( action.type === EDITOR_PAGE_ORDER_UPDATE ) {
+		return action.order.indexOf( state );
+	}
+
 	return state;
 };
 


### PR DESCRIPTION
This patch fixes an issue where the current page indicator wouldn't update correctly after moving the current page in the order.  
Previously, the highlight would remain on the previous position causing it to get out of sync.

# Testing

- Open the editor and make sure you've got at least a few pages.
- Drag the currently selected page to a new location.
- The page should remain selected, at the new position.