### PR TITLE
Fix text cutting on MC buttons

### DIFF
--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -114,10 +114,6 @@ body {
 	}
 }
 
-.crowdsignal-forms-button.wp-block-button .wp-block-button__link {
-	line-height: normal;
-}
-
 .crowdsignal-forms-button.wp-block-button.is-style-outline {
 	&.is-style-emoji {
 		.crowdsignal-forms-button__button {

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -114,6 +114,10 @@ body {
 	}
 }
 
+.crowdsignal-forms-button.wp-block-button .wp-block-button__link {
+	line-height: normal;
+}
+
 .crowdsignal-forms-button.wp-block-button.is-style-outline {
 	&.is-style-emoji {
 		.crowdsignal-forms-button__button {

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -45,3 +45,7 @@ body {
 .wp-block-image {
 	text-align: unset;
 }
+
+.crowdsignal-forms-button.wp-block-button .wp-block-button__link {
+	line-height: normal;
+}


### PR DESCRIPTION
This PR fixes text being cut on MC buttons due to wrong line-height setting.

## Test instructions
Create/edit a project, insert a MC question. Set a background color on MC buttons and preview it.
Pay attention to letters going under the line, like "p", "g", "j", "y", etc. Those letters should be entirely visible.

Before:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/157240/165156425-b431d6d7-b766-45b1-b592-139148351c37.png">

After:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/157240/165156457-ded789d7-1035-49b3-88e1-dd595b88e642.png">
