### PR TITLE
Add/edit button for editable page header

### DIFF
--- a/packages/components/src/editable-page-header/README.md
+++ b/packages/components/src/editable-page-header/README.md
@@ -1,6 +1,6 @@
 # Editable Page Header
 
-Renders a page header which can be edited in place.
+Renders a page header that can be edited in place.
 
 ## Usage
 

--- a/packages/components/src/editable-page-header/README.md
+++ b/packages/components/src/editable-page-header/README.md
@@ -1,6 +1,6 @@
 # Editable Page Header
 
-Renders a page header that can be edited in place.
+Renders a page header which can be edited in place.
 
 ## Usage
 

--- a/packages/components/src/editable-page-header/index.js
+++ b/packages/components/src/editable-page-header/index.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import PageHeader from '../page-header';
+import Button from '../button';
 import Form from './form';
 
 /**
@@ -29,24 +30,39 @@ const EditablePageHeader = ( { onChange, text, disabled } ) => {
 	};
 	const hideForm = () => setActive( false );
 
+	const [ showButton, setShowButton ] = useState( false );
+
 	const classes = classnames( 'editable-page-header', {
 		'is-disabled': disabled,
 	} );
 
 	return (
-		<div className={ classes }>
-			{ ! active && (
-				<PageHeader onClick={ showForm }>{ text }</PageHeader>
-			) }
-
-			{ active && (
-				<Form
-					value={ text }
-					onChange={ onChange }
-					onCancel={ hideForm }
-				/>
-			) }
-		</div>
+		<>
+			<div
+				className={ classes }
+				onMouseEnter={ () => setShowButton( true ) }
+				onMouseLeave={ () => setShowButton( false ) }
+			>
+				{ ! active && (
+					<PageHeader onClick={ showForm }>{ text }</PageHeader>
+				) }
+				{ ! active && showButton && (
+					<Button
+						className="editable-page-header__button"
+						onClick={ showForm }
+					>
+						Edit
+					</Button>
+				) }
+				{ active && (
+					<Form
+						value={ text }
+						onChange={ onChange }
+						onCancel={ hideForm }
+					/>
+				) }
+			</div>
+		</>
 	);
 };
 

--- a/packages/components/src/editable-page-header/index.js
+++ b/packages/components/src/editable-page-header/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ const EditablePageHeader = ( { onChange, text, disabled } ) => {
 						className="editable-page-header__button"
 						onClick={ showForm }
 					>
-						__( { ( 'Edit', 'dashboard' ) } )
+						{ __( 'Edit', 'dashboard' ) }
 					</Button>
 				) }
 				{ active && (

--- a/packages/components/src/editable-page-header/index.js
+++ b/packages/components/src/editable-page-header/index.js
@@ -51,7 +51,7 @@ const EditablePageHeader = ( { onChange, text, disabled } ) => {
 						className="editable-page-header__button"
 						onClick={ showForm }
 					>
-						Edit
+						__( { ( 'Edit', 'dashboard' ) } )
 					</Button>
 				) }
 				{ active && (

--- a/packages/components/src/editable-page-header/style.scss
+++ b/packages/components/src/editable-page-header/style.scss
@@ -6,6 +6,7 @@
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
+
 }
 
 .editable-page-header__form {
@@ -27,4 +28,8 @@
 		padding: 0;
 		width: 100%;
 	}
+}
+
+.editable-page-header__button {
+	margin-left: 8px;
 }


### PR DESCRIPTION
As per c/e3VMFofI-tr this PR adds a (fully working!) edit button when the editable page header div is moused over.  The button hides when the mouse leaves the div or the button is clicked.

We decided to leave the click to edit functionality of the header itself just because, but it would be easy enough to take out if necessary.

Testing:

Check out the branch, go to the localhost project editor.  Hover over the title and note the button's appearance.  
Move the mouse away and make sure the button disappears.
Mouse back and click the button.
Verify you can now edit the header and the button is not displayed. (the text should be highlighted).  

