### PR TITLE
Fix a typo in the description for Customer Service Feedback Template

### DIFF
--- a/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/customer-service-feedback.js
@@ -10,7 +10,7 @@ import { createTemplate } from './create-template';
 
 export const customerServiceFeedbackTemplate = createTemplate(
 	__( 'Customer Service Feedback', 'dashboard' ),
-	__( 'Understand the impact or your latest customer interactions.' ),
+	__( 'Understand the impact of your latest customer interactions.' ),
 	[
 		[
 			{


### PR DESCRIPTION
Wee fix to fix a typo in the customer service feedback template description.

# Testing

Open `/project` and make sure the typo is fixed.