### PR TITLE
Provide fallback values for matrix questions' default table border color

### DIFF
--- a/packages/blocks/src/matrix-question/styles.js
+++ b/packages/blocks/src/matrix-question/styles.js
@@ -10,7 +10,11 @@ export const MatrixTable = styled.div`
 
 export const MatrixCell = styled.div`
 	align-items: center;
-	border: 1px solid var( --crowdsignal-forms-question-border-color );
+	border: 1px solid;
+	border-color: var(
+		--crowdsignal-forms-question-border-color,
+		var( --wp--preset--color--foreground, #ccc )
+	);
 	border-top-width: 0;
 	border-left-width: 0;
 	box-sizing: border-box;


### PR DESCRIPTION
This patch provides fallback values for the default table border color on the matrix question block, fixing the issue pointed out by @jcheringer in #257.

In anticipation of upcoming features for managing style settings, I decided it'd be best not to overcomplicate our stylesheets - not all of them share the same variables, some depend on WP variables which may or may not exist depending on the theme as well - and addressed the issue inside the block styles directly.

The border is now clearly visible in every theme, and matches them fairly well too:

<img width="745" alt="Screen Shot 2022-06-02 at 8 17 04 PM" src="https://user-images.githubusercontent.com/8056203/171700065-9f50716f-8462-4576-996b-a432752f3cb9.png">
<img width="659" alt="Screen Shot 2022-06-02 at 8 17 18 PM" src="https://user-images.githubusercontent.com/8056203/171700074-197553d1-ee91-40e1-b13b-6aa642e579dc.png">
<img width="742" alt="Screen Shot 2022-06-02 at 8 17 31 PM" src="https://user-images.githubusercontent.com/8056203/171700086-ded82798-0604-4461-82f7-9e2e0018059c.png">
<img width="740" alt="Screen Shot 2022-06-02 at 8 17 46 PM" src="https://user-images.githubusercontent.com/8056203/171700099-ac1af670-18ea-4fc7-89ec-5afa61838bf4.png">
<img width="746" alt="Screen Shot 2022-06-02 at 8 18 00 PM" src="https://user-images.githubusercontent.com/8056203/171700115-d7a751e8-093d-45ec-a9ce-06217d8d8d98.png">
<img width="749" alt="Screen Shot 2022-06-02 at 8 18 13 PM" src="https://user-images.githubusercontent.com/8056203/171700135-f0a01cfa-e16d-420d-8601-84ab7b9522c8.png">

# Testing

- Create a Matrix Question block
- The table border should now be visible on every theme without explicitly adding it.