### PR TITLE
Add toolbar and sidebar settings for the Matrix Question block

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -28,6 +28,7 @@
     "@wordpress/data": "^6.6.0",
     "@wordpress/element": "^4.4.0",
     "@wordpress/i18n": "^4.6.0",
+    "@wordpress/icons": "^8.2.0",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"

--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -41,4 +41,17 @@ export default {
 			},
 		],
 	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	width: {
+		type: 'number',
+	},
 };

--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -7,6 +7,10 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	multipleChoice: {
+		type: 'boolean',
+		default: true,
+	},
 	columns: {
 		type: 'array',
 		default: [

--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -7,6 +7,10 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
 	multipleChoice: {
 		type: 'boolean',
 		default: true,

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -16,6 +16,7 @@ import {
 	QuestionHeader,
 	QuestionWrapper,
 } from '@crowdsignal/blocks';
+import Sidebar from './sidebar';
 
 const shiftLabelFocus = ( wrapper, type, index ) =>
 	tap(
@@ -25,7 +26,9 @@ const shiftLabelFocus = ( wrapper, type, index ) =>
 		( input ) => input && input.focus()
 	);
 
-const EditMatrix = ( { attributes, setAttributes } ) => {
+const EditMatrix = ( props ) => {
+	const { attributes, setAttributes } = props;
+
 	const tableWrapper = useRef();
 
 	const handleChangeQuestion = ( question ) => setAttributes( { question } );
@@ -95,6 +98,8 @@ const EditMatrix = ( { attributes, setAttributes } ) => {
 
 	return (
 		<QuestionWrapper attributes={ attributes }>
+			<Sidebar { ...props } />
+
 			<RichText
 				tagName={ QuestionHeader }
 				placeholder={ __( 'Enter your question', 'block-editor' ) }

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -49,7 +49,7 @@ const shiftLabelFocus = ( wrapper, type, index ) =>
 	);
 
 const EditMatrix = ( props ) => {
-	const { attributes, setAttributes } = props;
+	const { attributes, className, setAttributes } = props;
 
 	const [ currentColumn, setCurrentColumn ] = useState( null );
 	const [ currentRow, setCurrentRow ] = useState( null );
@@ -157,6 +157,14 @@ const EditMatrix = ( props ) => {
 		setCurrentRow( index );
 	};
 
+	const blockClasses = classnames(
+		'crowdsignal-forms-matrix-question-block',
+		className,
+		{
+			'is-required': attributes.mandatory,
+		}
+	);
+
 	const tableStyles = {
 		gridTemplateColumns: join(
 			times( attributes.columns.length + 1, () => '1fr' ),
@@ -170,7 +178,7 @@ const EditMatrix = ( props ) => {
 	};
 
 	return (
-		<QuestionWrapper attributes={ attributes }>
+		<QuestionWrapper attributes={ attributes } className={ blockClasses }>
 			<Toolbar
 				currentColumn={ currentColumn }
 				currentRow={ currentRow }

--- a/packages/block-editor/src/matrix-question/sidebar.js
+++ b/packages/block-editor/src/matrix-question/sidebar.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BorderSettings from '../components/border-settings';
+import ColorSettings from '../components/color-settings';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeMandatory = ( mandatory ) =>
+		setAttributes( {
+			mandatory,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Answer Settings', 'block-editor' ) }
+				initialOpen={ true }
+			>
+				<ToggleControl
+					label={ __( 'An answer is required', 'block-editor' ) }
+					checked={ attributes.mandatory }
+					onChange={ handleChangeMandatory }
+				/>
+			</PanelBody>
+
+			<ColorSettings
+				initialOpen={ false }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+			<BorderSettings
+				initialOpen={ false }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/block-editor/src/matrix-question/styles.js
+++ b/packages/block-editor/src/matrix-question/styles.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+export const Label = styled.div`
+	cursor: pointer;
+	position: relative;
+
+	&.crowdsignal-forms-matrix-question-block__column-label.is-active::before {
+		border: 3px solid var( --color-primary );
+		box-sizing: border-box;
+		content: '';
+		display: block;
+		height: var( --crowdsignal-forms-matrix-question-block-table-height );
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: calc( 100% - 4px );
+	}
+
+	&.crowdsignal-forms-matrix-question-block__row-label.is-active::before {
+		border: 3px solid var( --color-primary );
+		box-sizing: border-box;
+		content: '';
+		display: block;
+		height: calc( 100% - 4px );
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: var( --crowdsignal-forms-matrix-question-block-table-width );
+	}
+`;

--- a/packages/block-editor/src/matrix-question/toolbar.js
+++ b/packages/block-editor/src/matrix-question/toolbar.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { BlockControls } from '@wordpress/block-editor';
+import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	tableColumnAfter,
+	tableColumnBefore,
+	tableColumnDelete,
+	tableRowAfter,
+	tableRowBefore,
+	tableRowDelete,
+	table,
+} from '@wordpress/icons';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { MultipleChoiceIcon, SingleChoiceIcon } from '@crowdsignal/icons';
+
+const multipleChoiceControls = [
+	{
+		icon: SingleChoiceIcon,
+		title: __( 'Single choice', 'block-editor' ),
+		value: false,
+		isActive: ( { multipleChoice } ) => ! multipleChoice,
+	},
+	{
+		icon: MultipleChoiceIcon,
+		title: __( 'Multiple choice', 'block-editor' ),
+		value: true,
+		isActive: ( { multipleChoice } ) => !! multipleChoice,
+	},
+];
+
+const MatrixQuestionToolbar = ( {
+	addLabel,
+	attributes,
+	currentColumn,
+	currentRow,
+	removeLabel,
+	setAttributes,
+} ) => {
+	const multipleChoiceToolbar = map(
+		multipleChoiceControls,
+		( { isActive, ...button } ) => ( {
+			...button,
+			isActive: isActive( attributes ),
+			onClick: () =>
+				setAttributes( {
+					multipleChoice: button.value,
+				} ),
+		} )
+	);
+
+	const tableControls = [
+		{
+			icon: tableRowBefore,
+			title: __( 'Insert row before' ),
+			isDisabled: currentRow === null,
+			onClick: addLabel( 'rows', currentRow ),
+		},
+		{
+			icon: tableRowAfter,
+			title: __( 'Insert row after' ),
+			isDisabled: currentRow === null,
+			onClick: addLabel( 'rows', currentRow + 1 ),
+		},
+		{
+			icon: tableRowDelete,
+			title: __( 'Delete row' ),
+			isDisabled: currentRow === null,
+			onClick: removeLabel( 'rows', currentRow ),
+		},
+		{
+			icon: tableColumnBefore,
+			title: __( 'Insert column before' ),
+			isDisabled: currentColumn === null,
+			onClick: addLabel( 'columns', currentColumn ),
+		},
+		{
+			icon: tableColumnAfter,
+			title: __( 'Insert column after' ),
+			isDisabled: currentColumn === null,
+			onClick: addLabel( 'columns', currentColumn + 1 ),
+		},
+		{
+			icon: tableColumnDelete,
+			title: __( 'Delete column' ),
+			isDisabled: currentColumn === null,
+			onClick: removeLabel( 'columns', currentColumn ),
+		},
+	];
+
+	return (
+		<>
+			<BlockControls>
+				<Toolbar controls={ multipleChoiceToolbar } />
+			</BlockControls>
+			<BlockControls group="other">
+				<ToolbarDropdownMenu
+					hasArrowIndicator
+					icon={ table }
+					label={ __( 'Edit matrix size', 'block-editor' ) }
+					controls={ tableControls }
+				/>
+			</BlockControls>
+		</>
+	);
+};
+
+export default MatrixQuestionToolbar;

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -52,7 +52,13 @@ const MatrixQuestion = ( { attributes } ) => {
 
 						{ times( attributes.columns.length, ( n ) => (
 							<MatrixCell key={ n }>
-								<FormCheckbox />
+								<FormCheckbox
+									type={
+										attributes.multipleChoice
+											? 'checkbox'
+											: 'radio'
+									}
+								/>
 							</MatrixCell>
 						) ) }
 					</Fragment>

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Fragment, RawHTML } from '@wordpress/element';
+import classnames from 'classnames';
 import { join, map, times } from 'lodash';
 
 /**
@@ -14,7 +15,15 @@ import { FormCheckbox, QuestionHeader, QuestionWrapper } from '../components';
  */
 import { MatrixCell, MatrixTable } from './styles';
 
-const MatrixQuestion = ( { attributes } ) => {
+const MatrixQuestion = ( { attributes, className } ) => {
+	const classes = classnames(
+		'crowdsignal-forms-matrix-question-block',
+		className,
+		{
+			'is-required': attributes.mandatory,
+		}
+	);
+
 	const tableStyles = {
 		gridTemplateColumns: join(
 			times( attributes.columns.length + 1, () => '1fr' ),
@@ -27,7 +36,7 @@ const MatrixQuestion = ( { attributes } ) => {
 	};
 
 	return (
-		<QuestionWrapper attributes={ attributes }>
+		<QuestionWrapper attributes={ attributes } className={ classes }>
 			<QuestionHeader>
 				<RawHTML>{ attributes.question }</RawHTML>
 			</QuestionHeader>

--- a/packages/blocks/src/matrix-question/styles.js
+++ b/packages/blocks/src/matrix-question/styles.js
@@ -19,11 +19,11 @@ export const MatrixCell = styled.div`
 	padding: 16px;
 	text-align: center;
 
-	&.crowdsignal-forms-matrix-block__column-label {
+	&.crowdsignal-forms-matrix-question-block__column-label {
 		border-top-width: 1px;
 	}
 
-	&.crowdsignal-forms-matrix-block__row-label {
+	&.crowdsignal-forms-matrix-question-block__row-label {
 		border-left-width: 1px;
 	}
 `;

--- a/packages/hooks/src/use-blur/index.js
+++ b/packages/hooks/src/use-blur/index.js
@@ -35,7 +35,7 @@ const useBlur = ( onBlur, elements = [] ) => {
 				return;
 			}
 
-			onBlur();
+			onBlur( event );
 		},
 		[ onBlur, ...elements ]
 	);


### PR DESCRIPTION
This patch adds the toolbar and sidebar settings for the Matrix Question block. Most of them match their existing counterparts in our other blocks while some are new. To give an overview:

- Added a mandatory toggle in the sidebar.
- Added color settings in the sidebar for background and text color.
- Added border settings in the sidebar, to control the question wrapper's border.
- Added a radio/checkbox toggle in the toolbar (icons yet to be updated).
- Added a toolbar dropdown for adding and removing rows or columns.

<img width="760" alt="Screen Shot 2022-05-24 at 11 59 26 AM" src="https://user-images.githubusercontent.com/8056203/170019681-902b3724-6d4e-4cfd-9b98-f61e6cd374da.png">

# Testing

- Verify the sidebar settings work in the same way as they do in our other blocks. They were carried over 1:1.
- The radio/checkbox toggle should cause the block to switch between checkboxes or radios.
- Verify the toolbar dropdown options for adding and removing rows and columns work:
  - Click on a column to enable the options for that column.
  - Clicking on a row will enable add/remove row options while disabling the column options.
  - Try adding and removing multiple rows at the same time. The focus should switch every time you add/remove a field.
  - Try adding or removing fields using the key shortcuts, and without selecting any field explicitly use the toolbar dropdown to add or remove a column. It should be done relatively to the one you just added.