### PR TITLE
Move blocks naming logic to @crowdsignal/blocks package

### DIFF
--- a/apps/project-renderer/src/components/app/index.js
+++ b/apps/project-renderer/src/components/app/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
+import { reduce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -9,16 +10,7 @@ import classnames from 'classnames';
  */
 import {
 	ContentWrapper,
-	CoreEmbed,
-	MultipleChoiceAnswer,
-	MultipleChoiceQuestion,
-	RankingAnswer,
-	RankingQuestion,
-	RatingScaleAnswer,
-	RatingScaleQuestion,
-	SubmitButton,
-	TextInput,
-	TextQuestion,
+	projectBlocks,
 	renderBlocks,
 } from '@crowdsignal/blocks';
 import { Form } from '@crowdsignal/form';
@@ -124,19 +116,13 @@ const App = ( {
 		return 'Wait...';
 	}
 
-	const renderContent = () =>
-		renderBlocks( content, {
-			'core/embed': CoreEmbed,
-			'crowdsignal-forms/multiple-choice-answer': MultipleChoiceAnswer,
-			'crowdsignal-forms/multiple-choice-question': MultipleChoiceQuestion,
-			'crowdsignal-forms/ranking-answer': RankingAnswer,
-			'crowdsignal-forms/ranking-question': RankingQuestion,
-			'crowdsignal-forms/rating-scale-answer': RatingScaleAnswer,
-			'crowdsignal-forms/rating-scale-question': RatingScaleQuestion,
-			'crowdsignal-forms/submit-button': SubmitButton,
-			'crowdsignal-forms/text-input': TextInput,
-			'crowdsignal-forms/text-question': TextQuestion,
-		} );
+	const blockMap = reduce(
+		projectBlocks,
+		( list, block ) => ( { ...list, [ block.BlockName ]: block } ),
+		{}
+	);
+
+	const renderContent = () => renderBlocks( content, blockMap );
 
 	const contentClasses = classnames(
 		'wp-embed-responsive',

--- a/packages/block-editor/src/multiple-choice-answer/index.js
+++ b/packages/block-editor/src/multiple-choice-answer/index.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { MultipleChoiceAnswer } from '@crowdsignal/blocks';
 import { MultipleChoiceAnswerIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditMultipleChoiceAnswer from './edit';
-
-const name = 'crowdsignal-forms/multiple-choice-answer';
 
 const settings = {
 	title: __( 'Answer', 'block-editor' ),
@@ -31,6 +30,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: MultipleChoiceAnswer.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/multiple-choice-question/index.js
+++ b/packages/block-editor/src/multiple-choice-question/index.js
@@ -12,8 +12,6 @@ import { MultipleChoiceQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditMultipleChoiceQuestion from './edit';
 
-const name = 'crowdsignal-forms/multiple-choice-question';
-
 const settings = {
 	apiVersion: 1,
 	title: __( 'Multiple Choice Question', 'block-editor' ),
@@ -93,6 +91,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: MultipleChoiceQuestion.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/poll-answer/index.js
+++ b/packages/block-editor/src/poll-answer/index.js
@@ -6,10 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { PollAnswer } from '@crowdsignal/blocks';
 import attributes from './attributes';
 import EditPollAnswer from './edit';
-
-const name = 'crowdsignal-forms/poll-answer';
 
 const settings = {
 	title: __( 'Poll Answer', 'blocks' ),
@@ -21,6 +20,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: PollAnswer.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/poll/index.js
+++ b/packages/block-editor/src/poll/index.js
@@ -7,10 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Poll } from '@crowdsignal/blocks';
 import attributes from './attributes';
 import EditPoll from './edit';
-
-const name = 'crowdsignal-forms/poll';
 
 const settings = {
 	apiVersion: 1,
@@ -31,6 +30,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: Poll.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/ranking-answer/index.js
+++ b/packages/block-editor/src/ranking-answer/index.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { RankingAnswer } from '@crowdsignal/blocks';
 import { RankingQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditRankingAnswer from './edit';
-
-const name = 'crowdsignal-forms/ranking-answer';
 
 const settings = {
 	title: __( 'Answer', 'block-editor' ),
@@ -31,6 +30,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: RankingAnswer.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/ranking-question/index.js
+++ b/packages/block-editor/src/ranking-question/index.js
@@ -7,11 +7,10 @@ import { InnerBlocks } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
+import { RankingQuestion } from '@crowdsignal/blocks';
 import { RankingQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditRakingQuestionBlock from './edit';
-
-const name = 'crowdsignal-forms/ranking-question';
 
 const settings = {
 	apiVersion: 1,
@@ -73,6 +72,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: RankingQuestion.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/rating-scale-answer/index.js
+++ b/packages/block-editor/src/rating-scale-answer/index.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { RatingScaleAnswer } from '@crowdsignal/blocks';
 import { RatingScaleQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditRatingScaleAnswer from './edit';
-
-const name = 'crowdsignal-forms/rating-scale-answer';
 
 const settings = {
 	title: __( 'Answer', 'block-editor' ),
@@ -31,6 +30,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: RatingScaleAnswer.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/rating-scale-question/index.js
+++ b/packages/block-editor/src/rating-scale-question/index.js
@@ -12,8 +12,6 @@ import { RatingScaleQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditRatingScaleQuestion from './edit';
 
-const name = 'crowdsignal-forms/rating-scale-question';
-
 const settings = {
 	apiVersion: 1,
 	title: __( 'Rating Question', 'block-editor' ),
@@ -93,6 +91,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: RatingScaleQuestion.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/submit-button/index.js
+++ b/packages/block-editor/src/submit-button/index.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { SubmitButton } from '@crowdsignal/blocks';
 import { SubmitButtonIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditSubmitButton from './edit';
-
-const name = 'crowdsignal-forms/submit-button';
 
 const settings = {
 	title: __( 'Submit Button', 'block-editor' ),
@@ -37,6 +36,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: SubmitButton.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/text-input/index.js
+++ b/packages/block-editor/src/text-input/index.js
@@ -6,12 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { TextInput } from '@crowdsignal/blocks';
 import { TextInputIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import Edit from './edit';
 import variation from './variations';
-
-const name = 'crowdsignal-forms/text-input';
 
 const settings = {
 	apiVersion: 1,
@@ -38,6 +37,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: TextInput.BlockName,
 	settings,
 };

--- a/packages/block-editor/src/text-question/index.js
+++ b/packages/block-editor/src/text-question/index.js
@@ -6,11 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { TextQuestion } from '@crowdsignal/blocks';
 import { TextQuestionIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditFreeText from './edit';
-
-const name = 'crowdsignal-forms/text-question';
 
 const settings = {
 	apiVersion: 1,
@@ -41,6 +40,6 @@ const settings = {
 };
 
 export default {
-	name,
+	name: TextQuestion.BlockName,
 	settings,
 };

--- a/packages/blocks/src/core-embed/index.js
+++ b/packages/blocks/src/core-embed/index.js
@@ -65,4 +65,6 @@ const CoreEmbed = ( { attributes } ) => {
 	);
 };
 
+CoreEmbed.BlockName = 'core/embed';
+
 export default CoreEmbed;

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,17 +1,45 @@
+import CoreEmbed from './core-embed';
+import MultipleChoiceAnswer from './multiple-choice-answer';
+import MultipleChoiceQuestion from './multiple-choice-question';
+import Poll from './poll';
+import PollAnswer from './poll-answer';
+import RankingAnswer from './ranking-answer';
+import RankingQuestion from './ranking-question';
+import RatingScaleAnswer from './rating-scale-answer';
+import RatingScaleQuestion from './rating-scale-question';
+import SubmitButton from './submit-button';
+import TextInput from './text-input';
+import TextQuestion from './text-question';
+
 export * from './components';
 
-export { default as CoreEmbed } from './core-embed';
-export { default as MultipleChoiceAnswer } from './multiple-choice-answer';
-export { default as MultipleChoiceQuestion } from './multiple-choice-question';
-export { default as Poll } from './poll';
-export { default as PollAnswer } from './poll-answer';
-export { default as RankingAnswer } from './ranking-answer';
-export { default as RankingQuestion } from './ranking-question';
-export { default as RatingScaleAnswer } from './rating-scale-answer';
-export { default as RatingScaleQuestion } from './rating-scale-question';
-export { default as SubmitButton } from './submit-button';
-export { default as TextInput } from './text-input';
-export { default as TextQuestion } from './text-question';
+export {
+	CoreEmbed,
+	MultipleChoiceAnswer,
+	MultipleChoiceQuestion,
+	Poll,
+	PollAnswer,
+	RankingAnswer,
+	RankingQuestion,
+	RatingScaleAnswer,
+	RatingScaleQuestion,
+	SubmitButton,
+	TextInput,
+	TextQuestion,
+};
+
+export const projectBlocks = [
+	CoreEmbed,
+	MultipleChoiceAnswer,
+	MultipleChoiceQuestion,
+	RankingAnswer,
+	RankingQuestion,
+	RatingScaleAnswer,
+	RatingScaleQuestion,
+	SubmitButton,
+	TextInput,
+	TextQuestion,
+];
 
 export { renderBlocks } from './render-blocks';
 

--- a/packages/blocks/src/multiple-choice-answer/index.js
+++ b/packages/blocks/src/multiple-choice-answer/index.js
@@ -64,4 +64,6 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 	);
 };
 
+MultipleChoiceAnswer.BlockName = 'crowdsignal-forms/multiple-choice-answer';
+
 export default MultipleChoiceAnswer;

--- a/packages/blocks/src/multiple-choice-question/index.js
+++ b/packages/blocks/src/multiple-choice-question/index.js
@@ -51,5 +51,6 @@ const MultipleChoiceQuestion = ( { attributes, children, className } ) => {
 
 MultipleChoiceQuestion.Context = Context;
 MultipleChoiceQuestion.Style = Style;
+MultipleChoiceQuestion.BlockName = 'crowdsignal-forms/multiple-choice-question';
 
 export default MultipleChoiceQuestion;

--- a/packages/blocks/src/poll-answer/index.js
+++ b/packages/blocks/src/poll-answer/index.js
@@ -25,4 +25,6 @@ const PollAnswer = ( { attributes, className } ) => {
 	);
 };
 
+PollAnswer.BlockName = 'crowdsignal-forms/poll-answer';
+
 export default PollAnswer;

--- a/packages/blocks/src/poll/index.js
+++ b/packages/blocks/src/poll/index.js
@@ -30,4 +30,6 @@ const Poll = ( { attributes, className, children } ) => {
 	);
 };
 
+Poll.BlockName = 'crowdsignal-forms/poll';
+
 export default Poll;

--- a/packages/blocks/src/ranking-answer/index.js
+++ b/packages/blocks/src/ranking-answer/index.js
@@ -38,4 +38,6 @@ const RankingAnswer = ( { attributes, className, draggable } ) => {
 	);
 };
 
+RankingAnswer.BlockName = 'crowdsignal-forms/ranking-answer';
+
 export default RankingAnswer;

--- a/packages/blocks/src/ranking-question/index.js
+++ b/packages/blocks/src/ranking-question/index.js
@@ -80,5 +80,6 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 };
 
 RankingQuestion.Context = Context;
+RankingQuestion.BlockName = 'crowdsignal-forms/ranking-question';
 
 export default RankingQuestion;

--- a/packages/blocks/src/rating-scale-answer/index.js
+++ b/packages/blocks/src/rating-scale-answer/index.js
@@ -52,4 +52,6 @@ const RatingScaleAnswer = ( { attributes, className } ) => {
 	);
 };
 
+RatingScaleAnswer.BlockName = 'crowdsignal-forms/rating-scale-answer';
+
 export default RatingScaleAnswer;

--- a/packages/blocks/src/rating-scale-question/index.js
+++ b/packages/blocks/src/rating-scale-question/index.js
@@ -52,5 +52,6 @@ const RatingScaleQuestion = ( { attributes, children, className } ) => {
 
 RatingScaleQuestion.Context = Context;
 RatingScaleQuestion.Style = Style;
+RatingScaleQuestion.BlockName = 'crowdsignal-forms/rating-scale-question';
 
 export default RatingScaleQuestion;

--- a/packages/blocks/src/submit-button/index.js
+++ b/packages/blocks/src/submit-button/index.js
@@ -55,4 +55,6 @@ const SubmitButton = ( { attributes, className } ) => {
 	);
 };
 
+SubmitButton.BlockName = 'crowdsignal-forms/submit-button';
+
 export default SubmitButton;

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -61,4 +61,6 @@ const TextInput = ( { attributes, className } ) => {
 	);
 };
 
+TextInput.BlockName = 'crowdsignal-forms/text-input';
+
 export default TextInput;

--- a/packages/blocks/src/text-question/index.js
+++ b/packages/blocks/src/text-question/index.js
@@ -54,4 +54,6 @@ const TextQuestion = ( { attributes, className } ) => {
 	);
 };
 
+TextQuestion.BlockName = 'crowdsignal-forms/text-question';
+
 export default TextQuestion;


### PR DESCRIPTION
## Summary

This PR changes the block naming logic to move It to the `@crowdsignal/blocks` package and reutilize it inside the `@crowdsignal/block-editor`.
It also changes the block registering logic to ensure that all `projectBlocks` exported on the `@crowdsignal/blocks` will be registered automatically.

## Test Instructions
* Create a project and add a bunch (or all) Crowdsignal blocks
* Check if the editor and the renderer are working properly