### PR TITLE
Fix storybook setup

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,4 +8,7 @@ module.exports = {
 	core: {
 		builder: 'webpack5',
 	},
+	features: {
+		emotionAlias: true,
+	},
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,7 +10,7 @@ import StyleProvider from '../packages/components/src/style-provider';
 
 export const decorators = [
 	( Story ) => (
-		<StyleProvider reset>
+		<StyleProvider reset namespace="crowdsignal">
 			<Story />
 		</StyleProvider>
 	),

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,3 @@
-const path = require( 'path' );
 const webpack = require( 'webpack' );
 const getBaseConfig = require( '@automattic/calypso-build/webpack.config.js' );
 
@@ -22,6 +21,12 @@ module.exports = ( { config } ) => {
 				},
 			],
 		},
-		resolve: baseConfig.resolve,
+		resolve: {
+			...baseConfig.resolve,
+			fallback: {
+				...baseConfig.resolve.fallback,
+				path: require.resolve( 'path-browserify' ),
+			},
+		},
 	} );
 }


### PR DESCRIPTION
This patch fixes our storybook configuration to make it usable again. For future reference, there were three issues that needed addressing:

- Setting `emotionAlias: true` to allow storybook to work with emotion 11.
- Setting a namespace for our styled components - required in emotion 11.
- Added a missing polyfill for `path`, which was previously automatically injected by webpack but was removed in webpack 5.

# Testing

- Run `yarn storybook` inside the repository root.
- Storybook should load correctly and you should be able to browse through our existing components.