### PR TITLE
Add a tooltip to results tab

### DIFF
--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -2,12 +2,17 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { EditablePageHeader, TabNavigation } from '@crowdsignal/components';
+import {
+	EditablePageHeader,
+	TabNavigation,
+	PopoverNotice,
+} from '@crowdsignal/components';
 import { STORE_NAME } from '../../data';
 
 /**
@@ -26,6 +31,8 @@ const ProjectNavigation = ( {
 	onChangeTitle,
 	projectId,
 } ) => {
+	const [ displayNotice, setDisplayNotice ] = useState( false );
+	const noteSpan = useRef();
 	const [ editorTitle, projectTitle ] = useSelect(
 		( select ) => [
 			select( STORE_NAME ).getEditorTitle(),
@@ -45,6 +52,7 @@ const ProjectNavigation = ( {
 				}
 				disabled={ disableTitleEditor }
 			/>
+
 			<TabNavigation>
 				<TabNavigation.Tab
 					isSelected={ activeTab === Tab.EDITOR }
@@ -53,13 +61,30 @@ const ProjectNavigation = ( {
 				>
 					{ __( 'Editor', 'dashboard' ) }
 				</TabNavigation.Tab>
-				<TabNavigation.Tab
-					isSelected={ activeTab === Tab.RESULTS }
-					isDisabled={ ! projectId }
-					href={ `/project/${ projectId }/results` }
+
+				<span
+					ref={ noteSpan }
+					onMouseEnter={ () => setDisplayNotice( true ) }
+					onMouseLeave={ () => setDisplayNotice( false ) }
 				>
-					{ __( 'Results', 'dashboard' ) }
-				</TabNavigation.Tab>
+					<PopoverNotice
+						context={ noteSpan }
+						onClose={ () => setDisplayNotice( false ) }
+						isVisible={ displayNotice && ! projectId }
+						position={ 'bottom left' }
+					>
+						{ __(
+							'Please save draft or publish project to view results'
+						) }
+					</PopoverNotice>
+					<TabNavigation.Tab
+						isSelected={ activeTab === Tab.RESULTS }
+						isDisabled={ ! projectId }
+						href={ `/project/${ projectId }/results` }
+					>
+						{ __( 'Results', 'dashboard' ) }
+					</TabNavigation.Tab>
+				</span>
 			</TabNavigation>
 		</div>
 	);

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -79,7 +79,10 @@ const ProjectNavigation = ( {
 				isVisible={ displayNotice && ! projectId }
 				position={ 'bottom left' }
 			>
-				{ __( 'Please save draft or publish project to view results' ) }
+				{ __(
+					'Please save draft or publish project to view results',
+					'dashboard'
+				) }
 			</PopoverNotice>
 		</div>
 	);

--- a/apps/dashboard/src/components/project-navigation/index.js
+++ b/apps/dashboard/src/components/project-navigation/index.js
@@ -32,7 +32,7 @@ const ProjectNavigation = ( {
 	projectId,
 } ) => {
 	const [ displayNotice, setDisplayNotice ] = useState( false );
-	const noteSpan = useRef();
+	const noteRef = useRef();
 	const [ editorTitle, projectTitle ] = useSelect(
 		( select ) => [
 			select( STORE_NAME ).getEditorTitle(),
@@ -62,30 +62,25 @@ const ProjectNavigation = ( {
 					{ __( 'Editor', 'dashboard' ) }
 				</TabNavigation.Tab>
 
-				<span
-					ref={ noteSpan }
+				<TabNavigation.Tab
+					ref={ noteRef }
 					onMouseEnter={ () => setDisplayNotice( true ) }
 					onMouseLeave={ () => setDisplayNotice( false ) }
+					isSelected={ activeTab === Tab.RESULTS }
+					isDisabled={ ! projectId }
+					href={ `/project/${ projectId }/results` }
 				>
-					<PopoverNotice
-						context={ noteSpan }
-						onClose={ () => setDisplayNotice( false ) }
-						isVisible={ displayNotice && ! projectId }
-						position={ 'bottom left' }
-					>
-						{ __(
-							'Please save draft or publish project to view results'
-						) }
-					</PopoverNotice>
-					<TabNavigation.Tab
-						isSelected={ activeTab === Tab.RESULTS }
-						isDisabled={ ! projectId }
-						href={ `/project/${ projectId }/results` }
-					>
-						{ __( 'Results', 'dashboard' ) }
-					</TabNavigation.Tab>
-				</span>
+					{ __( 'Results', 'dashboard' ) }
+				</TabNavigation.Tab>
 			</TabNavigation>
+			<PopoverNotice
+				context={ noteRef }
+				onClose={ () => setDisplayNotice( false ) }
+				isVisible={ displayNotice && ! projectId }
+				position={ 'bottom left' }
+			>
+				{ __( 'Please save draft or publish project to view results' ) }
+			</PopoverNotice>
 		</div>
 	);
 };

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -10,6 +10,7 @@ export { default as FormTextInput } from './form-text-input';
 export { default as PageHeader } from './page-header';
 export { default as Popover } from './popover';
 export { default as PopoverMenu } from './popover-menu';
+export { default as PopoverNotice } from './popover-notice';
 export { default as Sandbox } from './sandbox';
 export { default as StyleProvider } from './style-provider';
 export { default as TabNavigation } from './tab-navigation';

--- a/packages/components/src/popover-notice/README.md
+++ b/packages/components/src/popover-notice/README.md
@@ -7,7 +7,6 @@ Component for displaying a popover message on an element
 ```javascript
 import { useRef, useState } from '@wordpress/element';
 import { PopoverNotice } from '@crowdsignal/components';
-import { __ } from '@wordpress/i18n';
 
 const Menu () => {
 	const [ displayNotice, setDisplayNotice ] = useState( false );
@@ -28,9 +27,7 @@ const Menu () => {
 						isVisible={ setActive }
 						position={ 'bottom left' }
 					>
-						{ __(
-							'Your Message Goes Here'
-						) }
+						'Your Message Goes Here'
 					</PopoverNotice>
 		</>
 	);

--- a/packages/components/src/popover-notice/README.md
+++ b/packages/components/src/popover-notice/README.md
@@ -1,0 +1,71 @@
+# Popover Message
+
+Component for displaying a popover message on an element
+
+## Usage
+
+```javascript
+import { useRef, useState } from '@wordpress/element';
+import { PopoverNotice } from '@crowdsignal/components';
+
+const Menu () => {
+	const [ displayNotice, setDisplayNotice ] = useState( false );
+	const ref = noteRef();
+
+	const hideNote = () => setActive( false );
+	const toggleNote = () => setActive( ! active );
+
+	return (
+		<>
+			<button ref={ noteRef } onMouseEnter={ toggleNote } onMouseLeave={ hideNote }>
+				Hover for Message
+			</button>
+
+			<PopoverNotice
+						context={ noteFef }
+						onClose={ hideNote) }
+						isVisible={ setActive }
+						position={ 'bottom left' }
+					>
+						{ __(
+							'Your Message Goes Here'
+						) }
+					</PopoverNotice>
+		</>
+	);
+};
+```
+
+## PopoverNotice
+
+Responsible for displaying the tooltip. Essentially, a styled version of `Popover`.
+
+### Props
+
+**className**: Set a custom className for the main popover container.
+
+- Type: `String|Object`
+- Required: No
+- Default: `''`
+
+**context**: A reference to the element the popover should attach itself to.
+
+- Type: `ref`
+- Required: Yes
+
+**isVisible**: Controls opening and closing of the popover.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+**onClose**: The callback that will be called when the popover should be closed.
+
+- Type: `Function`
+- Required: Yes
+
+**position**: Determines the position of the popover relative to the context element.
+
+- Type: `String` - (`auto`, ``top left`, `top right`, `center left`, `center right`, `bottom left`, `bottom right`)
+- Required: No
+- Default: `bottom left`

--- a/packages/components/src/popover-notice/README.md
+++ b/packages/components/src/popover-notice/README.md
@@ -7,6 +7,7 @@ Component for displaying a popover message on an element
 ```javascript
 import { useRef, useState } from '@wordpress/element';
 import { PopoverNotice } from '@crowdsignal/components';
+import { __ } from '@wordpress/i18n';
 
 const Menu () => {
 	const [ displayNotice, setDisplayNotice ] = useState( false );
@@ -22,7 +23,7 @@ const Menu () => {
 			</button>
 
 			<PopoverNotice
-						context={ noteFef }
+						context={ noteRef }
 						onClose={ hideNote) }
 						isVisible={ setActive }
 						position={ 'bottom left' }

--- a/packages/components/src/popover-notice/index.js
+++ b/packages/components/src/popover-notice/index.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import Popover from '../popover';
+
+/**
+ * Style dependencies
+ */
+import { Wrapper } from './styles';
+
+const PopoverNotice = ( { children, ...popoverProps } ) => (
+	<Popover { ...popoverProps }>
+		<Wrapper>{ children }</Wrapper>
+	</Popover>
+);
+
+export default PopoverNotice;

--- a/packages/components/src/popover-notice/styles.js
+++ b/packages/components/src/popover-notice/styles.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+	font-size: 0.7em;
+	background-color: var( --color-surface );
+	border-color: var( --color-border );
+	border-radius: 5px;
+	border-style: solid;
+	border-width: 1px;
+	box-shadow: 1px 1px 3px 0 var( --color-shadow );
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	padding: 3px 5px 3px;
+	position: relative;
+	width: fit-content;
+	z-index: 100;
+
+	&::before,
+	&::after {
+		border-style: solid;
+		content: '';
+		display: block;
+		height: 0;
+		position: absolute;
+		width: 0;
+		z-index: 1;
+	}
+
+	&::before {
+		border-color: var( --color-border );
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+		border-width: 10px;
+		right: 7px;
+		top: -10px;
+	}
+
+	&::after {
+		border-color: var( --color-surface );
+		border-left-color: transparent;
+		border-right-color: transparent;
+		border-top: none;
+		border-width: 9px;
+		right: 8px;
+		top: -8px;
+	}
+`;

--- a/packages/components/src/popover-notice/styles.js
+++ b/packages/components/src/popover-notice/styles.js
@@ -14,7 +14,7 @@ export const Wrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	margin: 0;
-	padding: 3px 5px 3px;
+	padding: 4px;
 	position: relative;
 	width: fit-content;
 	z-index: 100;

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -52,7 +52,11 @@ export const getPopoverOffset = ( position, popover, context ) => {
 		case 'auto':
 		default:
 			return {
-				right: window.innerWidth - contextBox.left - contextBox.width,
+				right:
+					window.innerWidth -
+					contextBox.left -
+					contextBox.width / 2 -
+					17,
 				top: contextBox.top + contextBox.height + POPOVER_OFFSET,
 			};
 	}

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -56,7 +56,7 @@ export const getPopoverOffset = ( position, popover, context ) => {
 					window.innerWidth -
 					contextBox.left -
 					contextBox.width / 2 -
-					17,
+					17, //add offset to compensate for tooltip arrow position
 				top: contextBox.top + contextBox.height + POPOVER_OFFSET,
 			};
 	}

--- a/packages/components/src/tab-navigation/tab.js
+++ b/packages/components/src/tab-navigation/tab.js
@@ -4,7 +4,18 @@
 import classnames from 'classnames';
 import { forwardRef } from '@wordpress/element';
 
-const Tab = ( { children, href, isSelected, isDisabled, ...props }, ref ) => {
+const Tab = (
+	{
+		children,
+		href,
+		isSelected,
+		isDisabled,
+		onMouseEnter,
+		onMouseLeave,
+		...props
+	},
+	ref
+) => {
 	const ButtonComponent = href ? 'a' : 'button';
 
 	const classes = classnames( 'tab-navigation__item', {
@@ -16,8 +27,8 @@ const Tab = ( { children, href, isSelected, isDisabled, ...props }, ref ) => {
 		<li
 			ref={ ref }
 			className={ classes }
-			onMouseEnter={ () => {} }
-			onMouseLeave={ () => {} }
+			onMouseEnter={ onMouseEnter }
+			onMouseLeave={ onMouseLeave }
 		>
 			<ButtonComponent
 				className="tab-navigation__button"

--- a/packages/components/src/tab-navigation/tab.js
+++ b/packages/components/src/tab-navigation/tab.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { forwardRef } from '@wordpress/element';
 
-const Tab = ( { children, href, isSelected, isDisabled, ...props } ) => {
+const Tab = ( { children, href, isSelected, isDisabled, ...props }, ref ) => {
 	const ButtonComponent = href ? 'a' : 'button';
 
 	const classes = classnames( 'tab-navigation__item', {
@@ -12,7 +13,12 @@ const Tab = ( { children, href, isSelected, isDisabled, ...props } ) => {
 	} );
 
 	return (
-		<li className={ classes }>
+		<li
+			ref={ ref }
+			className={ classes }
+			onMouseEnter={ () => {} }
+			onMouseLeave={ () => {} }
+		>
 			<ButtonComponent
 				className="tab-navigation__button"
 				href={ href }
@@ -24,4 +30,4 @@ const Tab = ( { children, href, isSelected, isDisabled, ...props } ) => {
 	);
 };
 
-export default Tab;
+export default forwardRef( Tab );


### PR DESCRIPTION
This PR adds a "tooltip" style message to the editor when results is hovered over on a project that does not yet have an ID.

As it seems likely we will be adding more tool tips in the future, I added this as a component called popover-notice.

Since the default state of the button is disabled, I had to wrap the notice in a span outside the actual button so the mouse events would fire correctly.

There's also a small tweak made to the util.js for the parent popover component to tweak the alignment of the tool tip as it was a little off with the results button as suggested by @ice9js .

Testing:

Checkout the branch, fire up yarn and head over to https://crowdsignal.localhost:9000/project

Without saving anything, hover over the results tab in the editor and see the pop up message appear.  It will disappear when you move your mouse away from the element. 