### PR TITLE
Add width control to the Dropdown block sidebar

### DIFF
--- a/packages/block-editor/src/dropdown-input/attributes.js
+++ b/packages/block-editor/src/dropdown-input/attributes.js
@@ -34,4 +34,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	inputWidth: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/dropdown-input/edit.js
+++ b/packages/block-editor/src/dropdown-input/edit.js
@@ -135,7 +135,7 @@ export default ( props ) => {
 					value={ attributes.label }
 				/>
 			</FormInputWrapper.Label>
-			<FormDropdownInput.Wrapper>
+			<FormDropdownInput.Wrapper width={ attributes.inputWidth }>
 				<FormDropdownInput.Button outline>
 					<RichText
 						placeholder={ __( 'Choose an option', 'blocks' ) }

--- a/packages/block-editor/src/dropdown-input/sidebar.js
+++ b/packages/block-editor/src/dropdown-input/sidebar.js
@@ -8,13 +8,31 @@ import { InspectorControls } from '@wordpress/block-editor';
  */
 import ColorSettings from '../components/color-settings';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	// eslint-disable-next-line
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	Button,
+	Flex,
+	FlexItem,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 
 const Sidebar = ( { attributes, setAttributes } ) => {
+	const widthOptions = [ '25%', '50%', '75%', '100%' ];
+
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( {
 			[ key ]: value,
 		} );
+
+	const handleChangeInputWidth = ( value ) => {
+		setAttributes( {
+			inputWidth: value,
+		} );
+	};
 
 	return (
 		<InspectorControls>
@@ -27,6 +45,35 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 					checked={ attributes.mandatory }
 					onChange={ handleChangeAttribute( 'mandatory' ) }
 				/>
+				<Flex style={ { marginBottom: '12px' } }>
+					<FlexItem>{ __( 'Field Width', 'block-editor' ) }</FlexItem>
+					<FlexItem>
+						<Button
+							onClick={ () =>
+								handleChangeInputWidth( undefined )
+							}
+							isSecondary
+							isSmall
+						>
+							{ __( 'Auto', 'block-editor' ) }
+						</Button>
+					</FlexItem>
+				</Flex>
+				<ToggleGroupControl
+					label={ __( 'Field Width', 'block-editor' ) }
+					value={ attributes.inputWidth }
+					onChange={ handleChangeInputWidth }
+					style={ { width: '100%' } }
+					hideLabelFromVision
+				>
+					{ widthOptions.map( ( option ) => (
+						<ToggleGroupControlOption
+							key={ option }
+							value={ option }
+							label={ option }
+						/>
+					) ) }
+				</ToggleGroupControl>
 			</PanelBody>
 			<ColorSettings
 				attributes={ attributes }

--- a/packages/blocks/src/components/form-dropdown-input/index.js
+++ b/packages/blocks/src/components/form-dropdown-input/index.js
@@ -18,6 +18,8 @@ const BASE_CSS_CLASS = 'crowdsignal-forms-dropdown-input';
 
 const StyledListBox = withClassName(
 	styled.div`
+		min-width: ${ ( props ) => props.width ?? '240px' };
+		max-width: ${ ( props ) => props.width ?? '400px' };
 		display: inline-block;
 		position: relative;
 	`,
@@ -26,7 +28,7 @@ const StyledListBox = withClassName(
 
 const StyledListButton = withClassName(
 	styled( Button )`
-		max-width: 400px;
+		width: 100%;
 		margin-bottom: 0;
 		white-space: nowrap;
 
@@ -39,8 +41,8 @@ const StyledListButton = withClassName(
 
 		button {
 			position: relative;
-			min-width: 240px;
 			display: flex;
+			flex: 1;
 			align-items: center;
 			justify-content: flex-start;
 
@@ -62,7 +64,6 @@ const StyledListButton = withClassName(
 const StyledListOptions = withClassName(
 	styled.div`
 		width: 100%;
-		max-width: 400px;
 		max-height: 210px;
 		overflow: auto;
 		position: absolute;
@@ -128,7 +129,13 @@ const StyledListOption = withClassName(
 	`${ BASE_CSS_CLASS }__option`
 );
 
-const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
+const FormDropdownInput = ( {
+	buttonLabel,
+	onChange,
+	options,
+	value,
+	width,
+} ) => {
 	const _options = useMemo(
 		() => [ { clientId: '', label: buttonLabel }, ...options ],
 		[]
@@ -138,7 +145,12 @@ const FormDropdownInput = ( { buttonLabel, onChange, options, value } ) => {
 		find( _options, ( { clientId } ) => clientId === selectedValue ).label;
 
 	return (
-		<Listbox as={ StyledListBox } value={ value } onChange={ onChange }>
+		<Listbox
+			as={ StyledListBox }
+			value={ value }
+			onChange={ onChange }
+			width={ width }
+		>
 			<Listbox.Button as={ StyledListButton } outline>
 				<span title={ getButtonText( value ) }>
 					{ getButtonText( value ) }

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -55,6 +55,7 @@ const DropdownInput = ( { attributes, className } ) => {
 				options={ attributes.options }
 				onChange={ onChange }
 				value={ value }
+				width={ attributes.inputWidth }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>


### PR DESCRIPTION
## Summary

This PR adds a control to the Dropdown block sidebar that allows changing the width of the dropdown component.
It will provide more flexibility when creating more complex layouts.

## Test Instruction
* Create a project and add a Dropdown block
* Play with the `Field Width` setting inside the sidebar and check if the block behaves as expected

_Note:_ If you want the results to be collected properly, apply D82342-code

## Screenshots

![image](https://user-images.githubusercontent.com/7811225/173692398-10d29d41-9dd0-4293-ac1a-63fef38643ab.png)

![image](https://user-images.githubusercontent.com/7811225/173693019-dcddd6df-d024-4322-9f1c-d3c4486597d5.png)