### PR TITLE
Editor guide touchups

### DIFF
--- a/apps/dashboard/src/components/editor/guide.js
+++ b/apps/dashboard/src/components/editor/guide.js
@@ -76,7 +76,7 @@ const EditorGuide = ( { onFinish } ) => {
 							</Guide.Header>
 							<Guide.Text>
 								{ __(
-									'In the Crowdsignal Editor, questions, from fields, images, and videos are all blocks.',
+									'In the Crowdsignal Editor, questions, form fields, images, and videos are all blocks.',
 									'dashboard'
 								) }
 							</Guide.Text>

--- a/apps/dashboard/src/components/editor/styles/guide.js
+++ b/apps/dashboard/src/components/editor/styles/guide.js
@@ -4,7 +4,7 @@
 import styled from '@emotion/styled';
 
 export const EditorGuideWrapper = styled.div`
-	height: 470px;
+	height: 475px;
 	max-width: 345px;
 	position: absolute;
 	left: 20px;

--- a/packages/components/src/guide/styles.js
+++ b/packages/components/src/guide/styles.js
@@ -3,6 +3,11 @@
  */
 import styled from '@emotion/styled';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '../button/styles';
+
 export const GuideWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
@@ -10,19 +15,20 @@ export const GuideWrapper = styled.div`
 `;
 
 export const GuideCloseButton = styled.button`
-	background-color: var( --color-surface );
+	background-color: var( --color-text-subtle );
 	border: 0;
 	box-sizing: border-box;
+	fill: var( --color-text-inverted );
 	height: 32px;
 	padding: 4px;
-	opacity: 0.3;
+	opacity: 0.35;
 	position: absolute;
 	top: 8px;
 	right: 8px;
 	width: 32px;
 
 	&:hover {
-		opacity: 1;
+		opacity: 0.75;
 	}
 `;
 
@@ -48,12 +54,6 @@ export const PageContent = styled.div`
 export const PageText = styled.p`
 	font-size: 14px;
 	line-height: 24px;
-`;
-
-export const GuideFooter = styled.div`
-	display: flex;
-	justify-content: flex-end;
-	padding: 32px;
 `;
 
 export const PageNavigationWrapper = styled.div`
@@ -83,5 +83,19 @@ export const PageIndicatorButton = styled.button`
 
 	&.is-active > svg {
 		fill: var( --color-primary );
+	}
+`;
+
+export const GuideFooter = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	padding: 32px;
+
+	${ Button }:not(${ PageIndicatorButton }) {
+		margin-right: 12px;
+
+		&:last-child {
+			margin-right: 0;
+		}
 	}
 `;


### PR DESCRIPTION
This patch makes a few touchups to the editor guide:

- Fixed a typo spotted by @digitalwaveride 
- Updated the styles to match the new buttons in #240
- The close button for the guide is now darker

# Testing

- Verify the appearance of the editor guide matches the above description and that the typo has been fixed.