### PR TITLE
Add an editor welcome guide

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -170,7 +170,7 @@ const Editor = ( { project } ) => {
 				/>
 			</EditorWrapper>
 
-			{ showEditorGuide && (
+			{ ! showWizard && showEditorGuide && (
 				<EditorGuide onFinish={ handleCloseWelcomeGuide } />
 			) }
 			{ ! showEditorGuide && <EditorFeedbackButton /> }

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -18,6 +18,7 @@ import { useEditorContent } from './use-editor-content';
 import AutoSubmitButton from './auto-submit-button';
 import DocumentSettings from './document-settings';
 import EditorFeedbackButton from './feedback-button';
+import EditorGuide from './guide';
 import EditorNotice from './notice';
 import EditorStylesResolver from './styles-resolver';
 import HeaderMeta from '../header-meta';
@@ -43,6 +44,10 @@ const Editor = ( { project } ) => {
 	const [ showWizard, setShowWizard ] = useState( ! project.id );
 	const [ showThemesModal, setShowThemesModal ] = useState( false );
 	const [ showShareModal, setShowShareModal ] = useState( false );
+
+	const [ showEditorGuide, setShowEditorGuide ] = useState(
+		document.cookie.indexOf( 'hide_editor_guide=1;' ) === -1
+	);
 
 	const { updateEditorTitle } = useDispatch( STORE_NAME );
 
@@ -79,6 +84,15 @@ const Editor = ( { project } ) => {
 
 	const handleToggleShareModal = () => {
 		setShowShareModal( ! showShareModal );
+	};
+
+	const handleCloseWelcomeGuide = () => {
+		const expirationDate = new Date(
+			new Date().getTime() + 356 * 24 * 60 * 60 * 1000
+		).toGMTString();
+		document.cookie = `hide_editor_guide=1; expires=${ expirationDate }`;
+
+		setShowEditorGuide( false );
 	};
 
 	const settings = useMemo( () => {
@@ -156,7 +170,10 @@ const Editor = ( { project } ) => {
 				/>
 			</EditorWrapper>
 
-			<EditorFeedbackButton />
+			{ showEditorGuide && (
+				<EditorGuide onFinish={ handleCloseWelcomeGuide } />
+			) }
+			{ ! showEditorGuide && <EditorFeedbackButton /> }
 		</EditorLayout>
 	);
 };

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -46,7 +46,7 @@ const Editor = ( { project } ) => {
 	const [ showShareModal, setShowShareModal ] = useState( false );
 
 	const [ showEditorGuide, setShowEditorGuide ] = useState(
-		document.cookie.indexOf( 'hide_editor_guide=1;' ) === -1
+		document.cookie.indexOf( 'hide_editor_guide=1' ) === -1
 	);
 
 	const { updateEditorTitle } = useDispatch( STORE_NAME );

--- a/apps/dashboard/src/components/editor/guide.js
+++ b/apps/dashboard/src/components/editor/guide.js
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { Guide } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../../data';
+import { trackEvent } from '../../util/tracking';
+
+/**
+ * Style dependencies
+ */
+import {
+	EditorGuideHeading,
+	EditorGuidePageContent,
+	EditorGuideText,
+	EditorGuideWrapper,
+} from './styles/guide';
+
+const EditorGuide = ( { onFinish } ) => {
+	const currentUser = useSelect( ( select ) =>
+		select( STORE_NAME ).getCurrentUser()
+	);
+
+	useEffect( () => {
+		if ( ! currentUser ) {
+			return;
+		}
+
+		trackEvent( currentUser, 'crowdsignal_project_editor_guide_view', {} );
+	}, [ currentUser && currentUser.userId ] );
+
+	return (
+		<EditorGuideWrapper
+			as={ Guide }
+			onFinish={ onFinish }
+			pages={ [
+				{
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-welcome.png"
+							alt={ __(
+								'Welcome to the new Crowdsignal',
+								'dashboard'
+							) }
+						/>
+					),
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __(
+									'Welcome to the new Crowdsignal!',
+									'dashboard'
+								) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Take this showrt, interactive tour to lear the basics of the new Crowdsignal editor.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					image: (
+						<img
+							src="https://s0.wp.com/i/editor-welcome-tour/slide-all-blocks.gif"
+							alt={ __( 'Everything is a block', 'dashboard' ) }
+						/>
+					),
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __( 'Everything is a block', 'dashboard' ) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'In the Crowdsignal Editor, questions, from fields, images, and videos are all blocks.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-add_a_block.gif"
+							alt={ __( 'Adding a new block', 'dashboard' ) }
+						/>
+					),
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __( 'Adding a new block', 'dashboard' ) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Click + to open the inserter. Then click the block you want to add, like a question block.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					image: (
+						<img
+							src="https://s0.wp.com/i/editor-welcome-tour/slide-make-bold.gif"
+							alt={ __(
+								'Click a block to change it',
+								'dashboard'
+							) }
+						/>
+					),
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __(
+									'Click a block to change it',
+									'dashboard'
+								) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Use the toolbar to change the appearance of the selected block. Try making it bold.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-reordering.gif"
+							alt={ __(
+								'Add and reorder pages as you like',
+								'dashboard'
+							) }
+						/>
+					),
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __(
+									'Add and reorder pages as you like',
+									'dashboard'
+								) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Just make sure every page has at least one submit button, which you can relabel.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					// image: <img src="" />,
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __( 'Change the theme design', 'dashboard' ) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Choose one of several themes using the right sidebar, to make the page yours.',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					// image: <img src="" />,
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __(
+									'Publish & share your project',
+									'dashboard'
+								) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									'Publish your project and share the link to collect responses!',
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+				{
+					// image: <img src="" />,
+					content: (
+						<EditorGuidePageContent>
+							<EditorGuideHeading>
+								{ __( 'Congratulations!', 'dashboard' ) }
+							</EditorGuideHeading>
+							<EditorGuideText>
+								{ __(
+									`You've learned the basics of the new editor. Now it's time to watch responses coming in on your results page.`,
+									'dashboard'
+								) }
+							</EditorGuideText>
+						</EditorGuidePageContent>
+					),
+				},
+			] }
+		/>
+	);
+};
+
+export default EditorGuide;

--- a/apps/dashboard/src/components/editor/guide.js
+++ b/apps/dashboard/src/components/editor/guide.js
@@ -40,7 +40,7 @@ const EditorGuide = ( { onFinish } ) => {
 						<img
 							src="https://app.crowdsignal.com/images/guide/onboarding-welcome.png"
 							alt={ __(
-								'Welcome to the new Crowdsignal',
+								'Welcome to the new Crowdsignal editor!',
 								'dashboard'
 							) }
 						/>
@@ -49,13 +49,13 @@ const EditorGuide = ( { onFinish } ) => {
 						<>
 							<Guide.Header>
 								{ __(
-									'Welcome to the new Crowdsignal!',
+									'Welcome to the new Crowdsignal editor!',
 									'dashboard'
 								) }
 							</Guide.Header>
 							<Guide.Text>
 								{ __(
-									'Take this showrt, interactive tour to lear the basics of the new Crowdsignal editor.',
+									'Take this short, interactive tour to learn the basics of the new Crowdsignal editor.',
 									'dashboard'
 								) }
 							</Guide.Text>

--- a/apps/dashboard/src/components/editor/guide.js
+++ b/apps/dashboard/src/components/editor/guide.js
@@ -2,25 +2,20 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { Guide } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { Guide } from '@crowdsignal/components';
 import { STORE_NAME } from '../../data';
 import { trackEvent } from '../../util/tracking';
 
 /**
  * Style dependencies
  */
-import {
-	EditorGuideHeading,
-	EditorGuidePageContent,
-	EditorGuideText,
-	EditorGuideWrapper,
-} from './styles/guide';
+import { EditorGuideWrapper } from './styles/guide';
 
 const EditorGuide = ( { onFinish } ) => {
 	const currentUser = useSelect( ( select ) =>
@@ -51,20 +46,20 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __(
 									'Welcome to the new Crowdsignal!',
 									'dashboard'
 								) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Take this showrt, interactive tour to lear the basics of the new Crowdsignal editor.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -75,17 +70,17 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __( 'Everything is a block', 'dashboard' ) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'In the Crowdsignal Editor, questions, from fields, images, and videos are all blocks.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -96,17 +91,17 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __( 'Adding a new block', 'dashboard' ) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Click + to open the inserter. Then click the block you want to add, like a question block.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -120,20 +115,20 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __(
 									'Click a block to change it',
 									'dashboard'
 								) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Use the toolbar to change the appearance of the selected block. Try making it bold.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -147,20 +142,20 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __(
 									'Add and reorder pages as you like',
 									'dashboard'
 								) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Just make sure every page has at least one submit button, which you can relabel.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -171,17 +166,17 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __( 'Change the theme design', 'dashboard' ) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Choose one of several themes using the right sidebar, to make the page yours.',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -195,20 +190,20 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __(
 									'Publish & share your project',
 									'dashboard'
 								) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									'Publish your project and share the link to collect responses!',
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 				{
@@ -219,17 +214,17 @@ const EditorGuide = ( { onFinish } ) => {
 						/>
 					),
 					content: (
-						<EditorGuidePageContent>
-							<EditorGuideHeading>
+						<>
+							<Guide.Header>
 								{ __( 'Congratulations!', 'dashboard' ) }
-							</EditorGuideHeading>
-							<EditorGuideText>
+							</Guide.Header>
+							<Guide.Text>
 								{ __(
 									`You've learned the basics of the new editor. Now it's time to watch responses coming in on your results page.`,
 									'dashboard'
 								) }
-							</EditorGuideText>
-						</EditorGuidePageContent>
+							</Guide.Text>
+						</>
 					),
 				},
 			] }

--- a/apps/dashboard/src/components/editor/guide.js
+++ b/apps/dashboard/src/components/editor/guide.js
@@ -164,7 +164,12 @@ const EditorGuide = ( { onFinish } ) => {
 					),
 				},
 				{
-					// image: <img src="" />,
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-change_theme.png"
+							alt={ __( 'Change the theme design', 'dashboard' ) }
+						/>
+					),
 					content: (
 						<EditorGuidePageContent>
 							<EditorGuideHeading>
@@ -180,7 +185,15 @@ const EditorGuide = ( { onFinish } ) => {
 					),
 				},
 				{
-					// image: <img src="" />,
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-publish_share.png"
+							alt={ __(
+								'Publish & share your project',
+								'dashboard'
+							) }
+						/>
+					),
 					content: (
 						<EditorGuidePageContent>
 							<EditorGuideHeading>
@@ -199,7 +212,12 @@ const EditorGuide = ( { onFinish } ) => {
 					),
 				},
 				{
-					// image: <img src="" />,
+					image: (
+						<img
+							src="https://app.crowdsignal.com/images/guide/onboarding-finished.png"
+							alt={ __( 'Guide finished', 'dashboard' ) }
+						/>
+					),
 					content: (
 						<EditorGuidePageContent>
 							<EditorGuideHeading>

--- a/apps/dashboard/src/components/editor/styles/guide.js
+++ b/apps/dashboard/src/components/editor/styles/guide.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const EditorGuideWrapper = styled.div`
+	&&& {
+		max-width: 345px;
+		position: absolute;
+		bottom: 20px;
+		left: 20px;
+		max-height: 475px;
+	}
+
+	.components-guide__page-control {
+		.components-button {
+			border: 0 !important;
+			box-shadow: none !important;
+			outline: 0 !important;
+		}
+
+		li[aria-current='step'] svg circle {
+			fill: var( --color-primary );
+		}
+	}
+
+	.components-guide__footer {
+		height: 40px;
+
+		.components-button {
+			border: 0 !important;
+			box-shadow: none !important;
+			outline: 0 !important;
+
+			&:hover {
+				border: 0;
+				color: var( --color-primary );
+			}
+		}
+
+		.components-button.components-guide__forward-button {
+			background-color: var( --color-primary );
+			box-shadow: 0;
+			color: var( --color-text-inverted );
+			display: inline-block;
+			height: 40px;
+			padding: 12px 16px;
+			text-align: center;
+			width: 80px;
+
+			&:hover {
+				background-color: var( --color-primary-60 );
+				color: var( --color-text-inverted );
+				text-decoration: none;
+			}
+		}
+	}
+`;
+
+export const EditorGuidePageContent = styled.div`
+	padding: 32px;
+`;
+
+export const EditorGuideHeading = styled.h2`
+	font-weight: 600;
+	font-size: 18px;
+	line-height: 24px;
+	margin-bottom: 4px;
+`;
+
+export const EditorGuideText = styled.p`
+	font-size: 14px;
+	line-height: 24px;
+`;

--- a/apps/dashboard/src/components/editor/styles/guide.js
+++ b/apps/dashboard/src/components/editor/styles/guide.js
@@ -38,7 +38,8 @@ export const EditorGuideWrapper = styled.div`
 			}
 		}
 
-		.components-button.components-guide__forward-button {
+		.components-button.components-guide__forward-button,
+		.components-button.components-guide__finish-button {
 			background-color: var( --color-primary );
 			box-shadow: 0;
 			color: var( --color-text-inverted );

--- a/apps/dashboard/src/components/editor/styles/guide.js
+++ b/apps/dashboard/src/components/editor/styles/guide.js
@@ -4,72 +4,9 @@
 import styled from '@emotion/styled';
 
 export const EditorGuideWrapper = styled.div`
-	&&& {
-		max-width: 345px;
-		position: absolute;
-		bottom: 20px;
-		left: 20px;
-		max-height: 475px;
-	}
-
-	.components-guide__page-control {
-		.components-button {
-			border: 0 !important;
-			box-shadow: none !important;
-			outline: 0 !important;
-		}
-
-		li[aria-current='step'] svg circle {
-			fill: var( --color-primary );
-		}
-	}
-
-	.components-guide__footer {
-		height: 40px;
-
-		.components-button {
-			border: 0 !important;
-			box-shadow: none !important;
-			outline: 0 !important;
-
-			&:hover {
-				border: 0;
-				color: var( --color-primary );
-			}
-		}
-
-		.components-button.components-guide__forward-button,
-		.components-button.components-guide__finish-button {
-			background-color: var( --color-primary );
-			box-shadow: 0;
-			color: var( --color-text-inverted );
-			display: inline-block;
-			height: 40px;
-			padding: 12px 16px;
-			text-align: center;
-			width: 80px;
-
-			&:hover {
-				background-color: var( --color-primary-60 );
-				color: var( --color-text-inverted );
-				text-decoration: none;
-			}
-		}
-	}
-`;
-
-export const EditorGuidePageContent = styled.div`
-	padding: 32px;
-`;
-
-export const EditorGuideHeading = styled.h2`
-	font-weight: 600;
-	font-size: 18px;
-	line-height: 24px;
-	margin-bottom: 4px;
-`;
-
-export const EditorGuideText = styled.p`
-	font-size: 14px;
-	line-height: 24px;
+	height: 470px;
+	max-width: 345px;
+	position: absolute;
+	left: 20px;
+	bottom: 20px;
 `;

--- a/apps/dashboard/src/components/modal/index.js
+++ b/apps/dashboard/src/components/modal/index.js
@@ -20,7 +20,7 @@ export const ModalWrapper = styled.div`
 	left: 0;
 	right: 0;
 	top: 0;
-	z-index: 1000;
+	z-index: 100010;
 `;
 
 export const ModalDialog = styled.div`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,6 +22,7 @@
     "@wordpress/compose": "^5.4.0",
     "@wordpress/element": "^4.4.0",
     "@wordpress/i18n": "^4.6.0",
+    "@wordpress/icons": "^8.2.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.21"
   },

--- a/packages/components/src/dialog/index.js
+++ b/packages/components/src/dialog/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { useBlur } from '@crowdsignal/hooks';
+import RootChild from '../root-child';
+
+/**
+ * Style dependencies
+ */
+import { DialogWrapper, DialogOverlay } from './styles.js';
+
+const Dialog = ( { className, children, onRequestClose } ) => {
+	const dialog = useRef();
+
+	useBlur( onRequestClose || noop, [ dialog ] );
+
+	return (
+		<RootChild>
+			<DialogOverlay>
+				<DialogWrapper ref={ dialog } className={ className }>
+					{ children }
+				</DialogWrapper>
+			</DialogOverlay>
+		</RootChild>
+	);
+};
+
+export default Dialog;

--- a/packages/components/src/dialog/styles.js
+++ b/packages/components/src/dialog/styles.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const DialogOverlay = styled.div`
+	align-items: center;
+	background-color: var( --color-backdrop );
+	box-sizing: border-box;
+	display: flex;
+	justify-content: center;
+	padding: 100px;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	top: 0;
+	z-index: 1000000;
+`;
+
+export const DialogWrapper = styled.div`
+	background-color: var( --color-surface );
+	box-shadow: 5px 5px 15px var( --color-shadow );
+	box-sizing: border-box;
+	color: var( --color-text );
+	display: flex;
+	flex-direction: column;
+	position: relative;
+`;

--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+import Dialog from '../dialog';
+import PageNavigation from './page-navigation';
+
+/**
+ * Style dependencies
+ */
+import {
+	GuidePage,
+	GuideWrapper,
+	PageHeader,
+	PageContent,
+	PageText,
+	GuideFooter,
+} from './styles';
+
+const Guide = ( { className, onFinish, pages } ) => {
+	const [ currentPage, setCurrentPage ] = useState( 0 );
+
+	return (
+		<GuideWrapper as={ Dialog } className={ className }>
+			<GuidePage>
+				{ pages[ currentPage ].image }
+
+				{ pages[ currentPage ].header && (
+					<PageHeader>pages[ currentPage ].header</PageHeader>
+				) }
+
+				<PageContent>{ pages[ currentPage ].content }</PageContent>
+			</GuidePage>
+
+			<GuideFooter>
+				<PageNavigation
+					currentPage={ currentPage }
+					onSelect={ setCurrentPage }
+					pageCount={ pages.length }
+				/>
+
+				{ currentPage > 0 && (
+					<Button
+						borderless
+						onClick={ () => setCurrentPage( currentPage - 1 ) }
+					>
+						{ __( 'Previous', 'components' ) }
+					</Button>
+				) }
+
+				{ currentPage < pages.length - 1 && (
+					<Button
+						primary
+						onClick={ () => setCurrentPage( currentPage + 1 ) }
+					>
+						{ __( 'Next', 'components' ) }
+					</Button>
+				) }
+
+				{ currentPage === pages.length - 1 && (
+					<Button primary onClick={ onFinish }>
+						{ __( 'Finish', 'components' ) }
+					</Button>
+				) }
+			</GuideFooter>
+		</GuideWrapper>
+	);
+};
+
+Guide.Header = PageHeader;
+Guide.Text = PageText;
+
+export default Guide;

--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -3,6 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Icon, close } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import PageNavigation from './page-navigation';
  * Style dependencies
  */
 import {
+	GuideCloseButton,
 	GuidePage,
 	GuideWrapper,
 	PageHeader,
@@ -28,6 +30,10 @@ const Guide = ( { className, onFinish, pages } ) => {
 
 	return (
 		<GuideWrapper as={ Dialog } className={ className }>
+			<GuideCloseButton onClick={ onFinish }>
+				<Icon icon={ close } />
+			</GuideCloseButton>
+
 			<GuidePage>
 				{ pages[ currentPage ].image }
 

--- a/packages/components/src/guide/page-navigation.js
+++ b/packages/components/src/guide/page-navigation.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
+/**
+ * Style dependencies
+ */
+import { PageIndicatorButton, PageNavigationWrapper } from './styles';
+
+const PageNavigation = ( { currentPage, onSelect, pageCount } ) => (
+	<PageNavigationWrapper>
+		{ times( pageCount, ( pageNumber ) => (
+			<PageIndicatorButton
+				className={ currentPage === pageNumber ? 'is-active' : '' }
+				key={ pageNumber }
+				onClick={ () => onSelect( pageNumber ) }
+			>
+				<svg
+					width={ 8 }
+					height={ 8 }
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<circle cx={ 4 } cy={ 4 } r={ 4 } />
+				</svg>
+			</PageIndicatorButton>
+		) ) }
+	</PageNavigationWrapper>
+);
+
+export default PageNavigation;

--- a/packages/components/src/guide/styles.js
+++ b/packages/components/src/guide/styles.js
@@ -6,6 +6,24 @@ import styled from '@emotion/styled';
 export const GuideWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+	position: relative;
+`;
+
+export const GuideCloseButton = styled.button`
+	background-color: var( --color-surface );
+	border: 0;
+	box-sizing: border-box;
+	height: 32px;
+	padding: 4px;
+	opacity: 0.3;
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 32px;
+
+	&:hover {
+		opacity: 1;
+	}
 `;
 
 export const GuidePage = styled.div`

--- a/packages/components/src/guide/styles.js
+++ b/packages/components/src/guide/styles.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const GuideWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+export const GuidePage = styled.div`
+	flex: 1;
+
+	img {
+		width: 100%;
+	}
+`;
+
+export const PageHeader = styled.h2`
+	font-weight: 600;
+	font-size: 18px;
+	line-height: 24px;
+	margin-bottom: 4px;
+`;
+
+export const PageContent = styled.div`
+	padding: 0 32px;
+`;
+
+export const PageText = styled.p`
+	font-size: 14px;
+	line-height: 24px;
+`;
+
+export const GuideFooter = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	padding: 32px;
+`;
+
+export const PageNavigationWrapper = styled.div`
+	align-items: center;
+	display: flex;
+	flex: 1;
+`;
+
+export const PageIndicatorButton = styled.button`
+	align-items: center;
+	background-color: transparent;
+	border: 0;
+	display: flex;
+	height: 16px;
+	justify-content: center;
+	margin: 0;
+	padding: 0;
+	width: 16px;
+
+	> svg {
+		fill: var( --color-neutral-5 );
+	}
+
+	&:hover > svg {
+		fill: var( --color-nautral-light );
+	}
+
+	&.is-active > svg {
+		fill: var( --color-primary );
+	}
+`;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -7,6 +7,7 @@ export { default as FormFieldset } from './form/form-fieldset';
 export { default as FormLabel } from './form/form-label';
 export { default as FormSettingExplanation } from './form/form-setting-explanation';
 export { default as FormTextInput } from './form-text-input';
+export { default as Guide } from './guide';
 export { default as PageHeader } from './page-header';
 export { default as Popover } from './popover';
 export { default as PopoverMenu } from './popover-menu';

--- a/packages/components/src/root-child/index.js
+++ b/packages/components/src/root-child/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { createPortal, useEffect, useRef } from '@wordpress/element';
+
+const RootChild = ( { children } ) => {
+	const container = useRef( document.createElement( 'div' ) );
+
+	useEffect( () => {
+		const element = container.current;
+
+		document.body.appendChild( element );
+
+		return () => document.body.removeChild( element );
+	}, [] );
+
+	return createPortal( children, container.current );
+};
+
+export default RootChild;


### PR DESCRIPTION
This patch adds a welcome guide to the editor. The guide is shown when a user opens up the editor for the first time - once dismissed, it won't be shown again.  
When the guide is displayed it also fires a `crowdsignal_project_editor_guide_view` event.

The guide appears in the lower left corner of the window. The feedback button is also hidden while the guide is active.

![Screen Shot 2022-04-29 at 11 50 51 AM](https://user-images.githubusercontent.com/8056203/165929111-15759850-0287-4dbe-8e28-33134c9be683.png)

Solves c/WBvcw8eo-tr.

Note, some images are still missing.

# Testing

- Verify that the guide is shown when you first open up the editor.
- Dismiss the guide and reload the page.
- The guide should no longer be shown.

For testing, if you want to reset the guide, delete the `hide_editor_guide` cookie.