### PR TITLE
Prevent incorrect blocks from appearing in the block inserter

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -100,11 +100,12 @@ const Editor = ( { project } ) => {
 			return editorSettings;
 		}
 
-		return tap( cloneDeep( editorSettings ), ( { iso } ) => {
+		return tap( cloneDeep( editorSettings ), ( { editor, iso } ) => {
 			iso.blocks.allowBlocks = filter(
 				iso.blocks.allowBlocks,
 				( block ) => ! block.match( /^crowdsignal\-forms\/.+/ )
 			);
+			editor.allowedBlockTypes = iso.blocks.allowBlocks;
 		} );
 	}, [ confirmationPage ] );
 

--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -22,32 +22,34 @@ setCategories( [
 	...getCategories(),
 ] );
 
+const enabledBlocks = [
+	'core/buttons',
+	'core/code',
+	'core/columns',
+	'core/embed',
+	'core/group',
+	'core/heading',
+	'core/html',
+	'core/image',
+	'core/list',
+	'core/paragraph',
+	'core/preformatted',
+	'core/pullquote',
+	'core/quote',
+	'core/row',
+	'core/separator',
+	'core/spacer',
+	'core/table',
+	'core/verse',
+	'core/video',
+	...map( blocks, ( block ) => block.name ),
+];
+
 export const editorSettings = {
 	iso: {
 		blocks: {
-			allowBlocks: [
-				'core/buttons',
-				'core/code',
-				'core/columns',
-				'core/embed',
-				'core/group',
-				'core/heading',
-				'core/html',
-				'core/image',
-				'core/list',
-				'core/paragraph',
-				'core/preformatted',
-				'core/pullquote',
-				'core/quote',
-				'core/row',
-				'core/separator',
-				'core/spacer',
-				'core/table',
-				'core/verse',
-				'core/video',
-
-				...map( blocks, ( block ) => block.name ),
-			],
+			allowBlocks: enabledBlocks,
+			disallowBlock: null,
 		},
 		defaultPreferences: {
 			fixedToolbar: false,
@@ -66,6 +68,7 @@ export const editorSettings = {
 	},
 	editor: {
 		alignWide: true,
+		allowedBlockTypes: enabledBlocks,
 		supportsLayout: false,
 		hasUploadPermissions: true, // not sure what this does, Gutenberg setting.
 		// if allowedMimeTypes is not present or empty, when you click on the MediaUpload handler it will just remove the buttons (????)


### PR DESCRIPTION
This patch will prevent unwanted blocks from appearing in the block inserter.

While it solves #262, it's worth noting it doesn't address the actual core issue in Automattic/isolated-block-editor which leads to there being two different settings objects in use for the same editor instance.

# Testing

- Open a project, verify the inserter only contains the correct blocks.
- Make an edit.
- Verify the project still only contains the correct blocks.
- Repeat the test on the confirmation page, which also shouldn't allow any form blocks.