### PR TITLE
Enable voting and validation for the Matrix Question block

### DIFF
--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -17,37 +17,11 @@ export default {
 	},
 	columns: {
 		type: 'array',
-		default: [
-			{
-				clientId: 'a',
-				label: 'A',
-			},
-			{
-				clientId: 'b',
-				label: 'B',
-			},
-			{
-				clientId: 'c',
-				label: 'C',
-			},
-		],
+		default: [ {}, {}, {} ],
 	},
 	rows: {
 		type: 'array',
-		default: [
-			{
-				clientId: 'd',
-				label: '1',
-			},
-			{
-				clientId: 'e',
-				label: '2',
-			},
-			{
-				clientId: 'f',
-				label: '3',
-			},
-		],
+		default: [ {}, {}, {} ],
 	},
 	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
 	backgroundColor: {

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -4,6 +4,7 @@
 import { RichText } from '@wordpress/block-editor';
 import {
 	Fragment,
+	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -22,7 +23,7 @@ import {
 	QuestionHeader,
 	QuestionWrapper,
 } from '@crowdsignal/blocks';
-import { useBlur } from '@crowdsignal/hooks';
+import { useBlur, useClientId } from '@crowdsignal/hooks';
 import Sidebar from './sidebar';
 import Toolbar from './toolbar';
 
@@ -86,6 +87,27 @@ const EditMatrix = ( props ) => {
 		},
 		[ tableWrapper ]
 	);
+
+	useClientId( props );
+	useEffect( () => {
+		if (
+			! some( attributes.columns, ( column ) => ! column.clientId ) &&
+			! some( attributes.rows, ( row ) => ! row.clientId )
+		) {
+			return;
+		}
+
+		setAttributes( {
+			columns: map( attributes.columns, ( column ) => ( {
+				...column,
+				clientId: column.clientId || uuid(),
+			} ) ),
+			rows: map( attributes.rows, ( row ) => ( {
+				...row,
+				clientId: row.clientId || uuid(),
+			} ) ),
+		} );
+	}, [] );
 
 	const handleChangeQuestion = ( question ) => setAttributes( { question } );
 
@@ -250,7 +272,7 @@ const EditMatrix = ( props ) => {
 								onClick={ handleChangeCurrentRow( index ) }
 							>
 								<RichText
-									placeholder={ __( 'Rows', 'block-editor' ) }
+									placeholder={ __( 'Row', 'block-editor' ) }
 									onChange={ handleChangeLabel(
 										'rows',
 										index

--- a/packages/blocks/src/matrix-question/cell.js
+++ b/packages/blocks/src/matrix-question/cell.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { useField } from '@crowdsignal/form';
+import { FormCheckbox } from '../components';
+
+/**
+ * Style dependencies
+ */
+import { MatrixCell } from './styles';
+
+const Cell = ( { column, multipleChoice, questionClientId, row } ) => {
+	const { inputProps } = useField( {
+		name: `q_${ questionClientId }[${ row.clientId }]${
+			multipleChoice ? '[]' : ''
+		}`,
+		type: multipleChoice ? 'checkbox' : 'radio',
+		value: column.clientId,
+	} );
+
+	return (
+		<MatrixCell as="label">
+			<FormCheckbox { ...inputProps } />
+		</MatrixCell>
+	);
+};
+
+export default Cell;

--- a/packages/blocks/src/matrix-question/row.js
+++ b/packages/blocks/src/matrix-question/row.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Cell from './cell';
+
+/**
+ * Style dependencies
+ */
+import { MatrixCell } from './styles';
+
+const Row = ( { columns, multipleChoice, questionClientId, row } ) => (
+	<>
+		<MatrixCell className="crowdsignal-forms-matrix-question-block__row-label">
+			<RawHTML>{ row.label }</RawHTML>
+		</MatrixCell>
+
+		{ map( columns, ( column ) => (
+			<Cell
+				key={ column.clientId }
+				multipleChoice={ multipleChoice }
+				column={ column }
+				row={ row }
+				questionClientId={ questionClientId }
+			/>
+		) ) }
+	</>
+);
+
+export default Row;


### PR DESCRIPTION
This patch enables voting and validation for the new Matrix Question block.

<img width="800" alt="Screen Shot 2022-05-26 at 10 33 27 AM" src="https://user-images.githubusercontent.com/8056203/170461061-461d03d7-e820-499f-b296-ac6332a84801.png">

Requires code-D81546, #247 and #248.

# Testing

- Add a new matrix question block to your project, label the rows and columns, publish the project.
- You should be able to submit the project form without filling in any data.
- Mark the matrix question as required and update the project.
- You shouldn't be able to submit an empty form anymore and should get an error about the question being required.
- Select an answer for a single row but leave others empty.
- You should still get a 'this field is required' error message.
- Select answers for all rows, the form should go through and you should see the correct responses back in the dashboard.
- Verify the form works with both radio and checkbox matrix questions.