### PR TITLE
Fix QuestionHeader required indicator styles

### DIFF
--- a/packages/blocks/src/components/question-header/index.js
+++ b/packages/blocks/src/components/question-header/index.js
@@ -18,7 +18,7 @@ const QuestionHeader = styled.h3`
 	}
 
 	${ QuestionWrapper.className }.is-required &::after {
-		display: 'inline';
+		display: inline;
 		content: ' *';
 	}
 `;


### PR DESCRIPTION
This patch fixes QuestionHeader styles so the required option indicator appears correctly.

Before:
![Screen Shot 2022-05-20 at 4 41 53 PM](https://user-images.githubusercontent.com/8056203/169552828-e0e94313-88eb-489a-a3d0-cd11bdd0224a.png)

After:
![Screen Shot 2022-05-20 at 4 41 03 PM](https://user-images.githubusercontent.com/8056203/169552843-04626ced-9831-4f5d-9085-e4829d72dd69.png)

# Testing

- Create/edit a project.
- Add a text- and/or a multiple-choice question.
- Verify that the question header appears correctly when the required option is selected.