### PR TITLE
Add alignment controls to question blocks

### DIFF
--- a/packages/block-editor/src/matrix-question/attributes.js
+++ b/packages/block-editor/src/matrix-question/attributes.js
@@ -48,4 +48,7 @@ export default {
 	width: {
 		type: 'number',
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -187,6 +187,7 @@ const EditMatrix = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/matrix-question/edit.js
+++ b/packages/block-editor/src/matrix-question/edit.js
@@ -187,7 +187,6 @@ const EditMatrix = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
-			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/matrix-question/index.js
+++ b/packages/block-editor/src/matrix-question/index.js
@@ -42,6 +42,7 @@ const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'wide', 'full' ],
 	},
 	example: {
 		attributes: {
@@ -90,6 +91,11 @@ const settings = {
 				},
 			],
 		},
+	},
+	getEditWrapperProps( { justification } ) {
+		return {
+			'data-justify': justification,
+		};
 	},
 };
 

--- a/packages/block-editor/src/matrix-question/toolbar.js
+++ b/packages/block-editor/src/matrix-question/toolbar.js
@@ -19,6 +19,7 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import { CheckboxInputIcon, RadioInputIcon } from '@crowdsignal/icons';
+import { JustificationControl } from '../util/justification-control';
 
 const multipleChoiceControls = [
 	{
@@ -93,22 +94,30 @@ const MatrixQuestionToolbar = ( {
 			  ];
 
 	return (
-		<BlockControls group="other">
-			<Toolbar controls={ multipleChoiceToolbar } />
+		<>
+			<JustificationControl
+				justification={ attributes.justification }
+				onChange={ ( value ) => {
+					setAttributes( { justification: value } );
+				} }
+			/>
+			<BlockControls group="other">
+				<Toolbar controls={ multipleChoiceToolbar } />
 
-			{ ( currentColumn !== null || currentRow !== null ) && (
-				<ToolbarDropdownMenu
-					hasArrowIndicator
-					icon={ table }
-					label={ __( 'Edit matrix size', 'block-editor' ) }
-					controls={ tableControls }
-					popoverProps={ {
-						className:
-							'crowdsignal-forms-matrix-question-block__toolbar-dropdown',
-					} }
-				/>
-			) }
-		</BlockControls>
+				{ ( currentColumn !== null || currentRow !== null ) && (
+					<ToolbarDropdownMenu
+						hasArrowIndicator
+						icon={ table }
+						label={ __( 'Edit matrix size', 'block-editor' ) }
+						controls={ tableControls }
+						popoverProps={ {
+							className:
+								'crowdsignal-forms-matrix-question-block__toolbar-dropdown',
+						} }
+					/>
+				) }
+			</BlockControls>
+		</>
 	);
 };
 

--- a/packages/block-editor/src/multiple-choice-question/attributes.js
+++ b/packages/block-editor/src/multiple-choice-question/attributes.js
@@ -49,4 +49,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/multiple-choice-question/edit.js
+++ b/packages/block-editor/src/multiple-choice-question/edit.js
@@ -35,7 +35,6 @@ const EditMultipleChoiceQuestion = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
-			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/multiple-choice-question/edit.js
+++ b/packages/block-editor/src/multiple-choice-question/edit.js
@@ -35,6 +35,7 @@ const EditMultipleChoiceQuestion = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/multiple-choice-question/index.js
+++ b/packages/block-editor/src/multiple-choice-question/index.js
@@ -36,6 +36,7 @@ const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'wide', 'full' ],
 	},
 	styles: [
 		{
@@ -87,6 +88,11 @@ const settings = {
 				},
 			},
 		],
+	},
+	getEditWrapperProps( { justification } ) {
+		return {
+			'data-justify': justification,
+		};
 	},
 };
 

--- a/packages/block-editor/src/multiple-choice-question/toolbar.js
+++ b/packages/block-editor/src/multiple-choice-question/toolbar.js
@@ -10,6 +10,7 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import { MultipleChoiceIcon, SingleChoiceIcon } from '@crowdsignal/icons';
+import { JustificationControl } from '../util/justification-control';
 
 const multipleChoiceControls = [
 	{
@@ -40,9 +41,17 @@ const MultipleChoiceQuestionToolbar = ( { attributes, setAttributes } ) => {
 	);
 
 	return (
-		<BlockControls>
-			<Toolbar controls={ multipleChoiceToolbar } />
-		</BlockControls>
+		<>
+			<JustificationControl
+				justification={ attributes.justification }
+				onChange={ ( value ) => {
+					setAttributes( { justification: value } );
+				} }
+			/>
+			<BlockControls>
+				<Toolbar controls={ multipleChoiceToolbar } />
+			</BlockControls>
+		</>
 	);
 };
 

--- a/packages/block-editor/src/ranking-question/attributes.js
+++ b/packages/block-editor/src/ranking-question/attributes.js
@@ -31,4 +31,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/ranking-question/edit.js
+++ b/packages/block-editor/src/ranking-question/edit.js
@@ -24,10 +24,7 @@ const EditRakingQuestionBlock = ( props ) => {
 
 	const classes = classnames(
 		'crowdsignal-forms-ranking-question-block',
-		className,
-		{
-			[ `justify-${ attributes.justification }` ]: attributes.justification,
-		}
+		className
 	);
 
 	return (

--- a/packages/block-editor/src/ranking-question/edit.js
+++ b/packages/block-editor/src/ranking-question/edit.js
@@ -15,6 +15,7 @@ import Sidebar from './sidebar';
  * Style dependencies
  */
 import { QuestionHeader, QuestionWrapper } from '@crowdsignal/blocks';
+import Toolbar from './toolbar';
 
 const EditRakingQuestionBlock = ( props ) => {
 	const { attributes, className, setAttributes } = props;
@@ -23,12 +24,16 @@ const EditRakingQuestionBlock = ( props ) => {
 
 	const classes = classnames(
 		'crowdsignal-forms-ranking-question-block',
-		className
+		className,
+		{
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
+		}
 	);
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ classes }>
 			<Sidebar { ...props } />
+			<Toolbar { ...props } />
 
 			<RichText
 				tagName={ QuestionHeader }

--- a/packages/block-editor/src/ranking-question/index.js
+++ b/packages/block-editor/src/ranking-question/index.js
@@ -34,6 +34,7 @@ const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'wide', 'full' ],
 	},
 	example: {
 		attributes: {
@@ -68,6 +69,11 @@ const settings = {
 				},
 			},
 		],
+	},
+	getEditWrapperProps( { justification } ) {
+		return {
+			'data-justify': justification,
+		};
 	},
 };
 

--- a/packages/block-editor/src/ranking-question/toolbar.js
+++ b/packages/block-editor/src/ranking-question/toolbar.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { JustificationControl } from '../util/justification-control';
+
+export default ( { attributes, setAttributes } ) => {
+	return (
+		<JustificationControl
+			justification={ attributes.justification }
+			onChange={ ( value ) => {
+				setAttributes( { justification: value } );
+			} }
+		/>
+	);
+};

--- a/packages/block-editor/src/rating-scale-question/attributes.js
+++ b/packages/block-editor/src/rating-scale-question/attributes.js
@@ -47,4 +47,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/rating-scale-question/edit.js
+++ b/packages/block-editor/src/rating-scale-question/edit.js
@@ -32,7 +32,6 @@ const EditRatingScaleQuestion = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
-			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/rating-scale-question/edit.js
+++ b/packages/block-editor/src/rating-scale-question/edit.js
@@ -15,7 +15,7 @@ import {
 	QuestionWrapper,
 	getBlockStyle,
 } from '@crowdsignal/blocks';
-// import Toolbar from './toolbar';
+import Toolbar from './toolbar';
 import Sidebar from './sidebar';
 
 const ALLOWED_ANSWER_BLOCKS = [ 'crowdsignal-forms/rating-scale-answer' ];
@@ -32,6 +32,7 @@ const EditRatingScaleQuestion = ( props ) => {
 		className,
 		{
 			'is-required': attributes.mandatory,
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 
@@ -41,7 +42,7 @@ const EditRatingScaleQuestion = ( props ) => {
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ classes }>
-			{ /* <Toolbar { ...props } /> */ }
+			<Toolbar { ...props } />
 			<Sidebar { ...props } />
 
 			<RichText

--- a/packages/block-editor/src/rating-scale-question/index.js
+++ b/packages/block-editor/src/rating-scale-question/index.js
@@ -36,6 +36,7 @@ const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'wide', 'full' ],
 	},
 	styles: [
 		{
@@ -87,6 +88,11 @@ const settings = {
 				},
 			},
 		],
+	},
+	getEditWrapperProps( { justification } ) {
+		return {
+			'data-justify': justification,
+		};
 	},
 };
 

--- a/packages/block-editor/src/rating-scale-question/toolbar.js
+++ b/packages/block-editor/src/rating-scale-question/toolbar.js
@@ -1,49 +1,15 @@
 /**
- * External dependencies
- */
-import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { map } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import { MultipleChoiceIcon, SingleChoiceIcon } from '@crowdsignal/icons';
+import { JustificationControl } from '../util/justification-control';
 
-const multipleChoiceControls = [
-	{
-		icon: SingleChoiceIcon,
-		title: __( 'Single choice', 'block-editor' ),
-		value: 1,
-		isActive: ( { maximumChoices } ) => maximumChoices === 1,
-	},
-	{
-		icon: MultipleChoiceIcon,
-		title: __( 'Multiple choice', 'block-editor' ),
-		value: 2,
-		isActive: ( { maximumChoices } ) => maximumChoices !== 1,
-	},
-];
-
-const RatingScaleQuestionToolbar = ( { attributes, setAttributes } ) => {
-	const multipleChoiceToolbar = map(
-		multipleChoiceControls,
-		( { isActive, ...button } ) => ( {
-			...button,
-			isActive: isActive( attributes ),
-			onClick: () =>
-				setAttributes( {
-					maximumChoices: button.value,
-				} ),
-		} )
-	);
-
+export default ( { attributes, setAttributes } ) => {
 	return (
-		<BlockControls>
-			<Toolbar controls={ multipleChoiceToolbar } />
-		</BlockControls>
+		<JustificationControl
+			justification={ attributes.justification }
+			onChange={ ( value ) => {
+				setAttributes( { justification: value } );
+			} }
+		/>
 	);
 };
-
-export default RatingScaleQuestionToolbar;

--- a/packages/block-editor/src/text-question/attributes.js
+++ b/packages/block-editor/src/text-question/attributes.js
@@ -60,4 +60,7 @@ export default {
 		type: 'number',
 		default: 100,
 	},
+	justification: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/text-question/edit.js
+++ b/packages/block-editor/src/text-question/edit.js
@@ -43,7 +43,6 @@ const EditTextQuestion = ( props ) => {
 		'crowdsignal-forms-text-question-block',
 		{
 			'is-required': attributes.mandatory,
-			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 

--- a/packages/block-editor/src/text-question/edit.js
+++ b/packages/block-editor/src/text-question/edit.js
@@ -16,6 +16,7 @@ import {
 } from '@crowdsignal/blocks';
 import { useClientId } from '@crowdsignal/hooks';
 import Sidebar from './sidebar';
+import Toolbar from '../ranking-question/toolbar';
 
 const EditTextQuestion = ( props ) => {
 	const { attributes, className, isSelected, setAttributes } = props;
@@ -42,12 +43,14 @@ const EditTextQuestion = ( props ) => {
 		'crowdsignal-forms-text-question-block',
 		{
 			'is-required': attributes.mandatory,
+			[ `justify-${ attributes.justification }` ]: attributes.justification,
 		}
 	);
 
 	return (
 		<QuestionWrapper attributes={ attributes } className={ classes }>
 			<Sidebar { ...props } />
+			<Toolbar { ...props } />
 
 			<RichText
 				tagName={ QuestionHeader }

--- a/packages/block-editor/src/text-question/index.js
+++ b/packages/block-editor/src/text-question/index.js
@@ -31,11 +31,17 @@ const settings = {
 	supports: {
 		html: false,
 		reusable: false,
+		align: [ 'wide', 'full' ],
 	},
 	example: {
 		attributes: {
 			question: __( 'How does gravity work?', 'block-editor' ),
 		},
+	},
+	getEditWrapperProps( { justification } ) {
+		return {
+			'data-justify': justification,
+		};
 	},
 };
 

--- a/packages/block-editor/src/text-question/toolbar.js
+++ b/packages/block-editor/src/text-question/toolbar.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { JustificationControl } from '../util/justification-control';
+
+export default ( { attributes, setAttributes } ) => {
+	return (
+		<JustificationControl
+			justification={ attributes.justification }
+			onChange={ ( value ) => {
+				setAttributes( { justification: value } );
+			} }
+		/>
+	);
+};

--- a/packages/block-editor/src/util/justification-control.js
+++ b/packages/block-editor/src/util/justification-control.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { BlockControls, JustifyContentControl } from '@wordpress/block-editor';
+
+export const JustificationControl = ( { justification, onChange } ) => (
+	<BlockControls group="block">
+		<JustifyContentControl
+			value={ justification }
+			onChange={ onChange }
+			allowedControls={ [ 'left', 'center', 'right' ] }
+		/>
+	</BlockControls>
+);

--- a/packages/blocks/src/components/content-wrapper/index.js
+++ b/packages/blocks/src/components/content-wrapper/index.js
@@ -9,10 +9,10 @@ const ContentWrapper = styled.div`
 	width: 100%;
 
 	&
-		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .wp-block-separator ):not( .entry-attachment ),
+		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .justify ):not( .wp-block-separator ):not( .entry-attachment ),
 	&
 		[class*='inner-container']
-		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .wp-block-separator ) {
+		> *:not( .alignwide ):not( .alignfull ):not( .alignleft ):not( .alignright ):not( .justify ):not( .wp-block-separator ) {
 		max-width: 720px;
 		margin-left: auto;
 		margin-right: auto;

--- a/packages/blocks/src/components/form-input-wrapper/index.js
+++ b/packages/blocks/src/components/form-input-wrapper/index.js
@@ -10,7 +10,6 @@ import { ErrorMessage } from '../';
 
 const FormInputWrapper = styled.div`
 	position: relative;
-	margin-bottom: 24px;
 
 	${ ErrorMessage.className } {
 		position: absolute;

--- a/packages/blocks/src/components/index.js
+++ b/packages/blocks/src/components/index.js
@@ -6,6 +6,7 @@ export { default as FormFileInput } from './form-file-input';
 export { default as FormInputWrapper } from './form-input-wrapper';
 export { default as FormTextarea } from './form-textarea';
 export { default as FormTextInput } from './form-text-input';
+export { default as JustificationWrapper } from './justification-wrapper';
 export { default as QuestionHeader } from './question-header';
 export { default as QuestionWrapper } from './question-wrapper';
 export { default as Spinner } from './spinner';

--- a/packages/blocks/src/components/justification-wrapper/index.js
+++ b/packages/blocks/src/components/justification-wrapper/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+export default ( { justification, children } ) => {
+	const classes = classnames( {
+		[ `justify` ]: justification,
+		[ `justify-${ justification }` ]: justification,
+	} );
+
+	return justification ? (
+		<div className={ classes }>{ children }</div>
+	) : (
+		<>{ children }</>
+	);
+};

--- a/packages/blocks/src/components/question-wrapper/index.js
+++ b/packages/blocks/src/components/question-wrapper/index.js
@@ -17,8 +17,6 @@ const StyledQuestionWrapper = styled.div`
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	margin-bottom: 24px;
-	margin-top: 24px;
 	padding: 32px;
 	position: relative;
 	text-align: left;

--- a/packages/blocks/src/matrix-question/index.js
+++ b/packages/blocks/src/matrix-question/index.js
@@ -10,7 +10,12 @@ import { filter, first, isEmpty, join, map, times } from 'lodash';
  * Internal dependencies
  */
 import { useValidation } from '@crowdsignal/form';
-import { ErrorMessage, QuestionHeader, QuestionWrapper } from '../components';
+import {
+	ErrorMessage,
+	JustificationWrapper,
+	QuestionHeader,
+	QuestionWrapper,
+} from '../components';
 import Row from './row';
 
 /**
@@ -43,6 +48,7 @@ const MatrixQuestion = ( { attributes, className } ) => {
 		{
 			'is-required': attributes.mandatory,
 			'is-error': ! isEmpty( errors ),
+			[ `align${ attributes.align }` ]: attributes.align,
 		}
 	);
 
@@ -64,38 +70,40 @@ const MatrixQuestion = ( { attributes, className } ) => {
 	};
 
 	return (
-		<QuestionWrapper attributes={ attributes } className={ classes }>
-			<QuestionHeader>
-				<RawHTML>{ attributes.question }</RawHTML>
-			</QuestionHeader>
+		<JustificationWrapper justification={ attributes.justification }>
+			<QuestionWrapper attributes={ attributes } className={ classes }>
+				<QuestionHeader>
+					<RawHTML>{ attributes.question }</RawHTML>
+				</QuestionHeader>
 
-			<MatrixTable style={ tableStyles }>
-				<MatrixCell />
+				<MatrixTable style={ tableStyles }>
+					<MatrixCell />
 
-				{ map( attributes.columns, ( column ) => (
-					<MatrixCell
-						key={ column.clientId }
-						className="crowdsignal-forms-matrix-question-block__column-label"
-					>
-						<RawHTML>{ column.label }</RawHTML>
-					</MatrixCell>
-				) ) }
+					{ map( attributes.columns, ( column ) => (
+						<MatrixCell
+							key={ column.clientId }
+							className="crowdsignal-forms-matrix-question-block__column-label"
+						>
+							<RawHTML>{ column.label }</RawHTML>
+						</MatrixCell>
+					) ) }
 
-				{ map( attributes.rows, ( row ) => (
-					<Row
-						key={ row.clientId }
-						questionClientId={ attributes.clientId }
-						row={ row }
-						columns={ attributes.columns }
-						multipleChoice={ attributes.multipleChoice }
-					/>
-				) ) }
-			</MatrixTable>
+					{ map( attributes.rows, ( row ) => (
+						<Row
+							key={ row.clientId }
+							questionClientId={ attributes.clientId }
+							row={ row }
+							columns={ attributes.columns }
+							multipleChoice={ attributes.multipleChoice }
+						/>
+					) ) }
+				</MatrixTable>
 
-			{ ! isEmpty( errors ) && (
-				<ErrorMessage>{ first( errors ) }</ErrorMessage>
-			) }
-		</QuestionWrapper>
+				{ ! isEmpty( errors ) && (
+					<ErrorMessage>{ first( errors ) }</ErrorMessage>
+				) }
+			</QuestionWrapper>
+		</JustificationWrapper>
 	);
 };
 

--- a/packages/blocks/src/multiple-choice-question/index.js
+++ b/packages/blocks/src/multiple-choice-question/index.js
@@ -9,7 +9,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ErrorMessage, QuestionHeader, QuestionWrapper } from '../components';
+import {
+	ErrorMessage,
+	JustificationWrapper,
+	QuestionHeader,
+	QuestionWrapper,
+} from '../components';
 import { Style } from './constants';
 import { useValidation } from '@crowdsignal/form';
 
@@ -33,19 +38,24 @@ const MultipleChoiceQuestion = ( { attributes, children, className } ) => {
 		{
 			'is-required': attributes.mandatory,
 			'is-error': error,
+			[ `align${ attributes.align }` ]: attributes.align,
 		}
 	);
 
 	return (
-		<QuestionWrapper attributes={ attributes } className={ classes }>
-			<QuestionHeader>
-				<RawHTML>{ attributes.question }</RawHTML>
-			</QuestionHeader>
-			<Context.Provider value={ attributes }>
-				<QuestionWrapper.Content>{ children }</QuestionWrapper.Content>
-			</Context.Provider>
-			{ error && <ErrorMessage>{ error }</ErrorMessage> }
-		</QuestionWrapper>
+		<JustificationWrapper justification={ attributes.justification }>
+			<QuestionWrapper attributes={ attributes } className={ classes }>
+				<QuestionHeader>
+					<RawHTML>{ attributes.question }</RawHTML>
+				</QuestionHeader>
+				<Context.Provider value={ attributes }>
+					<QuestionWrapper.Content>
+						{ children }
+					</QuestionWrapper.Content>
+				</Context.Provider>
+				{ error && <ErrorMessage>{ error }</ErrorMessage> }
+			</QuestionWrapper>
+		</JustificationWrapper>
 	);
 };
 

--- a/packages/blocks/src/ranking-question/index.js
+++ b/packages/blocks/src/ranking-question/index.js
@@ -10,7 +10,11 @@ import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 /**
  * Internal dependencies
  */
-import { QuestionHeader, QuestionWrapper } from '../components';
+import {
+	QuestionHeader,
+	QuestionWrapper,
+	JustificationWrapper,
+} from '../components';
 import { useField } from '@crowdsignal/form';
 
 const Context = createContext();
@@ -34,48 +38,57 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 
 	const classes = classnames(
 		'crowdsignal-forms-ranking-question-block',
-		className
+		className,
+		{
+			[ `align${ attributes.align }` ]: attributes.align,
+		}
 	);
 
 	return (
-		<QuestionWrapper attributes={ attributes } className={ classes }>
-			<QuestionHeader>
-				<RawHTML>{ attributes.question }</RawHTML>
-			</QuestionHeader>
-			<Context.Provider value={ attributes }>
-				<QuestionWrapper.Content>
-					<DragDropContext onDragEnd={ handleMoveAnswer }>
-						<Droppable droppableId="crowdsignal/ranking-question">
-							{ ( { droppableProps, innerRef, placeholder } ) => (
-								<div ref={ innerRef } { ...droppableProps }>
-									{ map( children, ( child, index ) => (
-										<Draggable
-											key={ `answer-${ index }` }
-											disableInteractiveElementBlocking={
-												true
-											}
-											draggableId={ `answer-${ index }` }
-											index={ index }
-										>
-											{ ( provided, snapshot ) =>
-												cloneElement( child, {
-													draggable: {
-														...provided,
-														isDragging:
-															snapshot.isDragging,
-													},
-												} )
-											}
-										</Draggable>
-									) ) }
-									{ placeholder }
-								</div>
-							) }
-						</Droppable>
-					</DragDropContext>
-				</QuestionWrapper.Content>
-			</Context.Provider>
-		</QuestionWrapper>
+		<JustificationWrapper justification={ attributes.justification }>
+			<QuestionWrapper attributes={ attributes } className={ classes }>
+				<QuestionHeader>
+					<RawHTML>{ attributes.question }</RawHTML>
+				</QuestionHeader>
+				<Context.Provider value={ attributes }>
+					<QuestionWrapper.Content>
+						<DragDropContext onDragEnd={ handleMoveAnswer }>
+							<Droppable droppableId="crowdsignal/ranking-question">
+								{ ( {
+									droppableProps,
+									innerRef,
+									placeholder,
+								} ) => (
+									<div ref={ innerRef } { ...droppableProps }>
+										{ map( children, ( child, index ) => (
+											<Draggable
+												key={ `answer-${ index }` }
+												disableInteractiveElementBlocking={
+													true
+												}
+												draggableId={ `answer-${ index }` }
+												index={ index }
+											>
+												{ ( provided, snapshot ) =>
+													cloneElement( child, {
+														draggable: {
+															...provided,
+															isDragging:
+																snapshot.isDragging,
+														},
+													} )
+												}
+											</Draggable>
+										) ) }
+										{ placeholder }
+									</div>
+								) }
+							</Droppable>
+						</DragDropContext>
+					</QuestionWrapper.Content>
+				</Context.Provider>
+			</QuestionWrapper>
+		</JustificationWrapper>
 	);
 };
 

--- a/packages/blocks/src/rating-scale-question/index.js
+++ b/packages/blocks/src/rating-scale-question/index.js
@@ -9,7 +9,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ErrorMessage, QuestionHeader, QuestionWrapper } from '../components';
+import {
+	ErrorMessage,
+	JustificationWrapper,
+	QuestionHeader,
+	QuestionWrapper,
+} from '../components';
 import { Style } from './constants';
 import { useValidation } from '@crowdsignal/form';
 
@@ -32,21 +37,24 @@ const RatingScaleQuestion = ( { attributes, children, className } ) => {
 		{
 			'is-required': attributes.mandatory,
 			'is-error': error,
+			[ `align${ attributes.align }` ]: attributes.align,
 		}
 	);
 
 	return (
-		<QuestionWrapper attributes={ attributes } className={ classes }>
-			<QuestionHeader>
-				<RawHTML>{ attributes.question }</RawHTML>
-			</QuestionHeader>
-			<Context.Provider value={ attributes }>
-				<QuestionWrapper.Content horizontal>
-					{ children }
-				</QuestionWrapper.Content>
-			</Context.Provider>
-			{ error && <ErrorMessage>{ error }</ErrorMessage> }
-		</QuestionWrapper>
+		<JustificationWrapper justification={ attributes.justification }>
+			<QuestionWrapper attributes={ attributes } className={ classes }>
+				<QuestionHeader>
+					<RawHTML>{ attributes.question }</RawHTML>
+				</QuestionHeader>
+				<Context.Provider value={ attributes }>
+					<QuestionWrapper.Content horizontal>
+						{ children }
+					</QuestionWrapper.Content>
+				</Context.Provider>
+				{ error && <ErrorMessage>{ error }</ErrorMessage> }
+			</QuestionWrapper>
+		</JustificationWrapper>
 	);
 };
 

--- a/packages/blocks/src/text-question/index.js
+++ b/packages/blocks/src/text-question/index.js
@@ -13,6 +13,7 @@ import { useField } from '@crowdsignal/form';
 import {
 	ErrorMessage,
 	FormTextarea,
+	JustificationWrapper,
 	QuestionHeader,
 	QuestionWrapper,
 } from '../components';
@@ -33,24 +34,27 @@ const TextQuestion = ( { attributes, className } ) => {
 		{
 			'is-required': attributes.mandatory,
 			'is-error': error,
+			[ `align${ attributes.align }` ]: attributes.align,
 		}
 	);
 
 	return (
-		<QuestionWrapper attributes={ attributes } className={ classes }>
-			<QuestionHeader>
-				<RawHTML>{ attributes.question }</RawHTML>
-			</QuestionHeader>
+		<JustificationWrapper justification={ attributes.justification }>
+			<QuestionWrapper attributes={ attributes } className={ classes }>
+				<QuestionHeader>
+					<RawHTML>{ attributes.question }</RawHTML>
+				</QuestionHeader>
 
-			<FormTextarea
-				style={ {
-					height: attributes.inputHeight,
-				} }
-				placeholder={ attributes.placeholder }
-				{ ...inputProps }
-			/>
-			{ error && <ErrorMessage>{ error }</ErrorMessage> }
-		</QuestionWrapper>
+				<FormTextarea
+					style={ {
+						height: attributes.inputHeight,
+					} }
+					placeholder={ attributes.placeholder }
+					{ ...inputProps }
+				/>
+				{ error && <ErrorMessage>{ error }</ErrorMessage> }
+			</QuestionWrapper>
+		</JustificationWrapper>
 	);
 };
 

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -54,11 +54,6 @@ body {
 		margin-bottom: var(--cs--style--block-gap);
 	}
 
-	.crowdsignal-forms-question-wrapper, .crowdsignal-forms-text-input-block {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
 	.wp-block-column {
 		> * {
 			margin-top: 0;
@@ -101,6 +96,11 @@ body {
 	> .crowdsignal-forms-question-wrapper {
 		margin-bottom: var(--cs--style--block-gap-big);
 		margin-top: var(--cs--style--block-gap-big);
+
+		&.alignfull {
+			margin-left: var(--cs--style--block-gap);
+			margin-right: var(--cs--style--block-gap);
+		}
 	}
 
 	.crowdsignal-forms-question-wrapper__content.is-horizontal {
@@ -130,6 +130,34 @@ body {
 
 	> .alignleft {
 		float: left;
+	}
+
+	.justify {
+		max-width: unset;
+		display: flex;
+		justify-content: center;
+		margin-bottom: var(--cs--style--block-gap-big);
+		margin-top: var(--cs--style--block-gap-big);
+
+		&.justify-left {
+			justify-content: flex-start;
+		}
+
+		&.justify-right {
+			justify-content: flex-end;
+		}
+
+		> * {
+			max-width: 720px;
+			flex: 1;
+			margin-left: var(--cs--style--block-gap);
+			margin-right: var(--cs--style--block-gap);
+
+			&.crowdsignal-forms-question-wrapper {
+				margin-bottom: unset;
+				margin-top: unset;
+			}
+		}
 	}
 }
 

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -25,9 +25,14 @@
 	> .wp-block, [data-align] {
 		margin-left: auto;
 		margin-right: auto;
+
+		&[data-type^='crowdsignal'][data-type$='question'] {
+			margin-bottom: var(--cs--style--block-gap-big);
+			margin-top: var(--cs--style--block-gap-big);
+		}
 	}
 
-	.wp-block,
+	> .wp-block,
 	.block-editor-default-block-appender {
 		max-width: 720px;
 	}
@@ -38,12 +43,41 @@
 
 	[data-align='full'] {
 		max-width: none;
+		margin-left: var(--cs--style--block-gap);
+		margin-right: var(--cs--style--block-gap);
+
+		> .crowdsignal-forms-question-wrapper {
+			width: 100%
+		}
+
+		[data-align='full'] {
+			margin: 0;
+		}
 	}
 
-	> .wp-block {
-		 > .crowdsignal-forms-question-wrapper {
-			margin-bottom: var(--cs--style--block-gap-big);
-			margin-top: var(--cs--style--block-gap-big);
+	[data-justify] {
+		display: flex;
+		justify-content: center;
+
+		&[data-justify='left'], &[data-justify='right'] {
+			max-width: unset;
+			margin-left: var(--cs--style--block-gap);
+			margin-right: var(--cs--style--block-gap);
+		}
+
+		&[data-justify='left'] {
+			justify-content: flex-start;
+		}
+
+		&[data-justify='right'] {
+			justify-content: flex-end;
+		}
+
+		> * {
+			flex: 1;
+			max-width: 720px;
+			margin-left: unset;
+			margin-right: unset;
 		}
 	}
 
@@ -111,8 +145,10 @@
 		float: left;
 	}
 
-	& :where(.wp-block)[data-align=full]:first-child {
-		margin-top: var(--cs--block--alignfull-margin-top);
+	.is-root-container {
+		> .wp-block[data-align=full]:first-child {
+			margin-top: var(--cs--block--alignfull-margin-top);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR will add alignment controls to the following blocks:

* Matrix
* MC Question
* Ranking
* Rating Scale
* Text Question

Ref: c/jps1eLaW-tr

## Test Instructions
* Create a project and add one of each block listed above
* Play with the alignment and justification controls, and confirm if they work correctly

## Screenshots
![image](https://user-images.githubusercontent.com/7811225/171733793-15f6d65b-a4f2-4931-be4d-d461fb738254.png)
![image](https://user-images.githubusercontent.com/7811225/171733823-24aefc7e-66f0-4901-9153-62e6064f127d.png)