### PR TITLE
Add table border settings for the matrix question block

### DIFF
--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -23,8 +23,20 @@ export default {
 		type: 'array',
 		default: [],
 	},
+	tableBorderColor: {
+		type: 'string',
+	},
 	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
 	backgroundColor: {
+		type: 'string',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'string',
+	},
+	borderWidth: {
 		type: 'string',
 	},
 	gradient: {

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -191,6 +191,8 @@ const EditMatrix = ( props ) => {
 	);
 
 	const tableStyles = {
+		'--crowdsignal-forms-question-border-color':
+			attributes.tableBorderColor,
 		gridTemplateColumns:
 			'auto ' +
 			join(

--- a/packages/block-editor/src/matrix-question/sidebar.js
+++ b/packages/block-editor/src/matrix-question/sidebar.js
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/block-editor';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,9 +16,9 @@ import BorderSettings from '../components/border-settings';
 import ColorSettings from '../components/color-settings';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
-	const handleChangeMandatory = ( mandatory ) =>
+	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
-			mandatory,
+			[ key ]: value,
 		} );
 
 	return (
@@ -26,7 +30,7 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 				<ToggleControl
 					label={ __( 'An answer is required', 'block-editor' ) }
 					checked={ attributes.mandatory }
-					onChange={ handleChangeMandatory }
+					onChange={ handleChangeAttribute( 'mandatory' ) }
 				/>
 			</PanelBody>
 
@@ -39,6 +43,20 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 				initialOpen={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
+			/>
+
+			<PanelColorGradientSettings
+				title={ __( 'Table border', 'block-editor' ) }
+				initialOpen={ false }
+				settings={ [
+					{
+						label: __( 'Border color', 'block-editor' ),
+						colorValue: attributes.tableBorderColor,
+						onColorChange: handleChangeAttribute(
+							'tableBorderColor'
+						),
+					},
+				] }
 			/>
 		</InspectorControls>
 	);

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -47,6 +47,8 @@ const MatrixQuestion = ( { attributes, className } ) => {
 	);
 
 	const tableStyles = {
+		'--crowdsignal-forms-question-border-color':
+			attributes.tableBorderColor,
 		gridTemplateColumns:
 			'auto ' +
 			join(

--- a/packages/blocks/src/matrix-question/styles.js
+++ b/packages/blocks/src/matrix-question/styles.js
@@ -10,7 +10,7 @@ export const MatrixTable = styled.div`
 
 export const MatrixCell = styled.div`
 	align-items: center;
-	border: 1px solid;
+	border: 1px solid var( --crowdsignal-forms-question-border-color );
 	border-top-width: 0;
 	border-left-width: 0;
 	box-sizing: border-box;


### PR DESCRIPTION
This patch adds a 'Table Border' settings panel to the Matrix Question's sidebar, which allows for manual control over the table border color.

It should match the question wrapper border color by default or when disabled.

<img width="746" alt="Screen Shot 2022-06-02 at 11 01 28 AM" src="https://user-images.githubusercontent.com/8056203/171595779-d0594d94-d286-44c9-a9e7-18ca0b5abcf7.png">

# Testing

- Create a matrix question block.
- Change the table border color.
- Verify the table border color has been updated in the editor and on the preview as expected.