### PR TITLE
Add a placeholder for the matrix question block

### DIFF
--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -17,11 +17,11 @@ export default {
 	},
 	columns: {
 		type: 'array',
-		default: [ {}, {}, {} ],
+		default: [],
 	},
 	rows: {
 		type: 'array',
-		default: [ {}, {}, {} ],
+		default: [],
 	},
 	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
 	backgroundColor: {

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -4,7 +4,6 @@
 import { RichText } from '@wordpress/block-editor';
 import {
 	Fragment,
-	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
@@ -12,7 +11,18 @@ import {
 import { __ } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import classnames from 'classnames';
-import { filter, join, map, noop, slice, some, tap, trim, times } from 'lodash';
+import {
+	filter,
+	isEmpty,
+	join,
+	map,
+	noop,
+	slice,
+	some,
+	tap,
+	trim,
+	times,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +34,7 @@ import {
 	QuestionWrapper,
 } from '@crowdsignal/blocks';
 import { useBlur, useClientId } from '@crowdsignal/hooks';
+import MatrixQuestionPlaceholder from './placeholder';
 import Sidebar from './sidebar';
 import Toolbar from './toolbar';
 
@@ -59,7 +70,13 @@ const EditMatrix = ( props ) => {
 
 	const tableWrapper = useRef();
 
+	useClientId( props );
+
 	useLayoutEffect( () => {
+		if ( isEmpty( attributes.columns ) || isEmpty( attributes.rows ) ) {
+			return;
+		}
+
 		const container = tableWrapper.current.getBoundingClientRect();
 
 		setTableVars( {
@@ -87,27 +104,6 @@ const EditMatrix = ( props ) => {
 		},
 		[ tableWrapper ]
 	);
-
-	useClientId( props );
-	useEffect( () => {
-		if (
-			! some( attributes.columns, ( column ) => ! column.clientId ) &&
-			! some( attributes.rows, ( row ) => ! row.clientId )
-		) {
-			return;
-		}
-
-		setAttributes( {
-			columns: map( attributes.columns, ( column ) => ( {
-				...column,
-				clientId: column.clientId || uuid(),
-			} ) ),
-			rows: map( attributes.rows, ( row ) => ( {
-				...row,
-				clientId: row.clientId || uuid(),
-			} ) ),
-		} );
-	}, [] );
 
 	const handleChangeQuestion = ( question ) => setAttributes( { question } );
 
@@ -198,6 +194,10 @@ const EditMatrix = ( props ) => {
 		),
 		...tableVars,
 	};
+
+	if ( isEmpty( attributes.columns ) || isEmpty( attributes.rows ) ) {
+		return <MatrixQuestionPlaceholder { ...props } />;
+	}
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ blockClasses }>

--- a/packages/block-editor/src/matrix-question/placeholder.js
+++ b/packages/block-editor/src/matrix-question/placeholder.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { BlockIcon } from '@wordpress/block-editor';
+import { Button, Placeholder, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { v4 as uuid } from 'uuid';
+import { times } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { MatrixQuestionIcon } from '@crowdsignal/icons';
+
+/**
+ * Style dependencies
+ */
+import { PlaceholderForm, PlaceholderInput } from './styles';
+
+const MatrixQuestionPlaceholder = ( { setAttributes } ) => {
+	const [ columnCount, setColumnCount ] = useState( 3 );
+	const [ rowCount, setRowCount ] = useState( 3 );
+
+	const handleCreateMatrix = () =>
+		setAttributes( {
+			columns: times( columnCount, () => ( {
+				clientId: uuid(),
+				label: '',
+			} ) ),
+			rows: times( rowCount, () => ( {
+				clientId: uuid(),
+				label: '',
+			} ) ),
+		} );
+
+	return (
+		<Placeholder
+			label={ __( 'Matrix Question', 'block-editor' ) }
+			icon={ <BlockIcon icon={ MatrixQuestionIcon } /> }
+			instructions={ __(
+				'Choose the amount of rows and columns for your Matrix Question:',
+				'block-editor'
+			) }
+		>
+			<PlaceholderForm onSubmit={ handleCreateMatrix }>
+				<PlaceholderInput
+					as={ TextControl }
+					type="number"
+					label={ __( 'Column count' ) }
+					value={ columnCount }
+					onChange={ setColumnCount }
+					min="1"
+				/>
+				<PlaceholderInput
+					as={ TextControl }
+					type="number"
+					label={ __( 'Row count' ) }
+					value={ rowCount }
+					onChange={ setRowCount }
+					min="1"
+				/>
+				<Button variant="primary" type="submit">
+					{ __( 'Create Matrix Question' ) }
+				</Button>
+			</PlaceholderForm>
+		</Placeholder>
+	);
+};
+
+export default MatrixQuestionPlaceholder;

--- a/packages/block-editor/src/matrix-question/styles.js
+++ b/packages/block-editor/src/matrix-question/styles.js
@@ -31,3 +31,22 @@ export const Label = styled.div`
 		width: var( --crowdsignal-forms-matrix-question-block-table-width );
 	}
 `;
+
+export const PlaceholderForm = styled.form`
+	align-items: flex-end;
+	display: flex;
+	flex-direction: row;
+`;
+
+export const PlaceholderInput = styled.div`
+	margin-right: 8px;
+	width: 112px;
+
+	input[type='number'] {
+		height: 36px;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+`;


### PR DESCRIPTION
This patch adds a placeholder for the matrix question block which will allow you to specify how many rows or columns you'd like when the block is created:

<img width="750" alt="Screen Shot 2022-05-26 at 4 45 04 PM" src="https://user-images.githubusercontent.com/8056203/170525108-6736c2ec-0f5b-4808-b011-5b859bb56bbb.png">

# Testing

- Add a matrix question block, you should see the placeholder.
- Type in a number for the rows and columns and hit create.
- The block should be created with your desired number of rows and columns.