### PR TITLE
fix/title edit button styling

### DIFF
--- a/packages/components/src/button/styles.js
+++ b/packages/components/src/button/styles.js
@@ -102,6 +102,7 @@ export const Button = styled.button`
 		background-color: transparent;
 		padding-left: 6px;
 		padding-right: 6px;
+		box-shadow: inset 0 0 0 1px var( --color-text );
 
 		&:hover {
 			box-shadow: inset 0 0 0 1px var( --color-text );

--- a/packages/components/src/editable-page-header/style.scss
+++ b/packages/components/src/editable-page-header/style.scss
@@ -31,5 +31,5 @@
 }
 
 .editable-page-header__button {
-	margin-left: 8px;
+	margin-left: 16px;
 }


### PR DESCRIPTION
As title.  Thomas wanted a permanant border around the edit button that appears on hover in the editor.

Updated the borderless button style to ironically have a border (blame Kuba). 

Test, apply patch, hover over title in project, observe the edit button has a border.