### PR TITLE
Hide inserter and settings sidebars by default

### DIFF
--- a/apps/dashboard/src/components/editor/document-settings.js
+++ b/apps/dashboard/src/components/editor/document-settings.js
@@ -26,35 +26,25 @@ import { ToolbarButton } from './styles/button';
 import { getTheme } from '../../util/theme/themes';
 
 const DocumentSettings = ( { onChangeThemeClick, project } ) => {
-	const { openGeneralSidebar, setIsInserterOpened } = useDispatch(
-		'isolated/editor'
-	);
+	const { openGeneralSidebar } = useDispatch( 'isolated/editor' );
 	const { saveAndUpdateProject } = useDispatch( STORE_NAME );
 
 	const [
 		canPublish,
 		editorTheme,
 		selectedBlockClientId,
-		showInserter,
 	] = useSelect( ( select ) => [
 		select( STORE_NAME ).isEditorContentPublishable(),
 		select( STORE_NAME ).getEditorTheme(),
 		select( 'core/block-editor' ).getSelectedBlockClientId(),
-		select( STORE_NAME ).showInserter(),
 	] );
 
 	useEffect( () => {
-		if ( ! showInserter ) {
+		if ( ! selectedBlockClientId ) {
 			return;
 		}
 
-		setIsInserterOpened( true );
-	}, [ showInserter ] );
-
-	useEffect( () => {
-		openGeneralSidebar(
-			!! selectedBlockClientId ? 'edit-post/block' : 'edit-post/document'
-		);
+		openGeneralSidebar( 'edit-post/block' );
 	}, [ selectedBlockClientId ] );
 
 	const updateProjectVisibility = ( event ) => {


### PR DESCRIPTION
This patch hides both the inserter and settings sidebars by default. The right sidebar will still open once any block is selected.

The idea is to help with the screen feeling overcrowded. This is especially an issue on smaller screen sizes where both sidebars plus page navigation leave little space for the actual content.  
The new welcome guide and new project wizard add to the chaos too.

Solves c/lImTrzeM-tr.

# Testing

- Verify that the sidebars aren't shown by default when the editor loads.
- Verify the right sidebar still appears once any block is selected.