### PR TITLE
Fix columns gap

### DIFF
--- a/packages/theme-compatibility/package.json
+++ b/packages/theme-compatibility/package.json
@@ -16,6 +16,9 @@
   "bugs": {
     "url": "https://github.com/Automattic/crowdsignal-ui/issues"
   },
+  "devDependencies": {
+    "isolated-block-editor": "https://github.com/Automattic/isolated-block-editor.git#2.12.1"
+  },
   "scripts": {
     "build": "calypso-build"
   }

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -48,6 +48,7 @@ body {
 
 .wp-block-columns {
 	margin-bottom: var(--cs--style--block-gap);
+	gap: var(--cs--style--block-gap);
 
 	.wp-block-column:not(:last-child) {
 		margin-bottom: var(--cs--style--block-gap);


### PR DESCRIPTION
This patch fixes the issue with correct column gap settings no longer working, originally found in #235.  

The issue was caused by changes to Gutenberg core, which now [generates layout styles dynamically on the backend](https://github.com/WordPress/gutenberg/blob/c840e90376da5de3e73af9499571e66fc8f25ff4/lib/block-supports/layout.php).  
This is a quite a significant change, and this is really only a temporary fix. I'm assuming this will only affect more blocks in the future and we'll need to come up with a more permanent solution... probably involving our block renderer to some degree since we're not doing any processing of the blocks on the backend, nor does the editor save any reference of what styles actually were applied to a given block unless they were set explicitly for it.  
This will likely be a must to support global styles.

For now, I've updated the CSS to explicitly set the gap to `--cs--style--block-gap`.

Before:

![Screen Shot 2022-05-16 at 10 36 33 PM](https://user-images.githubusercontent.com/8056203/168678374-6d7756ca-84ae-4da9-855e-997b1250166f.png)

After:

![Screen Shot 2022-05-16 at 10 36 18 PM](https://user-images.githubusercontent.com/8056203/168678394-b60c34e7-f07b-4491-839e-d8717cf576f5.png)

# Testing

- Add a columns block and fill it with some content.
- Verify there's now visible space between the two columns.