### PR TITLE
Fixes for the Matrix Question block

### DIFF
--- a/apps/dashboard/src/components/editor/auto-submit-button.js
+++ b/apps/dashboard/src/components/editor/auto-submit-button.js
@@ -10,6 +10,7 @@ import { flatten, includes, map } from 'lodash';
  * Internal dependencies
  */
 import {
+	matrixQuestionBlock,
 	multipleChoiceAnswerBlock,
 	multipleChoiceQuestionBlock,
 	rankingAnswerBlock,
@@ -22,6 +23,7 @@ import {
 
 const FORM_BLOCKS = map(
 	[
+		matrixQuestionBlock,
 		multipleChoiceAnswerBlock,
 		multipleChoiceQuestionBlock,
 		rankingAnswerBlock,

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -188,14 +188,18 @@ const EditMatrix = ( props ) => {
 	);
 
 	const tableStyles = {
-		gridTemplateColumns: join(
-			times( attributes.columns.length + 1, () => '1fr' ),
-			' '
-		),
-		gridTemplateRows: join(
-			times( attributes.rows.length + 1, () => '1fr' ),
-			' '
-		),
+		gridTemplateColumns:
+			'auto ' +
+			join(
+				times( attributes.columns.length, () => '1fr' ),
+				' '
+			),
+		gridTemplateRows:
+			'auto ' +
+			join(
+				times( attributes.rows.length, () => '1fr' ),
+				' '
+			),
 		...tableVars,
 	};
 

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -75,8 +75,15 @@ const EditMatrix = ( props ) => {
 	useBlur(
 		( clickEvent ) => {
 			if (
-				some( getParentNodes( clickEvent.target ), ( element ) =>
-					element.classList.contains( 'block-editor-block-toolbar' )
+				some(
+					getParentNodes( clickEvent.target ),
+					( element ) =>
+						element.classList.contains(
+							'block-editor-block-toolbar'
+						) ||
+						element.classList.contains(
+							'crowdsignal-forms-matrix-question-block__toolbar-dropdown'
+						)
 				)
 			) {
 				return;

--- a/packages/block-editor/src/matrix-question/index.js
+++ b/packages/block-editor/src/matrix-question/index.js
@@ -13,9 +13,9 @@ import EditMatrix from './edit';
 
 const settings = {
 	apiVersion: 1,
-	title: __( 'Matrix Question', 'blocks' ),
-	description: __( 'Enter the matrix', 'blocks' ),
-	category: 'crowdsignal-forms',
+	title: __( 'Matrix Question', 'block-editor' ),
+	description: __( 'Enter the matrix', 'block-editor' ),
+	category: 'crowdsignal-forms/form',
 	edit: EditMatrix,
 	icon: <MatrixQuestionIcon />,
 	attributes,

--- a/packages/block-editor/src/matrix-question/styles.js
+++ b/packages/block-editor/src/matrix-question/styles.js
@@ -13,6 +13,7 @@ export const Label = styled.div`
 		content: '';
 		display: block;
 		height: var( --crowdsignal-forms-matrix-question-block-table-height );
+		pointer-events: none;
 		position: absolute;
 		top: 2px;
 		left: 2px;
@@ -25,6 +26,7 @@ export const Label = styled.div`
 		content: '';
 		display: block;
 		height: calc( 100% - 4px );
+		pointer-events: none;
 		position: absolute;
 		top: 2px;
 		left: 2px;

--- a/packages/block-editor/src/matrix-question/toolbar.js
+++ b/packages/block-editor/src/matrix-question/toolbar.js
@@ -55,58 +55,62 @@ const MatrixQuestionToolbar = ( {
 		} )
 	);
 
-	const tableControls = [
-		{
-			icon: tableRowBefore,
-			title: __( 'Insert row before' ),
-			isDisabled: currentRow === null,
-			onClick: addLabel( 'rows', currentRow ),
-		},
-		{
-			icon: tableRowAfter,
-			title: __( 'Insert row after' ),
-			isDisabled: currentRow === null,
-			onClick: addLabel( 'rows', currentRow + 1 ),
-		},
-		{
-			icon: tableRowDelete,
-			title: __( 'Delete row' ),
-			isDisabled: currentRow === null,
-			onClick: removeLabel( 'rows', currentRow ),
-		},
-		{
-			icon: tableColumnBefore,
-			title: __( 'Insert column before' ),
-			isDisabled: currentColumn === null,
-			onClick: addLabel( 'columns', currentColumn ),
-		},
-		{
-			icon: tableColumnAfter,
-			title: __( 'Insert column after' ),
-			isDisabled: currentColumn === null,
-			onClick: addLabel( 'columns', currentColumn + 1 ),
-		},
-		{
-			icon: tableColumnDelete,
-			title: __( 'Delete column' ),
-			isDisabled: currentColumn === null,
-			onClick: removeLabel( 'columns', currentColumn ),
-		},
-	];
+	const tableControls =
+		currentRow !== null
+			? [
+					{
+						icon: tableRowBefore,
+						title: __( 'Insert row before' ),
+						onClick: addLabel( 'rows', currentRow ),
+					},
+					{
+						icon: tableRowAfter,
+						title: __( 'Insert row after' ),
+						onClick: addLabel( 'rows', currentRow + 1 ),
+					},
+					{
+						icon: tableRowDelete,
+						title: __( 'Delete row' ),
+						onClick: removeLabel( 'rows', currentRow ),
+					},
+			  ]
+			: [
+					{
+						icon: tableColumnBefore,
+						title: __( 'Insert column before' ),
+						onClick: addLabel( 'columns', currentColumn ),
+					},
+					{
+						icon: tableColumnAfter,
+						title: __( 'Insert column after' ),
+						onClick: addLabel( 'columns', currentColumn + 1 ),
+					},
+					{
+						icon: tableColumnDelete,
+						title: __( 'Delete column' ),
+						onClick: removeLabel( 'columns', currentColumn ),
+					},
+			  ];
 
 	return (
 		<>
 			<BlockControls>
 				<Toolbar controls={ multipleChoiceToolbar } />
 			</BlockControls>
-			<BlockControls group="other">
-				<ToolbarDropdownMenu
-					hasArrowIndicator
-					icon={ table }
-					label={ __( 'Edit matrix size', 'block-editor' ) }
-					controls={ tableControls }
-				/>
-			</BlockControls>
+			{ ( currentColumn !== null || currentRow !== null ) && (
+				<BlockControls group="other">
+					<ToolbarDropdownMenu
+						hasArrowIndicator
+						icon={ table }
+						label={ __( 'Edit matrix size', 'block-editor' ) }
+						controls={ tableControls }
+						popoverProps={ {
+							className:
+								'crowdsignal-forms-matrix-question-block__toolbar-dropdown',
+						} }
+					/>
+				</BlockControls>
+			) }
 		</>
 	);
 };

--- a/packages/block-editor/src/matrix-question/toolbar.js
+++ b/packages/block-editor/src/matrix-question/toolbar.js
@@ -93,25 +93,22 @@ const MatrixQuestionToolbar = ( {
 			  ];
 
 	return (
-		<>
-			<BlockControls>
-				<Toolbar controls={ multipleChoiceToolbar } />
-			</BlockControls>
+		<BlockControls group="other">
+			<Toolbar controls={ multipleChoiceToolbar } />
+
 			{ ( currentColumn !== null || currentRow !== null ) && (
-				<BlockControls group="other">
-					<ToolbarDropdownMenu
-						hasArrowIndicator
-						icon={ table }
-						label={ __( 'Edit matrix size', 'block-editor' ) }
-						controls={ tableControls }
-						popoverProps={ {
-							className:
-								'crowdsignal-forms-matrix-question-block__toolbar-dropdown',
-						} }
-					/>
-				</BlockControls>
+				<ToolbarDropdownMenu
+					hasArrowIndicator
+					icon={ table }
+					label={ __( 'Edit matrix size', 'block-editor' ) }
+					controls={ tableControls }
+					popoverProps={ {
+						className:
+							'crowdsignal-forms-matrix-question-block__toolbar-dropdown',
+					} }
+				/>
 			) }
-		</>
+		</BlockControls>
 	);
 };
 

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -47,14 +47,18 @@ const MatrixQuestion = ( { attributes, className } ) => {
 	);
 
 	const tableStyles = {
-		gridTemplateColumns: join(
-			times( attributes.columns.length + 1, () => '1fr' ),
-			' '
-		),
-		gridTemplateRows: join(
-			times( attributes.rows.length + 1, () => '1fr' ),
-			' '
-		),
+		gridTemplateColumns:
+			'auto ' +
+			join(
+				times( attributes.columns.length, () => '1fr' ),
+				' '
+			),
+		gridTemplateRows:
+			'auto ' +
+			join(
+				times( attributes.rows.length, () => '1fr' ),
+				' '
+			),
 	};
 
 	return (

--- a/packages/blocks/src/matrix-question/styles.js
+++ b/packages/blocks/src/matrix-question/styles.js
@@ -16,6 +16,7 @@ export const MatrixCell = styled.div`
 	box-sizing: border-box;
 	display: inline-flex;
 	justify-content: center;
+	min-width: 0;
 	padding: 16px;
 	text-align: center;
 


### PR DESCRIPTION
This patch contains a number of fixes for the Matrix Question block:

- Fixed an issue where clicking any of the add/remove row/column options would cause the selected row or column to loose focus and nothing to happen.
- The 'table size' dropdown now only appears when a row or column is selected and only displays the relevant options.
- Adjusted the table styling to help the cells scale better relative to their content.
- Added the block to the list of blocks which will auto-append a submit button block if none is present.
- Moved the single/multiple-choice controls to the right side of the toolbar.

# Testing

Create a project with a matrix question block and verify the above issues are fixed.