### PR TITLE
Add Dropdown block

### DIFF
--- a/apps/dashboard/src/components/editor/auto-submit-button.js
+++ b/apps/dashboard/src/components/editor/auto-submit-button.js
@@ -10,6 +10,7 @@ import { flatten, includes, map } from 'lodash';
  * Internal dependencies
  */
 import {
+	dropdownInputBlock,
 	fileInputBlock,
 	matrixQuestionBlock,
 	multipleChoiceAnswerBlock,
@@ -24,6 +25,7 @@ import {
 
 const FORM_BLOCKS = map(
 	[
+		dropdownInputBlock,
 		fileInputBlock,
 		matrixQuestionBlock,
 		multipleChoiceAnswerBlock,

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -37,7 +37,7 @@ export const PagePreviewButton = styled.button`
 
 export const PagePreviewFrame = styled.div`
 	background-color: var( --color-surface );
-	background-color: var( --wp--custom--color--background );
+	background-color: var( --wp--preset--color--background );
 	border: 1px solid var( --color-border );
 	border-radius: 2px;
 	box-sizing: border-box;

--- a/packages/block-editor/src/dropdown-input/attributes.js
+++ b/packages/block-editor/src/dropdown-input/attributes.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	clientId: {
+		type: 'string',
+		default: null,
+	},
+	label: {
+		type: 'string',
+		default: '',
+	},
+	buttonLabel: {
+		type: 'string',
+		default: __( 'Choose an option', 'block-editor' ),
+	},
+	mandatory: {
+		type: 'boolean',
+		default: false,
+	},
+	// Style attributes, should follow the name scheme supported by @crowdsignal/styles helpers.
+	backgroundColor: {
+		type: 'string',
+	},
+	gradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+};

--- a/packages/block-editor/src/dropdown-input/attributes.js
+++ b/packages/block-editor/src/dropdown-input/attributes.js
@@ -16,6 +16,10 @@ export default {
 		type: 'string',
 		default: __( 'Choose an option', 'block-editor' ),
 	},
+	options: {
+		type: 'array',
+		default: [],
+	},
 	mandatory: {
 		type: 'boolean',
 		default: false,

--- a/packages/block-editor/src/dropdown-input/edit.js
+++ b/packages/block-editor/src/dropdown-input/edit.js
@@ -2,24 +2,29 @@
  * External dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { map, split, trim } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { FormInputWrapper } from '@crowdsignal/blocks';
-import Sidebar from './sidebar';
+import { DropdownOption } from './option';
+import { DropdownPlaceholder } from './placeholder';
+import { changeFocus } from '../util/change-focus';
+import { FormDropdownInput, FormInputWrapper } from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import { useClientId } from '@crowdsignal/hooks';
+import Sidebar from './sidebar';
 
 export default ( props ) => {
-	const { attributes, className, setAttributes } = props;
+	const { attributes, className, isSelected, setAttributes } = props;
 
 	useClientId( props );
 
-	const handleChangeAttribute = ( key ) => ( value ) =>
-		setAttributes( { [ key ]: value } );
+	const optionsWrapper = useRef();
+	const placeholder = useRef();
 
 	const classes = classnames(
 		className,
@@ -28,6 +33,69 @@ export default ( props ) => {
 			'is-required': attributes.mandatory,
 		}
 	);
+
+	const focusOption = ( index, cursorToEnd ) =>
+		changeFocus(
+			optionsWrapper.current,
+			'[role=textbox]',
+			index,
+			cursorToEnd
+		);
+
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( { [ key ]: value } );
+
+	const handleSingleValue = ( index, value, cursorToEnd ) => {
+		const options = [ ...attributes.options ];
+		options[ index ] = value;
+		setAttributes( { options } );
+		focusOption( index, cursorToEnd );
+	};
+
+	const handleMultiValues = ( index, array ) => {
+		const options = [ ...attributes.options ];
+		options.splice( index, 1, ...array );
+		setAttributes( { options } );
+		focusOption( index + array.length - 1, true );
+	};
+
+	const handleChangeOption = ( index, cursorToEnd ) => ( value ) => {
+		const values = split( value, '\n' ).filter(
+			( op ) => op && trim( op ) !== ''
+		);
+
+		if ( ! values.length ) {
+			return;
+		}
+
+		if ( values.length > 1 ) {
+			handleMultiValues( index, values );
+		} else {
+			handleSingleValue( index, values.pop(), cursorToEnd );
+		}
+	};
+
+	const handleSplitOption = ( index ) => ( value, isOriginal ) => {
+		if ( ! isOriginal ) {
+			return;
+		}
+
+		const splitValue = attributes.options[ index ].slice( value.length );
+		handleMultiValues( index, [ value, splitValue ] );
+	};
+
+	const handleDeleteOption = ( index ) => () => {
+		const options = [ ...attributes.options ];
+		options.splice( index, 1 );
+		setAttributes( { options } );
+
+		if ( ! options.length ) {
+			setTimeout( () => placeholder.current.focus(), 0 );
+			return;
+		}
+
+		focusOption( Math.max( index - 1, 0 ), true );
+	};
 
 	return (
 		<FormInputWrapper
@@ -42,7 +110,38 @@ export default ( props ) => {
 					value={ attributes.label }
 				/>
 			</FormInputWrapper.Label>
-			<div>[Dropdown Here]</div>
+			<FormDropdownInput.Wrapper>
+				<FormDropdownInput.Button outline>
+					<RichText
+						placeholder={ __( 'Choose an option', 'blocks' ) }
+						value={ attributes.buttonLabel }
+						onChange={ handleChangeAttribute( 'buttonLabel' ) }
+						allowedFormats={ [] }
+						multiline={ false }
+					/>
+				</FormDropdownInput.Button>
+				{ isSelected && (
+					<FormDropdownInput.Options ref={ optionsWrapper }>
+						{ attributes.options.length ? (
+							map( attributes.options, ( option, index ) => (
+								<DropdownOption
+									key={ index }
+									value={ option }
+									onChange={ handleChangeOption( index ) }
+									onRemove={ handleDeleteOption( index ) }
+									onSplit={ handleSplitOption( index ) }
+								/>
+							) )
+						) : (
+							<DropdownPlaceholder
+								key="placeholder"
+								ref={ placeholder }
+								onChange={ handleChangeOption( 0, true ) }
+							/>
+						) }
+					</FormDropdownInput.Options>
+				) }
+			</FormDropdownInput.Wrapper>
 		</FormInputWrapper>
 	);
 };

--- a/packages/block-editor/src/dropdown-input/edit.js
+++ b/packages/block-editor/src/dropdown-input/edit.js
@@ -16,7 +16,6 @@ import { DropdownPlaceholder } from './placeholder';
 import { changeFocus } from '../util/change-focus';
 import { ChevronDownIcon } from '@crowdsignal/icons';
 import { FormDropdownInput, FormInputWrapper } from '@crowdsignal/blocks';
-import { useColorStyles } from '@crowdsignal/styles';
 import { useClientId } from '@crowdsignal/hooks';
 import Sidebar from './sidebar';
 
@@ -120,11 +119,14 @@ export default ( props ) => {
 		focusOption( Math.max( index - 1, 0 ), true );
 	};
 
+	const styles = {
+		'--cs--style--button--foreground': attributes.textColor,
+		'--cs--style--button--background':
+			attributes.backgroundColor || attributes.gradient,
+	};
+
 	return (
-		<FormInputWrapper
-			className={ classes }
-			style={ { ...useColorStyles( attributes ) } }
-		>
+		<FormInputWrapper className={ classes } style={ { ...styles } }>
 			<Sidebar { ...props } />
 			<FormInputWrapper.Label className="crowdsignal-forms-dropdown-input-block__label">
 				<RichText

--- a/packages/block-editor/src/dropdown-input/edit.js
+++ b/packages/block-editor/src/dropdown-input/edit.js
@@ -14,6 +14,7 @@ import classnames from 'classnames';
 import { DropdownOption } from './option';
 import { DropdownPlaceholder } from './placeholder';
 import { changeFocus } from '../util/change-focus';
+import { ChevronDownIcon } from '@crowdsignal/icons';
 import { FormDropdownInput, FormInputWrapper } from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import { useClientId } from '@crowdsignal/hooks';
@@ -141,6 +142,7 @@ export default ( props ) => {
 						allowedFormats={ [] }
 						multiline={ false }
 					/>
+					<ChevronDownIcon />
 				</FormDropdownInput.Button>
 				{ isSelected && (
 					<FormDropdownInput.Options ref={ optionsWrapper }>

--- a/packages/block-editor/src/dropdown-input/edit.js
+++ b/packages/block-editor/src/dropdown-input/edit.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { FormInputWrapper } from '@crowdsignal/blocks';
+import Sidebar from './sidebar';
+import { useColorStyles } from '@crowdsignal/styles';
+import { useClientId } from '@crowdsignal/hooks';
+
+export default ( props ) => {
+	const { attributes, className, setAttributes } = props;
+
+	useClientId( props );
+
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( { [ key ]: value } );
+
+	const classes = classnames(
+		className,
+		'crowdsignal-forms-dropdown-input-block',
+		{
+			'is-required': attributes.mandatory,
+		}
+	);
+
+	return (
+		<FormInputWrapper
+			className={ classes }
+			style={ { ...useColorStyles( attributes ) } }
+		>
+			<Sidebar { ...props } />
+			<FormInputWrapper.Label className="crowdsignal-forms-dropdown-input-block__label">
+				<RichText
+					placeholder={ __( 'Enter form label', 'block-editor' ) }
+					onChange={ handleChangeAttribute( 'label' ) }
+					value={ attributes.label }
+				/>
+			</FormInputWrapper.Label>
+			<div>[Dropdown Here]</div>
+		</FormInputWrapper>
+	);
+};

--- a/packages/block-editor/src/dropdown-input/index.js
+++ b/packages/block-editor/src/dropdown-input/index.js
@@ -6,14 +6,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FileInputIcon } from '@crowdsignal/icons';
+import { MultipleChoiceQuestionIcon } from '@crowdsignal/icons';
+import { DropdownInput } from '@crowdsignal/blocks';
 import attributes from './attributes';
 import Edit from './edit';
-import { DropdownInput } from '@crowdsignal/blocks';
 
 const settings = {
 	title: __( 'Dropdown Input Form', 'block-editor' ),
-	description: __( 'TBD', 'block-editor' ),
+	description: __(
+		'Allows people to select an option from a list',
+		'block-editor'
+	),
 	category: 'crowdsignal-forms/form',
 	keywords: [
 		__( 'dropdown', 'block-editor' ),
@@ -22,7 +25,7 @@ const settings = {
 		__( 'select', 'block-editor' ),
 		__( 'form', 'block-editor' ),
 	],
-	icon: <FileInputIcon />, //FIXME
+	icon: <MultipleChoiceQuestionIcon />,
 	edit: Edit,
 	attributes,
 	supports: {
@@ -30,16 +33,12 @@ const settings = {
 		reusable: false,
 		//TODO: add alignment options
 	},
-	// example: {
-	// 	attributes: {
-	// 		label: __( 'Upload your application files:', 'block-editor' ),
-	// 		buttonLabel: __( 'Choose File', 'block-editor' ),
-	// 		message: __(
-	// 			'Supported file formats: pdf, png, jpg, mp4 - max. size 5 mb',
-	// 			'block-editor'
-	// 		),
-	// 	},
-	// },
+	example: {
+		attributes: {
+			label: __( 'Choose your country:', 'block-editor' ),
+			buttonLabel: __( 'Select an option', 'block-editor' ),
+		},
+	},
 };
 
 export default {

--- a/packages/block-editor/src/dropdown-input/index.js
+++ b/packages/block-editor/src/dropdown-input/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { FileInputIcon } from '@crowdsignal/icons';
+import attributes from './attributes';
+import Edit from './edit';
+import { DropdownInput } from '@crowdsignal/blocks';
+
+const settings = {
+	title: __( 'Dropdown Input Form', 'block-editor' ),
+	description: __( 'TBD', 'block-editor' ),
+	category: 'crowdsignal-forms/form',
+	keywords: [
+		__( 'dropdown', 'block-editor' ),
+		__( 'list', 'block-editor' ),
+		__( 'options', 'block-editor' ),
+		__( 'select', 'block-editor' ),
+		__( 'form', 'block-editor' ),
+	],
+	icon: <FileInputIcon />, //FIXME
+	edit: Edit,
+	attributes,
+	supports: {
+		html: false,
+		reusable: false,
+		//TODO: add alignment options
+	},
+	// example: {
+	// 	attributes: {
+	// 		label: __( 'Upload your application files:', 'block-editor' ),
+	// 		buttonLabel: __( 'Choose File', 'block-editor' ),
+	// 		message: __(
+	// 			'Supported file formats: pdf, png, jpg, mp4 - max. size 5 mb',
+	// 			'block-editor'
+	// 		),
+	// 	},
+	// },
+};
+
+export default {
+	name: DropdownInput.blockName,
+	settings,
+};

--- a/packages/block-editor/src/dropdown-input/option.js
+++ b/packages/block-editor/src/dropdown-input/option.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { FormDropdownInput } from '@crowdsignal/blocks';
+
+export const DropdownOption = ( { onChange, onSplit, onRemove, value } ) => {
+	return (
+		<FormDropdownInput.Option>
+			<RichText
+				value={ value }
+				onChange={ onChange }
+				onSplit={ onSplit }
+				onRemove={ onRemove }
+				onReplace={ noop }
+				__unstableDisableFormats
+			/>
+		</FormDropdownInput.Option>
+	);
+};

--- a/packages/block-editor/src/dropdown-input/placeholder.js
+++ b/packages/block-editor/src/dropdown-input/placeholder.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { forwardRef } from '@wordpress/element';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { FormDropdownInput } from '@crowdsignal/blocks';
+import { __ } from '@wordpress/i18n';
+
+export const DropdownPlaceholder = forwardRef( ( { onChange }, ref ) => {
+	const messages = [
+		__( 'Enter dropdown options.', 'block-editor' ),
+		__( 'Each row is one option.', 'block-editor' ),
+		__( 'You can paste a list here, too.', 'block-editor' ),
+	];
+
+	return (
+		<>
+			{ map( messages, ( msg, index ) => (
+				<FormDropdownInput.Option key={ index }>
+					<RichText
+						ref={ index === 0 ? ref : null }
+						placeholder={ msg }
+						onChange={ onChange }
+						__unstableDisableFormats
+					/>
+				</FormDropdownInput.Option>
+			) ) }
+		</>
+	);
+} );

--- a/packages/block-editor/src/dropdown-input/sidebar.js
+++ b/packages/block-editor/src/dropdown-input/sidebar.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import ColorSettings from '../components/color-settings';
+import { __ } from '@wordpress/i18n';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( {
+			[ key ]: value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Field Settings', 'block-editor' ) }
+				initialOpen={ true }
+			>
+				<ToggleControl
+					label={ __( 'The answer is required', 'block-editor' ) }
+					checked={ attributes.mandatory }
+					onChange={ handleChangeAttribute( 'mandatory' ) }
+				/>
+			</PanelBody>
+			<ColorSettings
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,3 +1,4 @@
+export { default as dropdownInputBlock } from './dropdown-input';
 export { default as fileInputBlock } from './file-input';
 export { default as matrixQuestionBlock } from './matrix-question';
 export { default as multipleChoiceAnswerBlock } from './multiple-choice-answer';

--- a/packages/block-editor/src/util/change-focus.js
+++ b/packages/block-editor/src/util/change-focus.js
@@ -1,0 +1,23 @@
+import { tap } from 'lodash';
+
+export const changeFocus = ( wrapper, selector, index, cursorToEnd ) =>
+	setTimeout( () => {
+		tap( wrapper.querySelectorAll( selector )[ index ], ( input ) => {
+			if ( ! input ) {
+				return;
+			}
+
+			input.focus();
+
+			// Allows moving the cursor to the end of
+			// 'contenteditable' elements like <RichText />
+			if ( document.createRange && cursorToEnd ) {
+				const range = document.createRange();
+				range.selectNodeContents( input );
+				range.collapse( false );
+				const selection = document.defaultView.getSelection();
+				selection.removeAllRanges();
+				selection.addRange( range );
+			}
+		} );
+	}, 0 );

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -22,6 +22,7 @@
     "@crowdsignal/icons": "^0.1.0",
     "@crowdsignal/rest-api": "^0.1.0",
     "@crowdsignal/styles": "^0.1.0",
+    "@headlessui/react": "^1.6.4",
     "@wordpress/element": "^4.4.0",
     "@wordpress/i18n": "^4.6.0",
     "classnames": "^2.2.5",

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { useColorStyles } from '@crowdsignal/styles';
+import { forwardRef } from '@wordpress/element';
 
 const StyledButtonWrapper = styled.div`
 	display: flex;
@@ -42,6 +43,7 @@ const Button = ( {
 	className,
 	outline,
 	style = {},
+	fRef,
 	...props
 } ) => (
 	<StyledButtonWrapper
@@ -55,6 +57,7 @@ const Button = ( {
 		) }
 	>
 		<StyledButton
+			ref={ fRef }
 			className="crowdsignal-forms-button__button wp-block-button__link"
 			style={ {
 				...useColorStyles( attributes ),
@@ -69,4 +72,6 @@ const Button = ( {
 
 Button.Wrapper = StyledButtonWrapper;
 
-export default Button;
+export default forwardRef( ( props, ref ) => (
+	<Button fRef={ ref } { ...props } />
+) );

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { Listbox } from '@headlessui/react';
+import { forwardRef } from '@wordpress/element';
+import classnames from 'classnames';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../index';
+
+//should live in another file
+const withClassName = ( Component, hocClassName ) =>
+	forwardRef( ( { className, ...props }, ref ) => (
+		<Component
+			ref={ ref }
+			className={ classnames( hocClassName, className ) }
+			{ ...props }
+		/>
+	) );
+
+const BASE_CSS_CLASS = 'dropdown-input-component';
+
+const StyledListBox = withClassName(
+	styled.div`
+		display: inline-block;
+		position: relative;
+	`,
+	BASE_CSS_CLASS
+);
+
+const StyledListButton = withClassName(
+	styled( Button )`
+		margin-bottom: 0;
+
+		button {
+			min-width: 240px;
+			text-align: left;
+			padding: 8px 12px;
+		}
+	`,
+	`${ BASE_CSS_CLASS }__button`
+);
+
+const StyledListOptions = withClassName(
+	styled.div`
+		width: 100%;
+		position: absolute;
+		top: 0;
+		z-index: 1000;
+		background-color: white;
+		border: 1px solid var( --color-neutral-90 );
+		margin: 0;
+		padding: 0;
+	`,
+	`${ BASE_CSS_CLASS }__options`
+);
+
+const StyledEditorListOptions = styled( StyledListOptions )`
+	position: relative;
+	margin-top: 8px;
+	padding: 8px 0;
+`;
+
+const StyledListOption = withClassName(
+	styled.div`
+		padding: 8px 12px;
+		line-height: 1.3;
+
+		&.active {
+			background-color: var( --color-neutral-10 );
+		}
+
+		&.selected {
+			background-color: var( --color-neutral-50 );
+			color: white;
+		}
+	`,
+	`${ BASE_CSS_CLASS }__option`
+);
+
+const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
+	const _options = [ buttonLabel, ...options ];
+
+	return (
+		<Listbox as={ StyledListBox } value={ value } onChange={ onChange }>
+			<Listbox.Button as={ StyledListButton } outline>
+				{ value || buttonLabel }
+			</Listbox.Button>
+			<Listbox.Options as={ StyledListOptions }>
+				{ _options.map( ( option, index ) => (
+					<Listbox.Option
+						as={ StyledListOption }
+						key={ index }
+						value={ option }
+						className={ ( { active, selected } ) =>
+							classnames( {
+								active,
+								selected,
+							} )
+						}
+					>
+						{ option }
+					</Listbox.Option>
+				) ) }
+			</Listbox.Options>
+		</Listbox>
+	);
+};
+
+FormDropdownInput.Wrapper = StyledListBox;
+FormDropdownInput.Button = StyledListButton;
+FormDropdownInput.Options = StyledEditorListOptions;
+FormDropdownInput.Option = StyledListOption;
+
+export default FormDropdownInput;

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Listbox } from '@headlessui/react';
-import { forwardRef } from '@wordpress/element';
 import classnames from 'classnames';
 import styled from '@emotion/styled';
 
@@ -10,16 +9,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { Button } from '../index';
-
-//should live in another file
-const withClassName = ( Component, hocClassName ) =>
-	forwardRef( ( { className, ...props }, ref ) => (
-		<Component
-			ref={ ref }
-			className={ classnames( hocClassName, className ) }
-			{ ...props }
-		/>
-	) );
+import { withClassName } from '../../util';
 
 const BASE_CSS_CLASS = 'dropdown-input-component';
 

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -14,7 +14,7 @@ import { withClassName } from '../../util';
 import { CheckIcon, ChevronDownIcon } from '@crowdsignal/icons';
 import { useMemo } from '@wordpress/element';
 
-const BASE_CSS_CLASS = 'dropdown-input-component';
+const BASE_CSS_CLASS = 'crowdsignal-forms-dropdown-input';
 
 const StyledListBox = withClassName(
 	styled.div`
@@ -26,7 +26,9 @@ const StyledListBox = withClassName(
 
 const StyledListButton = withClassName(
 	styled( Button )`
+		max-width: 400px;
 		margin-bottom: 0;
+		white-space: nowrap;
 
 		&&& {
 			button {
@@ -41,6 +43,11 @@ const StyledListButton = withClassName(
 			align-items: center;
 			justify-content: flex-start;
 
+			span {
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
 			svg {
 				position: absolute;
 				right: 8px;
@@ -53,7 +60,7 @@ const StyledListButton = withClassName(
 
 const StyledListOptions = withClassName(
 	styled.div`
-		width: 100%;
+		max-width: 400px;
 		max-height: 210px;
 		overflow: auto;
 		position: absolute;
@@ -78,6 +85,13 @@ const StyledListOption = withClassName(
 	styled.div`
 		padding: 8px 12px;
 		line-height: 1.3;
+
+		span {
+			display: block;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
 
 		&.active {
 			position: relative;
@@ -124,7 +138,9 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 	return (
 		<Listbox as={ StyledListBox } value={ value } onChange={ onChange }>
 			<Listbox.Button as={ StyledListButton } outline>
-				<span>{ getButtonText( value ) }</span>
+				<span title={ getButtonText( value ) }>
+					{ getButtonText( value ) }
+				</span>
 				<ChevronDownIcon />
 			</Listbox.Button>
 			<Listbox.Options as={ StyledListOptions }>
@@ -133,6 +149,7 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 						as={ StyledListOption }
 						key={ index }
 						value={ option.clientId }
+						title={ option.label }
 						className={ ( { active, selected } ) =>
 							classnames( {
 								active,

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -12,6 +12,7 @@ import { find } from 'lodash';
 import { Button } from '../index';
 import { withClassName } from '../../util';
 import { CheckIcon, ChevronDownIcon } from '@crowdsignal/icons';
+import { useMemo } from '@wordpress/element';
 
 const BASE_CSS_CLASS = 'dropdown-input-component';
 
@@ -53,14 +54,16 @@ const StyledListButton = withClassName(
 const StyledListOptions = withClassName(
 	styled.div`
 		width: 100%;
+		max-height: 210px;
+		overflow: auto;
 		position: absolute;
 		top: 0;
 		z-index: 1000;
 		background-color: white;
 		border: 1px solid var( --color-neutral-90 );
+		box-sizing: border-box;
 		margin: 0;
 		padding: 0;
-		overflow: hidden;
 	`,
 	`${ BASE_CSS_CLASS }__options`
 );
@@ -110,7 +113,10 @@ const StyledListOption = withClassName(
 );
 
 const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
-	const _options = [ { clientId: '', label: buttonLabel }, ...options ];
+	const _options = useMemo(
+		() => [ { clientId: '', label: buttonLabel }, ...options ],
+		[]
+	);
 
 	const getButtonText = ( selectedValue ) =>
 		find( _options, ( { clientId } ) => clientId === selectedValue ).label;

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -11,6 +11,7 @@ import { find } from 'lodash';
  */
 import { Button } from '../index';
 import { withClassName } from '../../util';
+import { CheckIcon, ChevronDownIcon } from '@crowdsignal/icons';
 
 const BASE_CSS_CLASS = 'dropdown-input-component';
 
@@ -26,10 +27,24 @@ const StyledListButton = withClassName(
 	styled( Button )`
 		margin-bottom: 0;
 
+		&&& {
+			button {
+				padding: 8px 36px 8px 12px;
+			}
+		}
+
 		button {
+			position: relative;
 			min-width: 240px;
-			text-align: left;
-			padding: 8px 12px;
+			display: flex;
+			align-items: center;
+			justify-content: flex-start;
+
+			svg {
+				position: absolute;
+				right: 8px;
+				margin-top: 2px;
+			}
 		}
 	`,
 	`${ BASE_CSS_CLASS }__button`
@@ -45,6 +60,7 @@ const StyledListOptions = withClassName(
 		border: 1px solid var( --color-neutral-90 );
 		margin: 0;
 		padding: 0;
+		overflow: hidden;
 	`,
 	`${ BASE_CSS_CLASS }__options`
 );
@@ -61,12 +77,33 @@ const StyledListOption = withClassName(
 		line-height: 1.3;
 
 		&.active {
-			background-color: var( --color-neutral-10 );
+			position: relative;
+
+			&:before {
+				position: absolute;
+				top: 0;
+				left: 0;
+				content: '';
+				width: 100%;
+				height: 100%;
+				background-color: var( --color-neutral-10 );
+				opacity: 0.3;
+			}
 		}
 
 		&.selected {
 			background-color: var( --color-neutral-50 );
 			color: white;
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+
+			svg {
+				width: 26px;
+				path {
+					stroke: currentColor;
+				}
+			}
 		}
 	`,
 	`${ BASE_CSS_CLASS }__option`
@@ -81,7 +118,8 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 	return (
 		<Listbox as={ StyledListBox } value={ value } onChange={ onChange }>
 			<Listbox.Button as={ StyledListButton } outline>
-				{ getButtonText( value ) }
+				<span>{ getButtonText( value ) }</span>
+				<ChevronDownIcon />
 			</Listbox.Button>
 			<Listbox.Options as={ StyledListOptions }>
 				{ _options.map( ( option, index ) => (
@@ -93,10 +131,16 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 							classnames( {
 								active,
 								selected,
+								placeholder: option.clientId === '',
 							} )
 						}
 					>
-						{ option.label }
+						{ ( { selected } ) => (
+							<>
+								<span>{ option.label }</span>
+								{ selected && <CheckIcon /> }
+							</>
+						) }
 					</Listbox.Option>
 				) ) }
 			</Listbox.Options>

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -32,7 +32,8 @@ const StyledListButton = withClassName(
 
 		&&& {
 			button {
-				padding: 8px 36px 8px 12px;
+				min-height: 40px;
+				padding: 4px 36px 4px 12px;
 			}
 		}
 
@@ -60,6 +61,7 @@ const StyledListButton = withClassName(
 
 const StyledListOptions = withClassName(
 	styled.div`
+		width: 100%;
 		max-width: 400px;
 		max-height: 210px;
 		overflow: auto;
@@ -83,7 +85,7 @@ const StyledEditorListOptions = styled( StyledListOptions )`
 
 const StyledListOption = withClassName(
 	styled.div`
-		padding: 8px 12px;
+		padding: 4px 12px;
 		line-height: 1.3;
 
 		> span {

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -86,7 +86,7 @@ const StyledListOption = withClassName(
 		padding: 8px 12px;
 		line-height: 1.3;
 
-		span {
+		> span {
 			display: block;
 			white-space: nowrap;
 			overflow: hidden;

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -4,6 +4,7 @@
 import { Listbox } from '@headlessui/react';
 import classnames from 'classnames';
 import styled from '@emotion/styled';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,19 +73,22 @@ const StyledListOption = withClassName(
 );
 
 const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
-	const _options = [ buttonLabel, ...options ];
+	const _options = [ { clientId: '', label: buttonLabel }, ...options ];
+
+	const getButtonText = ( selectedValue ) =>
+		find( _options, ( { clientId } ) => clientId === selectedValue ).label;
 
 	return (
 		<Listbox as={ StyledListBox } value={ value } onChange={ onChange }>
 			<Listbox.Button as={ StyledListButton } outline>
-				{ value || buttonLabel }
+				{ getButtonText( value ) }
 			</Listbox.Button>
 			<Listbox.Options as={ StyledListOptions }>
 				{ _options.map( ( option, index ) => (
 					<Listbox.Option
 						as={ StyledListOption }
 						key={ index }
-						value={ option }
+						value={ option.clientId }
 						className={ ( { active, selected } ) =>
 							classnames( {
 								active,
@@ -92,7 +96,7 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 							} )
 						}
 					>
-						{ option }
+						{ option.label }
 					</Listbox.Option>
 				) ) }
 			</Listbox.Options>

--- a/packages/blocks/src/components/index.js
+++ b/packages/blocks/src/components/index.js
@@ -2,6 +2,7 @@ export { default as Button } from './button';
 export { default as ContentWrapper } from './content-wrapper';
 export { default as ErrorMessage } from './error-message';
 export { default as FormCheckbox } from './form-checkbox';
+export { default as FormDropdownInput } from './form-dropdown-input';
 export { default as FormFileInput } from './form-file-input';
 export { default as FormInputWrapper } from './form-input-wrapper';
 export { default as FormTextarea } from './form-textarea';

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -9,7 +9,6 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import { useColorStyles } from '@crowdsignal/styles';
 import {
 	ErrorMessage,
 	FormDropdownInput,
@@ -40,11 +39,14 @@ const DropdownInput = ( { attributes, className } ) => {
 		}
 	);
 
+	const styles = {
+		'--cs--style--button--foreground': attributes.textColor,
+		'--cs--style--button--background':
+			attributes.backgroundColor || attributes.gradient,
+	};
+
 	return (
-		<FormInputWrapper
-			className={ classes }
-			style={ { ...useColorStyles( attributes ) } }
-		>
+		<FormInputWrapper className={ classes } style={ { ...styles } }>
 			<FormInputWrapper.Label className="crowdsignal-forms-dropdown-input-block__label">
 				<RawHTML>{ attributes.label }</RawHTML>
 			</FormInputWrapper.Label>

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -1,0 +1,5 @@
+const DropdownInput = () => {};
+
+DropdownInput.blockName = 'crowdsignal-forms/dropdown-input';
+
+export default DropdownInput;

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { RawHTML, useState } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { isEmpty } from 'lodash';
@@ -18,10 +18,14 @@ import {
 import { useField } from '@crowdsignal/form';
 
 const DropdownInput = ( { attributes, className } ) => {
-	const { error } = useField( {
+	const {
+		error,
+		inputProps: { onChange, value },
+	} = useField( {
 		name: `q_${ attributes.clientId }[choice]`,
-		validation: ( value ) => {
-			if ( attributes.mandatory && isEmpty( value ) ) {
+		type: 'dropdown',
+		validation: ( val ) => {
+			if ( attributes.mandatory && isEmpty( val ) ) {
 				return __( 'This field is required', 'blocks' );
 			}
 		},
@@ -36,12 +40,6 @@ const DropdownInput = ( { attributes, className } ) => {
 		}
 	);
 
-	const [ selectedOption, setSelectedOption ] = useState( null );
-
-	const test = ( value ) => {
-		setSelectedOption( value );
-	};
-
 	return (
 		<FormInputWrapper
 			className={ classes }
@@ -53,8 +51,8 @@ const DropdownInput = ( { attributes, className } ) => {
 			<FormDropdownInput
 				buttonLabel={ attributes.buttonLabel }
 				options={ attributes.options }
-				onChange={ test }
-				value={ selectedOption }
+				onChange={ onChange }
+				value={ value }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -1,4 +1,65 @@
-const DropdownInput = () => {};
+/**
+ * External dependencies
+ */
+import { RawHTML, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { useColorStyles } from '@crowdsignal/styles';
+import {
+	ErrorMessage,
+	FormDropdownInput,
+	FormInputWrapper,
+} from '../components';
+import { useField } from '@crowdsignal/form';
+
+const DropdownInput = ( { attributes, className } ) => {
+	const { error } = useField( {
+		name: `q_${ attributes.clientId }[choice]`,
+		validation: ( value ) => {
+			if ( attributes.mandatory && isEmpty( value ) ) {
+				return __( 'This field is required', 'blocks' );
+			}
+		},
+	} );
+
+	const classes = classnames(
+		className,
+		'crowdsignal-forms-dropdown-input-block',
+		{
+			'is-required': attributes.mandatory,
+			'is-error': error,
+		}
+	);
+
+	const [ selectedOption, setSelectedOption ] = useState( null );
+
+	const test = ( value ) => {
+		setSelectedOption( value );
+	};
+
+	return (
+		<FormInputWrapper
+			className={ classes }
+			style={ { ...useColorStyles( attributes ) } }
+		>
+			<FormInputWrapper.Label className="crowdsignal-forms-dropdown-input-block__label">
+				<RawHTML>{ attributes.label }</RawHTML>
+			</FormInputWrapper.Label>
+			<FormDropdownInput
+				buttonLabel={ attributes.buttonLabel }
+				options={ attributes.options }
+				onChange={ test }
+				value={ selectedOption }
+			/>
+			{ error && <ErrorMessage>{ error }</ErrorMessage> }
+		</FormInputWrapper>
+	);
+};
 
 DropdownInput.blockName = 'crowdsignal-forms/dropdown-input';
 

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -1,4 +1,5 @@
 import CoreEmbed from './core-embed';
+import DropdownInput from './dropdown-input';
 import FileInput from './file-input';
 import MatrixQuestion from './matrix-question';
 import MultipleChoiceAnswer from './multiple-choice-answer';
@@ -17,6 +18,7 @@ export * from './components';
 
 export {
 	CoreEmbed,
+	DropdownInput,
 	FileInput,
 	MatrixQuestion,
 	MultipleChoiceAnswer,
@@ -34,6 +36,7 @@ export {
 
 export const projectBlocks = [
 	CoreEmbed,
+	DropdownInput,
 	FileInput,
 	MatrixQuestion,
 	MultipleChoiceAnswer,

--- a/packages/blocks/src/util.js
+++ b/packages/blocks/src/util.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+import classnames from 'classnames';
+
+/**
  * Returns the current block style based on its className
  *
  * @param  {string} className Block class name
@@ -8,3 +14,19 @@ export const getBlockStyle = ( className ) => {
 	const styleClass = className && className.match( /is-style-([^\s]+)/i );
 	return styleClass ? styleClass[ 1 ] : '';
 };
+
+/**
+ * HOC to inject CSS classes into components
+ *
+ * @param  {Object} Component    Base component
+ * @param  {string} hocClassName Css class to inject
+ * @return {Object}              Component with injected CSS class
+ */
+export const withClassName = ( Component, hocClassName ) =>
+	forwardRef( ( { className, ...props }, ref ) => (
+		<Component
+			ref={ ref }
+			className={ classnames( hocClassName, className ) }
+			{ ...props }
+		/>
+	) );

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -28,7 +28,7 @@ export const useField = ( {
 	);
 
 	const onChange = ( event ) => {
-		let newValue = event.target.value;
+		let newValue = event?.target?.value;
 
 		if ( type === 'checkbox' ) {
 			newValue = event.target.checked
@@ -39,12 +39,15 @@ export const useField = ( {
 				  );
 		} else if ( type === 'file' ) {
 			newValue = event.target.files;
-			setFieldValue( formName, fieldName, newValue );
-			validateField( newValue );
-			return;
+		} else if ( type === 'dropdown' ) {
+			newValue = event;
 		}
 
 		setFieldValue( formName, fieldName, newValue );
+
+		if ( [ 'file', 'dropdown' ].includes( type ) ) {
+			validateField( newValue );
+		}
 	};
 
 	const onBlur = () => {
@@ -65,7 +68,7 @@ export const useField = ( {
 		onChange,
 	};
 
-	if ( includes( [ 'checkbox', 'radio' ], type ) ) {
+	if ( includes( [ 'checkbox', 'radio', 'dropdown' ], type ) ) {
 		inputProps.onBlur = onBlur;
 		inputProps.value = fieldValue;
 	}

--- a/packages/icons/src/chevron-down.js
+++ b/packages/icons/src/chevron-down.js
@@ -1,0 +1,11 @@
+export const ChevronDownIcon = () => (
+	<svg
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path d="M6.50002 10L12 15L17.5 10" stroke="#CCC" strokeWidth="2" />
+	</svg>
+);

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -1,5 +1,6 @@
 export * from './check-icon';
 export * from './checkbox-input';
+export * from './chevron-down';
 export * from './close-arrow';
 export * from './drag-handle';
 export * from './file-input';

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -228,6 +228,7 @@ body {
 	.crowdsignal-forms-dropdown-input__button.is-style-outline {
 		button.crowdsignal-forms-button__button {
 			font-size: var(--cs--style--button--font-size);
+			font-weight: var(--cs--style--button--font-weight);
 			color: var(--cs--style--button--foreground);
 			background: var(--cs--style--button--background);
 		}

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -224,8 +224,8 @@ body {
 	}
 }
 
-.dropdown-input-component {
-	.dropdown-input-component__button.is-style-outline {
+.crowdsignal-forms-dropdown-input {
+	.crowdsignal-forms-dropdown-input__button.is-style-outline {
 		button.crowdsignal-forms-button__button {
 			color: var(--cs--style--button--foreground);
 			background: var(--cs--style--button--background);

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -19,6 +19,8 @@ body {
 	--cs--style--border-width-regular: 1px;
 	--cs--style--border-width-thick: 2px;
 	--cs--style--border-radius: 0;
+	--cs--style--button-font-size: 1.2125em;
+	--cs--style--button-font-weight: 700;
 
 	--cs--content-padding-top: 16px;
 	--cs--content-padding-bottom: 16px;
@@ -48,15 +50,6 @@ body {
 		--cs--content-padding-horizontal: 0;
 		--cs--block--alignfull-width: unset;
 		--cs--block--alignfull-margin: unset;
-	}
-}
-
-.dropdown-input-component {
-	&__options {
-		background-color: var(--wp--preset--color--background);
-		border-color: var(--wp--preset--color--primary);
-		border-width: var(--cs--style--border-width-thick);
-		border-radius: var(--cs--style--border-radius);
 	}
 }
 
@@ -224,6 +217,41 @@ body {
 		&__button {
 			flex-grow: 1;
 			cursor: inherit;
+		}
+	}
+}
+
+.dropdown-input-component {
+	&__button {
+		svg path {
+			stroke: currentColor;
+		}
+	}
+
+	&__options {
+		background-color: var(--wp--preset--color--background);
+		border-color: var(--wp--preset--color--primary);
+		border-width: var(--cs--style--border-width-thick);
+		border-radius: var(--cs--style--border-radius);
+	}
+
+	&__option {
+		color: var(--wp--preset--color--primary);
+		font-size: var(--cs--style--button-font-size);
+		font-weight: var(--cs--style--button-font-weight);
+
+		&.placeholder {
+			opacity: 0.5;
+		}
+
+		&.selected {
+			background-color: var(--wp--preset--color--primary);
+		}
+
+		&.active {
+			&:before {
+				background-color: var(--wp--preset--color--primary);
+			}
 		}
 	}
 }

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -18,9 +18,12 @@ body {
 
 	--cs--style--border-width-regular: 1px;
 	--cs--style--border-width-thick: 2px;
-	--cs--style--border-radius: 0;
-	--cs--style--button-font-size: 1.2125em;
-	--cs--style--button-font-weight: 700;
+
+	--cs--style--button--background: var(--wp--preset--color--background);
+	--cs--style--button--foreground: var(--wp--preset--color--primary);
+	--cs--style--button--font-size: var(--wp--preset--font-size--normal);
+	--cs--style--button--font-weight: 400;
+	--cs--style--button--border-radius: 0;
 
 	--cs--content-padding-top: 16px;
 	--cs--content-padding-bottom: 16px;
@@ -222,36 +225,42 @@ body {
 }
 
 .dropdown-input-component {
-	&__button {
-		svg path {
-			stroke: currentColor;
+	.dropdown-input-component__button.is-style-outline {
+		button.crowdsignal-forms-button__button {
+			color: var(--cs--style--button--foreground);
+			background: var(--cs--style--button--background);
 		}
 	}
 
 	&__options {
-		background-color: var(--wp--preset--color--background);
-		border-color: var(--wp--preset--color--primary);
+		color: var(--cs--style--button--foreground);
+		background: var(--cs--style--button--background);
+		border-color: currentColor;
 		border-width: var(--cs--style--border-width-thick);
-		border-radius: var(--cs--style--border-radius);
+		border-radius: var(--cs--style--button--border-radius);
 	}
 
 	&__option {
-		color: var(--wp--preset--color--primary);
-		font-size: var(--cs--style--button-font-size);
-		font-weight: var(--cs--style--button-font-weight);
+		font-size: var(--cs--style--button--font-size);
+		font-weight: var(--cs--style--button--font-weight);
 
 		&.placeholder {
 			opacity: 0.5;
 		}
 
 		&.selected {
-			background-color: var(--wp--preset--color--primary);
+			background: var(--cs--style--button--foreground);
 		}
 
 		&.active {
 			&:before {
-				background-color: var(--wp--preset--color--primary);
+				background: var(--cs--style--button--foreground);
 			}
 		}
+	}
+
+	svg path {
+		stroke: currentColor;
+		fill: none;
 	}
 }

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -15,6 +15,11 @@ body {
 	--cs--style--block-gap: var(--wp--style--block-gap);
 	--cs--style--block-gap-big: calc(var(--wp--style--block-gap) * 2);
 	--cs--style--block-gap-small: calc(var(--wp--style--block-gap) / 2);
+
+	--cs--style--border-width-regular: 1px;
+	--cs--style--border-width-thick: 2px;
+	--cs--style--border-radius: 0;
+
 	--cs--content-padding-top: 16px;
 	--cs--content-padding-bottom: 16px;
 	--cs--content-padding-horizontal: 16px;
@@ -43,6 +48,15 @@ body {
 		--cs--content-padding-horizontal: 0;
 		--cs--block--alignfull-width: unset;
 		--cs--block--alignfull-margin: unset;
+	}
+}
+
+.dropdown-input-component {
+	&__options {
+		background-color: var(--wp--preset--color--background);
+		border-color: var(--wp--preset--color--primary);
+		border-width: var(--cs--style--border-width-thick);
+		border-radius: var(--cs--style--border-radius);
 	}
 }
 

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -227,6 +227,7 @@ body {
 .crowdsignal-forms-dropdown-input {
 	.crowdsignal-forms-dropdown-input__button.is-style-outline {
 		button.crowdsignal-forms-button__button {
+			font-size: var(--cs--style--button--font-size);
 			color: var(--cs--style--button--foreground);
 			background: var(--cs--style--button--background);
 		}

--- a/packages/theme-compatibility/src/blockbase/base.scss
+++ b/packages/theme-compatibility/src/blockbase/base.scss
@@ -2,6 +2,10 @@
 	--wp--preset--font-size--normal: 18px;
 }
 
+body {
+	--cs--style--button--border-radius: var(--wp--custom--button--border--radius);
+}
+
 .crowdsignal-forms-question-wrapper {
 	border: var(--wp--custom--form--border--width) var(--wp--custom--form--border--style) var(--wp--custom--color--primary);
 	border-radius: var(--wp--custom--form--border--radius);

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -6,7 +6,7 @@
 }
 
 body {
-	--wp--preset--color--primary: #1285ce;
+	--wp--preset--color--primary: #ff302c;
 
 	--crowdsignal-forms-input-border-color: #ddd;
 	--crowdsignal-forms-question-border-color: #eee;
@@ -14,6 +14,8 @@ body {
 	--crowdsignal-forms-submit-button-background-color: #ff302c;
 	--color-text: #444;
 	--wp--custom--color--background: #f7f7f6;
+
+	--cs--style--border-radius: 9px;
 }
 
 body {
@@ -25,6 +27,12 @@ body {
 		.wp-block-column:not(:last-child)  {
 			margin-bottom: 0;
 		}
+	}
+}
+
+.dropdown-input-component {
+	&__options {
+		border-color: var(--wp--preset--color--primary);
 	}
 }
 

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -15,7 +15,6 @@ body {
 	--crowdsignal-forms-submit-button-background-color: #ff302c;
 	--color-text: #444;
 
-	--cs--style--button--font-size: 1.2125em;
 	--cs--style--button--font-weight: 700;
 	--cs--style--button--border-radius: 9px;
 }

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -7,15 +7,17 @@
 
 body {
 	--wp--preset--color--primary: #ff302c;
+	--wp--preset--color--background: #f7f7f6;
 
 	--crowdsignal-forms-input-border-color: #ddd;
 	--crowdsignal-forms-question-border-color: #eee;
 	--crowdsignal-forms-question-background-color: #fff;
 	--crowdsignal-forms-submit-button-background-color: #ff302c;
 	--color-text: #444;
-	--wp--custom--color--background: #f7f7f6;
 
-	--cs--style--border-radius: 9px;
+	--cs--style--button--font-size: 1.2125em;
+	--cs--style--button--font-weight: 700;
+	--cs--style--button--border-radius: 9px;
 }
 
 body {
@@ -27,12 +29,6 @@ body {
 		.wp-block-column:not(:last-child)  {
 			margin-bottom: 0;
 		}
-	}
-}
-
-.dropdown-input-component {
-	&__options {
-		border-color: var(--wp--preset--color--primary);
 	}
 }
 

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -15,7 +15,6 @@ body {
 	--crowdsignal-forms-submit-button-background-color: #ff302c;
 	--color-text: #444;
 
-	--cs--style--button--font-weight: 700;
 	--cs--style--button--border-radius: 9px;
 }
 

--- a/packages/theme-compatibility/src/quadrat/base.scss
+++ b/packages/theme-compatibility/src/quadrat/base.scss
@@ -24,5 +24,5 @@ body {
 
 .crowdsignal-forms-question-wrapper {
 	color: var(--wp--custom--color--foreground);
-	background-color: var(--wp--custom--color--background);
+	background-color: var(--wp--preset--color--background);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@headlessui/react@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.4.tgz#c73084e23386bef5fb86cd16da3352c3a844bb4c"
+  integrity sha512-0yqz1scwbFtwljmbbKjXsSGl5ABEYNICVHZnMCWo0UtOZodo2Tpu94uOVgCRjRZ77l2WcTi2S0uidINDvG7lsA==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"


### PR DESCRIPTION
## Summary

This PR adds the Dropdown block for the new editor.

Depends on: D82342-code

Ref: c/5G7VBwCE-tr

## Test Instructions

* Make sure to apply the backend patch
* Create a new project and use one of the inserters to include the Dropdown block
* Play with the block to include the desired options. It should support pasting a list of options
* Go to the renderer and check if the block works as a regular dropdown component
* It should support keyboard navigation

## Screenshots
![image](https://user-images.githubusercontent.com/7811225/173134758-bab5c33c-0767-4112-a78c-942c084d8e3c.png)

![image](https://user-images.githubusercontent.com/7811225/173134676-85ce4cf0-84c5-4379-8469-00fc66dd8f76.png)

