### PR TITLE
Fix styles inside Cover blocks

### DIFF
--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -164,3 +164,7 @@ body {
 		}
 	}
 }
+
+.wp-block-cover:not(.is-light) {
+	color: var(--wp--preset--color--background);
+}

--- a/packages/theme-compatibility/src/blockbase/base.scss
+++ b/packages/theme-compatibility/src/blockbase/base.scss
@@ -6,4 +6,6 @@
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
 	border-radius: var(--wp--custom--form--border--radius);
 	box-shadow: var(--wp--custom--form--color--box-shadow);
+	color: var(--wp--preset--color--foreground);
+	background-color: var(--wp--preset--color--background);
 }

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -31,6 +31,12 @@ body {
 .crowdsignal-forms-question-wrapper {
 	border-color: var(--crowdsignal-forms-question-border-color);
 	background-color: var(--crowdsignal-forms-question-background-color);
+
+	.wp-block-cover & {
+		h3:not(.has-text-color) {
+			color: var( --color-text );
+		}
+	}
 }
 
 .crowdsignal-forms-submit-button-block .crowdsignal-forms-button__button {

--- a/packages/theme-compatibility/src/quadrat/base.scss
+++ b/packages/theme-compatibility/src/quadrat/base.scss
@@ -21,3 +21,8 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 	--wp--custom--form--padding: 14px 7px;
 }
+
+.crowdsignal-forms-question-wrapper {
+	color: var(--wp--custom--color--foreground);
+	background-color: var(--wp--custom--color--background);
+}

--- a/packages/theme-compatibility/src/twentynineteen/base.scss
+++ b/packages/theme-compatibility/src/twentynineteen/base.scss
@@ -6,6 +6,8 @@
 
 body {
 	--wp--preset--color--primary: #0073aa;
+	--wp--preset--color--background: #fff;
+	--color-text: #111;
 }
 
 .crowdsignal-forms-form {
@@ -18,8 +20,14 @@ body {
 	}
 }
 
-input, .crowdsignal-forms-question-wrapper {
+input {
 	border: 1px solid #CCC;
+}
+
+.crowdsignal-forms-question-wrapper {
+	border: 1px solid #CCC;
+	background-color: var(--wp--preset--color--background);
+	color: var(--color-text);
 }
 
 button, input, select, optgroup, textarea {
@@ -32,7 +40,7 @@ button, input, select, optgroup, textarea {
 	}
 
 	&:not(.is-style-outline) .wp-block-button__link {
-		background: #0073aa;
+		background: var(--wp--preset--color--primary);
 	}
 
 	.wp-block-button__link {
@@ -43,12 +51,12 @@ button, input, select, optgroup, textarea {
 
 		&:hover {
 			color: white;
-			background: #111;
+			background: var(--color-text);
 			cursor: pointer;
 		}
 
 		&:not(.has-text-color) {
-			color: #fff;
+			color: var(--wp--preset--color--background);
 		}
 	}
 }

--- a/packages/theme-compatibility/src/twentytwentytwo/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo/base.scss
@@ -24,4 +24,6 @@ body {
 
 .crowdsignal-forms-question-wrapper {
 	border-radius: 0;
+	color: var(--wp--preset--color--foreground);
+	background-color: var(--wp--preset--color--background);
 }


### PR DESCRIPTION
This PR will give our blocks wrapper background/foreground colors so it remains consistent even on unexpected backgrounds (ie Cover block)

## Test instructions
Place any of our question blocks (not inputs) inside a cover block. Try using different backgrounds on the cover block.
Our blocks should retain the background/foreground colors.

NOTE:  we've left our inputs (text, email, URL) aside of this change due to the "inline" look'n feel those provide, hence, styled as any other text inside the Cover block. 