### PR TITLE
Add a matrix question block

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -17,6 +17,13 @@ import { MediaUploader } from './media-upload';
 
 export const registerBlocks = () =>
 	forEach( blocks, ( block ) => {
+		if (
+			process.env.NODE_ENV === 'production' &&
+			block.name === 'crowdsignal-forms/matrix-question'
+		) {
+			return;
+		}
+
 		registerBlockType( block.name, block.settings );
 	} );
 

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,3 +1,4 @@
+export { default as matrixQuestionBlock } from './matrix-question';
 export { default as multipleChoiceAnswerBlock } from './multiple-choice-answer';
 export { default as multipleChoiceQuestionBlock } from './multiple-choice-question';
 export { default as rankingAnswerBlock } from './ranking-answer';

--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -1,0 +1,44 @@
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	question: {
+		type: 'string',
+		default: null,
+	},
+	columns: {
+		type: 'array',
+		default: [
+			{
+				clientId: 'a',
+				label: 'A',
+			},
+			{
+				clientId: 'b',
+				label: 'B',
+			},
+			{
+				clientId: 'c',
+				label: 'C',
+			},
+		],
+	},
+	rows: {
+		type: 'array',
+		default: [
+			{
+				clientId: 'd',
+				label: '1',
+			},
+			{
+				clientId: 'e',
+				label: '2',
+			},
+			{
+				clientId: 'f',
+				label: '3',
+			},
+		],
+	},
+};

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { Fragment, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { v4 as uuid } from 'uuid';
+import { filter, join, map, noop, slice, tap, trim, times } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormCheckbox,
+	MatrixQuestion,
+	QuestionHeader,
+	QuestionWrapper,
+} from '@crowdsignal/blocks';
+
+const shiftLabelFocus = ( wrapper, type, index ) =>
+	tap(
+		wrapper.querySelectorAll(
+			`.crowdsignal-forms-matrix-block__${ type }-label [role=textbox]`
+		)[ index ],
+		( input ) => input && input.focus()
+	);
+
+const EditMatrix = ( { attributes, setAttributes } ) => {
+	const tableWrapper = useRef();
+
+	const handleChangeQuestion = ( question ) => setAttributes( { question } );
+
+	const handleChangeLabel = ( type, index ) => ( label ) =>
+		setAttributes( {
+			[ type ]: tap( [ ...attributes[ type ] ], ( items ) => {
+				items[ index ] = {
+					...items[ index ],
+					label,
+				};
+			} ),
+		} );
+
+	const handleNewLabel = ( type, insertAt ) => () => {
+		if ( insertAt < attributes[ type ].length ) {
+			setAttributes( {
+				[ type ]: [
+					...slice( attributes[ type ], 0, insertAt ),
+					{
+						clientId: uuid(),
+						label: '',
+					},
+					...slice(
+						attributes[ type ],
+						insertAt,
+						attributes[ type ].length
+					),
+				],
+			} );
+		}
+
+		shiftLabelFocus(
+			tableWrapper.current,
+			trim( type, 's' ),
+			Math.min( insertAt, attributes[ type ].length )
+		);
+	};
+
+	const handleRemoveLabel = ( type, index ) => () => {
+		shiftLabelFocus(
+			tableWrapper.current,
+			trim( type, 's' ),
+			Math.max( index - 1, 0 )
+		);
+
+		setAttributes( {
+			[ type ]: filter(
+				attributes[ type ],
+				( item ) =>
+					attributes[ type ].length <= 2 ||
+					item !== attributes[ type ][ index ]
+			),
+		} );
+	};
+
+	const tableStyles = {
+		gridTemplateColumns: join(
+			times( attributes.columns.length + 1, () => '1fr' ),
+			' '
+		),
+		gridTemplateRows: join(
+			times( attributes.rows.length + 1, () => '1fr' ),
+			' '
+		),
+	};
+
+	return (
+		<QuestionWrapper attributes={ attributes }>
+			<RichText
+				tagName={ QuestionHeader }
+				placeholder={ __( 'Enter your question', 'block-editor' ) }
+				onChange={ handleChangeQuestion }
+				value={ attributes.question }
+			/>
+
+			<MatrixQuestion.Table ref={ tableWrapper } style={ tableStyles }>
+				<MatrixQuestion.Cell />
+
+				{ map( attributes.columns, ( column, index ) => (
+					<MatrixQuestion.Cell
+						key={ column.clientId }
+						className="crowdsignal-forms-matrix-block__column-label"
+					>
+						<RichText
+							placeholder={ __( 'Column', 'block-editor' ) }
+							onChange={ handleChangeLabel( 'columns', index ) }
+							onRemove={ handleRemoveLabel( 'columns', index ) }
+							onReplace={ noop }
+							onSplit={ handleNewLabel( 'columns', index + 1 ) }
+							value={ column.label }
+						/>
+					</MatrixQuestion.Cell>
+				) ) }
+
+				{ map( attributes.rows, ( row, index ) => (
+					<Fragment key={ row.clientId }>
+						<MatrixQuestion.Cell className="crowdsignal-forms-matrix-block__row-label">
+							<RichText
+								placeholder={ __( 'Rows', 'block-editor' ) }
+								onChange={ handleChangeLabel( 'rows', index ) }
+								onRemove={ handleRemoveLabel( 'rows', index ) }
+								onReplace={ noop }
+								onSplit={ handleNewLabel( 'rows', index + 1 ) }
+								value={ row.label }
+							/>
+						</MatrixQuestion.Cell>
+
+						{ times( attributes.columns.length, ( n ) => (
+							<MatrixQuestion.Cell key={ n }>
+								<FormCheckbox />
+							</MatrixQuestion.Cell>
+						) ) }
+					</Fragment>
+				) ) }
+			</MatrixQuestion.Table>
+		</QuestionWrapper>
+	);
+};
+
+export default EditMatrix;

--- a/packages/block-editor/src/matrix-question/index.js
+++ b/packages/block-editor/src/matrix-question/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { MatrixQuestion } from '@crowdsignal/blocks';
+import attributes from './attributes';
+import EditMatrix from './edit';
+
+const settings = {
+	apiVersion: 1,
+	title: __( 'Matrix', 'blocks' ),
+	description: __( "Create polls and get your audience's opinion", 'blocks' ),
+	category: 'crowdsignal-forms',
+	edit: EditMatrix,
+	attributes,
+};
+
+export default {
+	name: MatrixQuestion.blockName,
+	settings,
+};

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -31,6 +31,10 @@ const CheckboxWrapper = styled.div`
 	transform: translateY( 1px );
 	width: 1em;
 
+	&:last-child {
+		margin-right: 0;
+	}
+
 	.crowdsignal-forms-button & {
 		transform: none;
 	}

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,4 +1,5 @@
 import CoreEmbed from './core-embed';
+import MatrixQuestion from './matrix-question';
 import MultipleChoiceAnswer from './multiple-choice-answer';
 import MultipleChoiceQuestion from './multiple-choice-question';
 import Poll from './poll';
@@ -15,6 +16,7 @@ export * from './components';
 
 export {
 	CoreEmbed,
+	MatrixQuestion,
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	Poll,
@@ -30,6 +32,7 @@ export {
 
 export const projectBlocks = [
 	CoreEmbed,
+	MatrixQuestion,
 	MultipleChoiceAnswer,
 	MultipleChoiceQuestion,
 	RankingAnswer,

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { Fragment, RawHTML } from '@wordpress/element';
+import { join, map, times } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { FormCheckbox, QuestionHeader, QuestionWrapper } from '../components';
+
+/**
+ * Style dependencies
+ */
+import { MatrixCell, MatrixTable } from './styles';
+
+const MatrixQuestion = ( { attributes } ) => {
+	const tableStyles = {
+		gridTemplateColumns: join(
+			times( attributes.columns.length + 1, () => '1fr' ),
+			' '
+		),
+		gridTemplateRows: join(
+			times( attributes.rows.length + 1, () => '1fr' ),
+			' '
+		),
+	};
+
+	return (
+		<QuestionWrapper attributes={ attributes }>
+			<QuestionHeader>
+				<RawHTML>{ attributes.question }</RawHTML>
+			</QuestionHeader>
+
+			<MatrixTable style={ tableStyles }>
+				<MatrixCell />
+
+				{ map( attributes.columns, ( column ) => (
+					<MatrixCell
+						key={ column.clientId }
+						className="crowdsignal-forms-matrix-block__column-label"
+					>
+						<RawHTML>{ column.label }</RawHTML>
+					</MatrixCell>
+				) ) }
+
+				{ map( attributes.rows, ( row ) => (
+					<Fragment key={ row.clientId }>
+						<MatrixCell className="crowdsignal-forms-matrix-block__row-label">
+							<RawHTML>{ row.label }</RawHTML>
+						</MatrixCell>
+
+						{ times( attributes.columns.length, ( n ) => (
+							<MatrixCell key={ n }>
+								<FormCheckbox />
+							</MatrixCell>
+						) ) }
+					</Fragment>
+				) ) }
+			</MatrixTable>
+		</QuestionWrapper>
+	);
+};
+
+MatrixQuestion.Cell = MatrixCell;
+MatrixQuestion.Table = MatrixTable;
+
+MatrixQuestion.blockName = 'crowdsignal-forms/matrix-question';
+
+export default MatrixQuestion;

--- a/packages/blocks/src/matrix-question/styles.js
+++ b/packages/blocks/src/matrix-question/styles.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const MatrixTable = styled.div`
+	border: 0;
+	display: grid;
+`;
+
+export const MatrixCell = styled.div`
+	align-items: center;
+	border: 1px solid;
+	border-top-width: 0;
+	border-left-width: 0;
+	box-sizing: border-box;
+	display: inline-flex;
+	justify-content: center;
+	padding: 16px;
+	text-align: center;
+
+	&.crowdsignal-forms-matrix-block__column-label {
+		border-top-width: 1px;
+	}
+
+	&.crowdsignal-forms-matrix-block__row-label {
+		border-left-width: 1px;
+	}
+`;


### PR DESCRIPTION
This patch adds the matrix question block. The block is currently behind a flag and thus will not be included in the production build until it's ready.

In it's current state, it will allow you to add a matrix question inside the editor as well as edit, add or remove rows or columns from the matrix. It also contains some basic styles although proper block customization will be implemented later.

Voting on the block also isn't supported quite yet and will be added separately.

<img width="747" alt="Screen Shot 2022-05-23 at 3 39 30 PM" src="https://user-images.githubusercontent.com/8056203/169845404-2983248b-421a-419b-89a5-dfee161c91e0.png">

# Testing

- Open the project editor and create a matrix question block.
- You should be able to edit the row and column labels.
- You should be able to create new rows or columns by pressing enter.
- If press backspace in an already empty label, it'll delete that row or column completely.
- Save the project and verify the preview matches your editor creation.