### PR TITLE
Only display the inserter on the first page of a new project by default.

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -25,7 +25,7 @@ import { STORE_NAME } from '../../data';
 import { ToolbarButton } from './styles/button';
 import { getTheme } from '../../util/theme/themes';
 
-const DocumentSettings = ( { project, onChangeThemeClick } ) => {
+const DocumentSettings = ( { onChangeThemeClick, project } ) => {
 	const { openGeneralSidebar, setIsInserterOpened } = useDispatch(
 		'isolated/editor'
 	);
@@ -35,19 +35,21 @@ const DocumentSettings = ( { project, onChangeThemeClick } ) => {
 		canPublish,
 		editorTheme,
 		selectedBlockClientId,
+		showInserter,
 	] = useSelect( ( select ) => [
 		select( STORE_NAME ).isEditorContentPublishable(),
 		select( STORE_NAME ).getEditorTheme(),
 		select( 'core/block-editor' ).getSelectedBlockClientId(),
+		select( STORE_NAME ).showInserter(),
 	] );
 
 	useEffect( () => {
-		if ( project.id ) {
+		if ( ! showInserter ) {
 			return;
 		}
 
 		setIsInserterOpened( true );
-	}, [] );
+	}, [ showInserter ] );
 
 	useEffect( () => {
 		openGeneralSidebar(

--- a/apps/dashboard/src/data/editor/reducer.js
+++ b/apps/dashboard/src/data/editor/reducer.js
@@ -187,6 +187,30 @@ const isSaving = ( state = false, action ) => {
 };
 
 /**
+ * Tracks whether the user has interacted with the editor since it was laoded.
+ * Used for triggering behaviors like displaying the inserter for new projects.
+ *
+ * @param  {boolean} state  App state.
+ * @param  {Object}  action Action object.
+ * @return {boolean}         Pristine flag.
+ */
+const isPristine = ( state = false, action ) => {
+	if ( action.type === EDITOR_INIT ) {
+		return true;
+	}
+
+	if (
+		action.type === EDITOR_CURRENT_PAGE_INDEX_SET ||
+		action.type === EDITOR_PAGE_UPDATE ||
+		action.type === EDITOR_SAVE
+	) {
+		return false;
+	}
+
+	return state;
+};
+
+/**
  * Project's pages.
  *
  * @param  {Array}  state  App state.
@@ -300,6 +324,7 @@ export default combineReducers( {
 	edited,
 	error,
 	isSaving,
+	isPristine,
 	pages,
 	projectId,
 	template,

--- a/apps/dashboard/src/data/editor/selectors.js
+++ b/apps/dashboard/src/data/editor/selectors.js
@@ -177,3 +177,12 @@ export const getEditorUpdatedProjectData = ( state, options = {} ) => {
 
 	return data;
 };
+
+/**
+ * Returns whether the inserter should be displayed after the editor (re-)loads.
+ *
+ * @param  {Object}  state App state.
+ * @return {boolean}       Flag signifying if the inserter should be shown.
+ */
+export const showInserter = ( state ) =>
+	getEditorProjectId( state ) === 0 && state.editor.isPristine;


### PR DESCRIPTION
This patch updates the editor so the inserter only appears on the first page of a new project - and only if the user hasn't interacted with the editor yet.  
This addresses the issue where the inserter would also appear after the project saves for the first time, or when switching pages before it has been saved.

It was actually quite tricky to implement, as the `isolated/editor` store only works within the editor. But that means that also whatever component houses the logic for displaying the inserter will be forced to reload whenever the editor reloads (saving/switching pages).  
So in the end I needed to employ our editor state to solve this issue. Consider this an immediate fix, while we can still fine tune the behavior a little later - in terms of when we actually want it to appear.

Solves c/Yw2FLCeX-tr.

# Testing

- Start a new project, the inserter should appear by default.
- Switch pages, the inserter should no longer appear.
- Save the project, the inserter should no longer appear.
