### PR TITLE
Expose settings and unmount API for the feedback widget

### DIFF
--- a/apps/feedback-widget/babel.config.js
+++ b/apps/feedback-widget/babel.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	],
 	plugins: [
 		'@babel/plugin-transform-runtime',
-		'@wordpress/babel-plugin-import-jsx-pragma',
+		'@babel/plugin-proposal-optional-chaining',
+		'babel-plugin-emotion',
 	],
 };

--- a/apps/feedback-widget/src/index.js
+++ b/apps/feedback-widget/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@wordpress/element';
+import { render, unmountComponentAtNode } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,7 +9,7 @@ import { render } from '@wordpress/element';
 import { StyleProvider } from '@crowdsignal/components';
 import FeedbackWidget from './widget';
 
-const renderWidget = ( surveyId ) => {
+const renderWidget = ( surveyId, settings = {} ) => {
 	const wrapperElement = document.createElement( 'div' );
 	document.body.appendChild( wrapperElement );
 
@@ -21,10 +21,15 @@ const renderWidget = ( surveyId ) => {
 			namespace="feedback-widget"
 			container={ shadowRoot }
 		>
-			<FeedbackWidget surveyId={ surveyId } />
+			<FeedbackWidget surveyId={ surveyId } settings={ settings } />
 		</StyleProvider>,
 		shadowRoot
 	);
+
+	return () => {
+		unmountComponentAtNode( wrapperElement );
+		wrapperElement.remove();
+	};
 };
 
 export default renderWidget;

--- a/apps/feedback-widget/src/styles/popover-styles.js
+++ b/apps/feedback-widget/src/styles/popover-styles.js
@@ -35,6 +35,7 @@ export const Popover = styled.div(
 			flex-direction: column;
 			height: ${ height || 'auto' };
 			max-height: 480px;
+			line-height: initial;
 			outline: 0;
 			overflow-y: scroll;
 			padding: 24px;

--- a/apps/feedback-widget/src/util.js
+++ b/apps/feedback-widget/src/util.js
@@ -89,5 +89,9 @@ export const getPopoverPosition = ( position ) => {
 		return x === 'left' ? 'center right' : 'center left';
 	}
 
-	return 'auto';
+	if ( y === 'bottom' ) {
+		return x === 'left' ? 'top right' : 'top left';
+	}
+
+	return x === 'left' ? 'bottom right' : 'bottom left';
 };

--- a/apps/feedback-widget/src/widget.js
+++ b/apps/feedback-widget/src/widget.js
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +29,7 @@ import { ToggleMode } from './constants';
  */
 import { PopoverWrapper } from './styles/popover-styles';
 
-const settings = {
+const defaultSettings = {
 	emailRequired: false,
 	position: 'center right',
 	style: {},
@@ -44,20 +45,22 @@ const settings = {
 	showBranding: false,
 };
 
-const FeedbackWidget = ( { surveyId } ) => {
+const FeedbackWidget = ( { settings, surveyId } ) => {
 	const [ active, setActive ] = useState( false );
 	const [ _, setSurvey ] = useState( null );
 	const [ position, setPosition ] = useState( {} );
 
 	const toggle = useRef( null );
 
+	const widgetSettings = merge( defaultSettings, settings );
+
 	const updatePosition = useCallback( () => {
-		const [ y ] = settings.position.split( ' ' );
+		const [ y ] = widgetSettings.position.split( ' ' );
 
 		setPosition(
 			adjustFrameOffset(
 				getTogglePosition(
-					settings.position,
+					widgetSettings.position,
 					toggle.current.offsetWidth,
 					y === 'center'
 						? toggle.current.offsetWidth
@@ -104,7 +107,7 @@ const FeedbackWidget = ( { surveyId } ) => {
 					isOpen={ active }
 					onClick={ handleToggle }
 					onToggle={ updatePosition }
-					settings={ settings }
+					settings={ widgetSettings }
 				/>
 			</PopoverWrapper>
 
@@ -112,9 +115,12 @@ const FeedbackWidget = ( { surveyId } ) => {
 				isVisible={ active }
 				context={ toggle }
 				onClose={ handleClose }
-				position={ getPopoverPosition( settings.position ) }
+				position={ getPopoverPosition( widgetSettings.position ) }
 			>
-				<FeedbackPopover surveyId={ surveyId } settings={ settings } />
+				<FeedbackPopover
+					surveyId={ surveyId }
+					settings={ widgetSettings }
+				/>
 			</Popover>
 		</>
 	);

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -16,7 +16,7 @@ export const getPopoverOffset = ( position, popover, context ) => {
 	switch ( lowerCase( position ) ) {
 		case 'top right':
 			return {
-				bottom: window.innerHeight - context.top + POPOVER_OFFSET,
+				bottom: window.innerHeight - contextBox.top + POPOVER_OFFSET,
 				left: contextBox.left,
 			};
 


### PR DESCRIPTION
This patch exposes settings and allows for unmounting the feedback widget through its public API, while maintaining compatibility with the previous code.  
It also fixes popover positioning which was previously crashing in `top right` position.

These changes are required by #220.

# Testing

TBA