### PR TITLE
Add a feedback widget inside the editor

### DIFF
--- a/apps/dashboard/public/index.html
+++ b/apps/dashboard/public/index.html
@@ -14,5 +14,7 @@
 	<script src="https://app.crowdsignal.com/js/react/react-dom.development.js"></script>
 	<script src="https://stats.wp.com/w.js"></script>
 	<script src="/main.js"></script>
+
+	<script src="https://app.crowdsignal.com/js/dashboard-feedback.js"></script>
 </body>
 </html>

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -17,6 +17,7 @@ import { STORE_NAME } from '../../data';
 import { useEditorContent } from './use-editor-content';
 import AutoSubmitButton from './auto-submit-button';
 import DocumentSettings from './document-settings';
+import EditorFeedbackButton from './feedback-button';
 import EditorNotice from './notice';
 import EditorStylesResolver from './styles-resolver';
 import HeaderMeta from '../header-meta';
@@ -154,6 +155,8 @@ const Editor = ( { project } ) => {
 					version={ version }
 				/>
 			</EditorWrapper>
+
+			<EditorFeedbackButton />
 		</EditorLayout>
 	);
 };

--- a/apps/dashboard/src/components/editor/feedback-button.js
+++ b/apps/dashboard/src/components/editor/feedback-button.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+const EditorFeedbackButton = () => {
+	useEffect(
+		() =>
+			window.crowdsignal.FeedbackWidget( 2765015, {
+				position: 'bottom left',
+			} ),
+		[]
+	);
+
+	return null;
+};
+
+export default EditorFeedbackButton;


### PR DESCRIPTION
This patch adds a feedback widget into the editor UI. The widget will be displayed on bottom left.

![widget](https://user-images.githubusercontent.com/8056203/164014707-cefaefc2-a377-4d41-993f-a7af7cf2bf28.png)

# Testing

Requires D79005-code.

- Open the editor, you should see the feedback widget button inside the editor, in the bottom left corner.
- When switching to a different page like the results tab, the feedback widget should no longer be present.