### PR TITLE
fix/change document to project in inspector panel

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -57,7 +57,7 @@ export const editorSettings = {
 			inspector: true,
 		},
 		toolbar: {
-			documentInspector: __( 'Document', 'dashboard' ),
+			documentInspector: __( 'Project', 'dashboard' ),
 			inspector: true,
 			navigation: true,
 			toc: false,


### PR DESCRIPTION
Now that we updated our deps, I was finally able to change the word "document" to "project" on the inspector with a one-liner.
<img width="271" alt="Screen Shot 2022-06-01 at 10 43 41 AM" src="https://user-images.githubusercontent.com/12895386/171433302-e979949e-4a52-4ba8-90bc-128e7109a735.png">

testing:  Apply the patch, click the editor and confirm the tab on the right sidebar says "project" instead of "Document"
