### PR TITLE
Add Editor content insert tracking

### DIFF
--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -11,7 +11,7 @@ import { useClientId } from '@crowdsignal/hooks';
 import { isPublic } from '@crowdsignal/project';
 import { STORE_NAME } from '../../data';
 import { NOTICE_UNPUBLISHED } from './notice';
-import { trackThemeChange } from '../../util/tracking';
+import { trackContentInsert, trackThemeChange } from '../../util/tracking';
 
 export const useEditorContent = ( project ) => {
 	const [ forceDraft, setForceDraft ] = useState( false );
@@ -109,6 +109,10 @@ export const useEditorContent = ( project ) => {
 			projectTemplate.draftContent.pages,
 			editorTheme
 		);
+
+		if ( projectTemplate.draftContent.pages[ 0 ].length ) {
+			trackContentInsert( currentUser );
+		}
 
 		// Force IsolatedBlockEditor to reload
 		setEditorId( `${ editorId }*` );

--- a/apps/dashboard/src/util/tracking/index.js
+++ b/apps/dashboard/src/util/tracking/index.js
@@ -36,6 +36,10 @@ export const trackEditorLoad = ( user, projectId ) => {
 	}
 };
 
+export const trackContentInsert = ( user ) => {
+	trackEvent( user, 'crowdsignal_project_editor_content_insert' );
+};
+
 export const trackThemeChange = ( user, theme, projectId ) => {
 	trackEvent( user, 'crowdsignal_project_theme_change', {
 		theme,


### PR DESCRIPTION
## Summary

This PR includes a new frontend tracking event (`crowdsignal_project_editor_content_insert`) that should be fired at the first content insertion on a new project.

## Testing

* Create a new project
* If you start with a non-blank template, the tracking event should be fired right away
* If you start with a blank template, as soon as you add some content the event should be fired
* The event should be seen on [Tracks Live view](https://mc.a8c.com/tracks/live/?eventname=crowdsignal_project_editor_content_insert)