### PR TITLE
Enable Matrix Question block

### DIFF
--- a/apps/dashboard/src/components/editor/blocks.js
+++ b/apps/dashboard/src/components/editor/blocks.js
@@ -16,16 +16,9 @@ import {
 import { MediaUploader } from './media-upload';
 
 export const registerBlocks = () =>
-	forEach( blocks, ( block ) => {
-		if (
-			process.env.NODE_ENV === 'production' &&
-			block.name === 'crowdsignal-forms/matrix-question'
-		) {
-			return;
-		}
-
-		registerBlockType( block.name, block.settings );
-	} );
+	forEach( blocks, ( block ) =>
+		registerBlockType( block.name, block.settings )
+	);
 
 addFilter(
 	'editor.BlockListBlock',


### PR DESCRIPTION
This patch will enable the matrix question block in the editor on production.

# Testing

- Compile the dashboard build with `NODE_ENV=production`.
- Matrix Question block should be available.