### PR TITLE
Restore the previous gallery block version

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -9,9 +9,10 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import * as blocks from '@crowdsignal/block-editor';
-
-// test
 import { uploadMedia } from '../../util/media';
+
+// Disable experimental gallery block version
+window.wp.galleryBlockV2Enabled = false;
 
 setCategories( [
 	{


### PR DESCRIPTION
This patch fixes an issue where the gallery block wouldn't display at all.  
This was introduced in our last Gutenberg update that apparently added a new experimental version that we don't quite support. I was able to force the old version back by setting `window.wp.galleryBlockV2Enabled = false;`.

This is something to be aware of for our next update.

# Testing

- Create/edit a project.
- Add a gallery block, it should work as usual and allow for image uploads.