### PR TITLE
Add new project templates

### DIFF
--- a/apps/dashboard/src/components/modal/index.js
+++ b/apps/dashboard/src/components/modal/index.js
@@ -70,7 +70,7 @@ export const ModalTemplateGrid = styled.div`
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-gap: 24px;
-	overflow-y: scroll;
+	overflow-y: auto;
 `;
 
 const CloseButton = styled.button`

--- a/apps/dashboard/src/components/modal/index.js
+++ b/apps/dashboard/src/components/modal/index.js
@@ -70,6 +70,7 @@ export const ModalTemplateGrid = styled.div`
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;
 	grid-gap: 24px;
+	overflow-y: scroll;
 `;
 
 const CloseButton = styled.button`

--- a/apps/dashboard/src/components/new-project-wizard/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/index.js
@@ -22,7 +22,11 @@ import * as projectTemplates from './templates';
 /**
  * Style dependencies
  */
-import { BackButton, ProjectWizardDialog } from './styles';
+import {
+	BackButton,
+	ProjectWizardDialog,
+	ProjectWizardContent,
+} from './styles';
 
 const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 	const editorTheme = useSelect( ( select ) =>
@@ -39,7 +43,7 @@ const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 				<div>
 					<ActiveTheme onChangeThemeClick={ onChangeThemeClick } />
 				</div>
-				<div>
+				<ProjectWizardContent>
 					<ModalHeader>
 						{ __(
 							'What would you like to build today?',
@@ -62,7 +66,7 @@ const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 							/>
 						) ) }
 					</ModalTemplateGrid>
-				</div>
+				</ProjectWizardContent>
 			</ProjectWizardDialog>
 		</ModalWrapper>
 	);

--- a/apps/dashboard/src/components/new-project-wizard/styles/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/index.js
@@ -16,6 +16,13 @@ export const ProjectWizardDialog = styled( ModalDialog )`
 	padding: 72px 60px;
 	flex-direction: row;
 	align-items: flex-end;
+	height: 100%;
+`;
+
+export const ProjectWizardContent = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 `;
 
 export const BackButton = styled.a`

--- a/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
@@ -17,11 +17,22 @@ export const TemplatePreviewFrame = styled.button`
 	border-radius: 2px;
 	box-sizing: border-box;
 	cursor: pointer;
-	height: 250px;
 	margin-bottom: 16px;
+	padding: 0;
 	position: relative;
 	overflow: hidden;
 	width: 100%;
+
+	&::before {
+		content: '';
+		display: block;
+		float: left;
+		padding: 67% 0 0;
+	}
+
+	.block-editor-block-preview__container {
+		position: absolute;
+	}
 
 	.block-editor-block-preview__content > iframe {
 		border: 0;

--- a/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
@@ -45,11 +45,14 @@ export const TemplatePreviewName = styled.h3`
 	font-size: 16px;
 	font-family: inherit;
 	font-weight: bold;
+	line-height: 1.5em;
+	margin-top: 0;
 	margin-bottom: 8px;
 `;
 
 export const TemplatePreviewDescription = styled.p`
 	color: var( --color-text-subtle );
 	font-size: 16px;
+	line-height: 1.5em;
 	margin: 0;
 `;

--- a/apps/dashboard/src/components/new-project-wizard/templates/blank.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/blank.js
@@ -24,6 +24,7 @@ const BlankProjectStartButton = styled.div`
 	box-sizing: border-box;
 	background-color: var( --color-surface );
 	padding: 8px 32px;
+	margin: 0 8px;
 `;
 
 export const blankProjectTemplate = createTemplate(

--- a/apps/dashboard/src/components/new-project-wizard/templates/customer-satisfaction.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/customer-satisfaction.js
@@ -1,0 +1,415 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplate } from './create-template';
+
+export const customerSatisfactionTemplate = createTemplate(
+	__( 'Customer Feedback', 'dashboard' ),
+	__( 'Description' ),
+	[
+		[
+			{
+				name: 'core/columns',
+				attributes: {
+					isStackedOnMobile: true,
+					align: 'full',
+				},
+				innerBlocks: [
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name: 'core/cover',
+								attributes: {
+									url:
+										'https://i0.wp.com/files.polldaddy.com/742e7093bacec71efc7e6c5e5dead5b7-627a6f4966bf2.png',
+									alt: 'Ice 4 Template Image',
+									hasParallax: false,
+									isRepeated: false,
+									dimRatio: 0,
+									backgroundType: 'image',
+									minHeight: 100,
+									minHeightUnit: 'vh',
+									isDark: false,
+									style: {
+										color: [],
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											content: ' ',
+											dropCap: false,
+											fontSize: 'large',
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-question',
+								attributes: {
+									question:
+										'Overall, how satisfied are you with ACME Ice Cream?',
+									mandatory: false,
+									allowOther: false,
+									minimumChoices: 0,
+									maximumChoices: 1,
+									borderRadius: 5,
+									boxShadow: false,
+									borderWidth: 1,
+									className: 'is-style-button',
+								},
+								innerBlocks: [
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Very Satisfied',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Somewhat Satisfied',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label:
+												'Neither satisfied nor unsatisfied',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Somewhat Unsatisfied',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Very Unsatisfied',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+							{
+								name: 'crowdsignal-forms/submit-button',
+								attributes: {
+									label: 'Next',
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'core/columns',
+				attributes: {
+					isStackedOnMobile: true,
+					align: 'full',
+				},
+				innerBlocks: [
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name: 'crowdsignal-forms/text-question',
+								attributes: {
+									restrictions: [],
+									question: 'Tell us a bit more about why',
+									note: '',
+									placeholder: '',
+									mandatory: false,
+									borderRadius: 5,
+									boxShadow: false,
+									borderWidth: 1,
+									inputHeight: '403px',
+									width: 100,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'crowdsignal-forms/submit-button',
+								attributes: {
+									label: 'Next',
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name: 'core/cover',
+								attributes: {
+									url:
+										'https://i2.wp.com/files.polldaddy.com/e89931dc78998206129aec2f0c957206-627a6d01273aa.png',
+									alt: 'Ice 2 Template Image',
+									hasParallax: false,
+									isRepeated: false,
+									dimRatio: 0,
+									backgroundType: 'image',
+									minHeight: 100,
+									minHeightUnit: 'vh',
+									isDark: false,
+									style: {
+										color: [],
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											content: ' ',
+											dropCap: false,
+											fontSize: 'large',
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'core/columns',
+				attributes: {
+					isStackedOnMobile: true,
+					align: 'full',
+				},
+				innerBlocks: [
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name: 'core/cover',
+								attributes: {
+									url:
+										'https://i1.wp.com/files.polldaddy.com/182b287f760bd466dcc5b75fdff24479-627a6b18c1aa4.png',
+									alt: 'Ice 1 Template Image',
+									hasParallax: false,
+									isRepeated: false,
+									dimRatio: 0,
+									backgroundType: 'image',
+									minHeight: 100,
+									minHeightUnit: 'vh',
+									isDark: false,
+									style: {
+										color: [],
+									},
+								},
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											align: 'center',
+											content: ' ',
+											dropCap: false,
+											placeholder: 'Write title…',
+											fontSize: 'large',
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-question',
+								attributes: {
+									question:
+										'Would you recommend our ice cream to a friend or family member?',
+									mandatory: false,
+									allowOther: false,
+									minimumChoices: 0,
+									maximumChoices: 1,
+									borderRadius: 5,
+									boxShadow: false,
+									borderWidth: 1,
+									className: 'is-style-button',
+								},
+								innerBlocks: [
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Definitely would',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Probably would',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Not sure',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Probably would not',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+									{
+										name:
+											'crowdsignal-forms/multiple-choice-answer',
+										attributes: {
+											label: 'Definitely would not',
+											shareSiblingAttributes: true,
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+							{
+								name: 'crowdsignal-forms/submit-button',
+								attributes: {
+									label: 'Submit',
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'core/spacer',
+				attributes: {
+					height: 52,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					textAlign: 'center',
+					content: 'Thank you!',
+					level: 2,
+					anchor: 'thank-you',
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/spacer',
+				attributes: {
+					height: 108,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/image',
+				attributes: {
+					align: 'full',
+					url:
+						'https://i1.wp.com/files.polldaddy.com/ff0d35f820e187b6994a33cb65932b2b-627a710ccd065.png',
+					alt: 'Ice 5 Template Image',
+					caption: '',
+					href:
+						'https://i1.wp.com/files.polldaddy.com/ff0d35f820e187b6994a33cb65932b2b-627a710ccd065.png',
+					sizeSlug: 'full',
+					linkDestination: 'media',
+				},
+				innerBlocks: [],
+			},
+		],
+	]
+);

--- a/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
@@ -1,0 +1,579 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplate } from './create-template';
+
+export const customerServiceFeedbackTemplate = createTemplate(
+	__( 'Customer Service Feedback', 'dashboard' ),
+	__( 'Description' ),
+	[
+		[
+			{
+				name: 'core/columns',
+				attributes: {
+					isStackedOnMobile: true,
+				},
+				innerBlocks: [
+					{
+						name: 'core/column',
+						attributes: {
+							verticalAlignment: 'center',
+						},
+						innerBlocks: [
+							{
+								name: 'core/image',
+								attributes: {
+									url:
+										'https://images.unsplash.com/photo-1606046604972-77cc76aee944?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=80',
+									alt: '',
+									caption: '',
+									sizeSlug: 'large',
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/spacer',
+								attributes: {
+									height: 15,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/paragraph',
+								attributes: {
+									content:
+										'We use your feedback on surveys like this to find out&nbsp;how we can&nbsp;improve&nbsp;our service to you in the future.',
+									dropCap: false,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/spacer',
+								attributes: {
+									height: 29,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'crowdsignal-forms/submit-button',
+								attributes: {
+									label: 'Start Survey',
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'core/column',
+						attributes: [],
+						innerBlocks: [
+							{
+								name: 'core/spacer',
+								attributes: {
+									height: 102,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/heading',
+								attributes: {
+									content:
+										'Thank you for recently reaching out to us!&nbsp;',
+									level: 3,
+									anchor:
+										'thank-you-for-recently-reaching-out-to-us',
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/spacer',
+								attributes: {
+									height: 41,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/image',
+								attributes: {
+									url:
+										'https://images.unsplash.com/photo-1560624052-449f5ddf0c31?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=870&q=80',
+									alt: '',
+									caption: '',
+									sizeSlug: 'large',
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'core/spacer',
+								attributes: {
+									height: 21,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'crowdsignal-forms/multiple-choice-question',
+				attributes: {
+					question:
+						'Based on your recent interaction, how satisfied have you been with the overall experience?',
+					mandatory: false,
+					allowOther: false,
+					minimumChoices: 0,
+					maximumChoices: 1,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					className: 'is-style-button',
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Very satisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Slightly satisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Neither satisifed nor dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Slightly dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Very dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'crowdsignal-forms/submit-button',
+				attributes: {
+					label: 'Next',
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/spacer',
+				attributes: {
+					height: 17,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1596436889106-be35e843f974?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 0,
+					backgroundType: 'image',
+					focalPoint: {
+						x: '0.54',
+						y: '0.66',
+					},
+					minHeight: 618,
+					minHeightUnit: 'px',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content: ' ',
+							dropCap: false,
+							fontSize: 'large',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1600767421554-069608adb34d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1575&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 0,
+					backgroundType: 'image',
+					focalPoint: {
+						x: '0.51',
+						y: '0.50',
+					},
+					minHeight: 376,
+					minHeightUnit: 'px',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content: ' ',
+							dropCap: false,
+							fontSize: 'large',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'crowdsignal-forms/multiple-choice-question',
+				attributes: {
+					question: 'Was this the first time you contacted us?',
+					mandatory: false,
+					allowOther: false,
+					minimumChoices: 0,
+					maximumChoices: 1,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					className: 'is-style-button',
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Yes',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'No',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'crowdsignal-forms/submit-button',
+				attributes: {
+					label: 'Next',
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'crowdsignal-forms/multiple-choice-question',
+				attributes: {
+					question: 'Was your issue resolved?',
+					mandatory: false,
+					allowOther: false,
+					minimumChoices: 0,
+					maximumChoices: 1,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					className: 'is-style-button',
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Yes, completely',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Yes, partially',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'No, not resolved',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'crowdsignal-forms/submit-button',
+				attributes: {
+					label: 'Next',
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'crowdsignal-forms/multiple-choice-question',
+				attributes: {
+					question:
+						'Based on your recent contact with us, how satisfying was your interaction with our team member?',
+					mandatory: false,
+					allowOther: false,
+					minimumChoices: 0,
+					maximumChoices: 1,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					className: 'is-style-button',
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Very satisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Slightly satisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Neither satisifed nor dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Slightly dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Very dissatisfied',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'crowdsignal-forms/text-question',
+				attributes: {
+					restrictions: [],
+					question: 'Why or why not?',
+					note: '',
+					placeholder: '',
+					mandatory: false,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					inputHeight: '80px',
+					width: 100,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'crowdsignal-forms/submit-button',
+				attributes: {
+					label: 'Next',
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'crowdsignal-forms/multiple-choice-question',
+				attributes: {
+					question:
+						'As a result of your recent experience, do you feel more positive or more negative about our company?',
+					mandatory: false,
+					allowOther: false,
+					minimumChoices: 0,
+					maximumChoices: 1,
+					borderRadius: '',
+					boxShadow: false,
+					borderWidth: '',
+					className: 'is-style-button',
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'More positive',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'Same as before',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/multiple-choice-answer',
+						attributes: {
+							label: 'More negative',
+							shareSiblingAttributes: true,
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'crowdsignal-forms/submit-button',
+				attributes: {
+					label: 'Submit',
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1455587734955-081b22074882?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 0,
+					backgroundType: 'image',
+					minHeight: 100,
+					minHeightUnit: 'vh',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/text-question',
+						attributes: {
+							restrictions: [],
+							question:
+								'If you could change anything about our hotel and service, what would it be?',
+							note: '',
+							placeholder: '',
+							mandatory: false,
+							borderRadius: '',
+							boxShadow: false,
+							borderWidth: '',
+							inputHeight: '80px',
+							width: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/submit-button',
+						attributes: {
+							label: 'Submit',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'core/spacer',
+				attributes: {
+					height: 15,
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					textAlign: 'center',
+					content:
+						'Thank you!<br>¡Gracias!<br>Merci!<br>Obrigada!<br>ありがとうございました<br>谢谢<br>Дякую!<br>Grazie!<br>Σας ευχαριστώ!<br>Dziękuję Ci!<br>Go raibh maith agat!<br>Danke!<br><br>',
+					level: 2,
+					anchor:
+						'thank-you-gracias-merci-obrigada-ありがとうございました谢谢дякую-grazie-σας-ευχαριστώ-dziekuje-ci-go-raibh-maith-agat-danke',
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+	]
+);

--- a/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
@@ -10,7 +10,7 @@ import { createTemplate } from './create-template';
 
 export const customerServiceFeedbackTemplate = createTemplate(
 	__( 'Customer Service Feedback', 'dashboard' ),
-	__( 'Description' ),
+	__( 'Understand the impact or your latest customer interactions.' ),
 	[
 		[
 			{

--- a/apps/dashboard/src/components/new-project-wizard/templates/event-rsvp.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/event-rsvp.js
@@ -1,0 +1,351 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createTemplate } from './create-template';
+
+export const eventRSVPTemplate = createTemplate(
+	__( 'Event RSVP', 'dashboard' ),
+	__( 'Description' ),
+	[
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1505373877841-8d25f7d46678?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1412&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 0,
+					backgroundType: 'image',
+					minHeight: 100,
+					minHeightUnit: 'vh',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/cover',
+						attributes: {
+							alt: '',
+							hasParallax: false,
+							isRepeated: false,
+							dimRatio: 100,
+							customOverlayColor: '#ffffff',
+							backgroundType: 'image',
+							minHeight: 241,
+							minHeightUnit: 'px',
+							contentPosition: 'top left',
+							isDark: false,
+						},
+						innerBlocks: [
+							{
+								name: 'core/heading',
+								attributes: {
+									content:
+										'We are glad you can join us!<br>For whom may we reserve a ticket?',
+									level: 4,
+									anchor:
+										'we-are-glad-you-can-join-us-for-whom-may-we-reserve-a-ticket',
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'crowdsignal-forms/text-input',
+								attributes: {
+									label: 'Name',
+									placeholder: '',
+									mandatory: false,
+									inputHeight: 40,
+									inputWidth: '100%',
+									validation: null,
+								},
+								innerBlocks: [],
+							},
+							{
+								name: 'crowdsignal-forms/text-input',
+								attributes: {
+									label: 'Email',
+									placeholder: '',
+									mandatory: false,
+									inputHeight: 40,
+									inputWidth: '100%',
+									validation: null,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'crowdsignal-forms/submit-button',
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Lorem Ipsum',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1638132704795-6bb223151bf7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 20,
+					backgroundType: 'image',
+					minHeight: 100,
+					minHeightUnit: 'vh',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-question',
+						attributes: {
+							question: 'How many people will be in your party?',
+							mandatory: false,
+							allowOther: false,
+							minimumChoices: 0,
+							maximumChoices: 1,
+							borderRadius: 0,
+							boxShadow: false,
+							borderWidth: 1,
+							className: 'is-style-button',
+						},
+						innerBlocks: [
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								attributes: {
+									label: '1',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								attributes: {
+									label: '2',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								attributes: {
+									label: '3',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'crowdsignal-forms/submit-button',
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1600093463592-8e36ae95ef56?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 50,
+					backgroundType: 'image',
+					minHeight: 100,
+					minHeightUnit: 'vh',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/text-question',
+						attributes: {
+							restrictions: [],
+							question:
+								'Do you or your guests have any dietary restrictions?',
+							note: '',
+							placeholder:
+								'Please tell us about your preferences',
+							mandatory: false,
+							borderRadius: 0,
+							boxShadow: false,
+							borderWidth: 1,
+							inputHeight: '209px',
+							width: 100,
+						},
+						innerBlocks: [],
+					},
+					{
+						name: 'crowdsignal-forms/submit-button',
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1517263904808-5dc91e3e7044?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=776&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 50,
+					backgroundType: 'image',
+					minHeight: 100,
+					minHeightUnit: 'vh',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'crowdsignal-forms/multiple-choice-question',
+						attributes: {
+							question:
+								'Will you be able to join us for the After Party?',
+							mandatory: false,
+							allowOther: false,
+							minimumChoices: 0,
+							maximumChoices: 1,
+							borderRadius: 0,
+							boxShadow: false,
+							borderWidth: 1,
+							className: 'is-style-button',
+						},
+						innerBlocks: [
+							{
+								name: 'core/paragraph',
+								attributes: {
+									content:
+										'<em>The location for the party will be just a 5 min walk from the main conference.</em>',
+									dropCap: false,
+								},
+								innerBlocks: [],
+							},
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								attributes: {
+									label: 'Yes',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+							{
+								name:
+									'crowdsignal-forms/multiple-choice-answer',
+								attributes: {
+									label: 'No',
+									shareSiblingAttributes: true,
+								},
+								innerBlocks: [],
+							},
+						],
+					},
+					{
+						name: 'crowdsignal-forms/submit-button',
+						attributes: {
+							label: 'Next',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+		],
+		[
+			{
+				name: 'core/cover',
+				attributes: {
+					url:
+						'https://images.unsplash.com/photo-1525011268546-bf3f9b007f6a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80',
+					alt: '',
+					hasParallax: false,
+					isRepeated: false,
+					dimRatio: 0,
+					backgroundType: 'image',
+					isDark: false,
+					align: 'full',
+					style: {
+						color: [],
+					},
+				},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							align: 'center',
+							content: ' ',
+							dropCap: false,
+							placeholder: 'Write title…',
+							fontSize: 'large',
+						},
+						innerBlocks: [],
+					},
+				],
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					textAlign: 'left',
+					content: 'Thank you!<br>We reserved your ticket!',
+					level: 2,
+					anchor: 'thank-you-we-reserved-your-ticket',
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '',
+					dropCap: false,
+				},
+				innerBlocks: [],
+			},
+		],
+	]
+);

--- a/apps/dashboard/src/components/new-project-wizard/templates/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/index.js
@@ -1,2 +1,3 @@
 export * from './blank';
+export * from './customer-service-feedback';
 export * from './product-feedback';

--- a/apps/dashboard/src/components/new-project-wizard/templates/product-feedback.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/product-feedback.js
@@ -25,7 +25,6 @@ export const productFeedbackTemplate = createTemplate(
 			},
 			{
 				name: 'core/columns',
-				isValid: true,
 				attributes: {
 					isStackedOnMobile: true,
 				},

--- a/apps/dashboard/src/components/themes-modal/theme-preview/styles.js
+++ b/apps/dashboard/src/components/themes-modal/theme-preview/styles.js
@@ -4,7 +4,6 @@
 import styled from '@emotion/styled';
 
 export const ThemePreviewWrapper = styled.div`
-	max-width: 360px;
 	display: flex;
 	flex-direction: column;
 `;


### PR DESCRIPTION
This PR adds three new project templates in the new project wizard as well as fixing a few of its style glitches. The new templates include:

- Customer satisfaction survey
- Customer service feedback survey
- Event RSVP form

<img width="1789" alt="Screen Shot 2022-05-10 at 10 49 00 PM" src="https://user-images.githubusercontent.com/8056203/167719364-0e9c07d1-6059-4cfc-980d-74eacfa38f35.png">

**Note:** currently only customer service feedback survey template is actually enabled due to issues with cover block scaling on the template previews.

# Testing

Go to `/project` and verify the new templates are available in the new project wizard and work as expected.

