### PR TITLE
Fix last published theme issue

### DIFF
--- a/apps/dashboard/src/data/ui/reducer.js
+++ b/apps/dashboard/src/data/ui/reducer.js
@@ -43,7 +43,10 @@ const notices = ( state = {}, action ) => {
 };
 
 const lastPublishedTheme = ( state = 'leven', action ) => {
-	if ( action.type === LAST_PUBLISHED_THEME_UPDATE ) {
+	if (
+		action.type === LAST_PUBLISHED_THEME_UPDATE &&
+		action.lastPublishedTheme
+	) {
 		return action.lastPublishedTheme;
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where the editor doesn't load correctly for users without the `last_published_theme` meta in their accounts.

## Test Instructions

Checkout this branch and open the project creation page logged with a user without the `last_published_theme` meta in their account.
You can check user meta here: https://app.crowdsignal.com/admin/view-account.php?u=[user_id]