### PR TITLE
Refactor project renderer

### DIFF
--- a/apps/project-renderer/src/components/project-form/index.js
+++ b/apps/project-renderer/src/components/project-form/index.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import ProjectFormPage from './page';
+import ProjectFormThemeProvider from './theme-provider';
+import { useProjectData } from './use-project-data';
+
+const ProjectForm = ( props ) => {
+	const { pageContent, submitPage, theme } = useProjectData( props );
+
+	if ( ! pageContent ) {
+		return 'Wait...';
+	}
+
+	return (
+		<ProjectFormThemeProvider theme={ theme }>
+			<ProjectFormPage
+				blocks={ pageContent }
+				onSubmit={ submitPage }
+				projectCode={ props.projectCode }
+			/>
+		</ProjectFormThemeProvider>
+	);
+};
+
+export default ProjectForm;

--- a/apps/project-renderer/src/components/project-form/page.js
+++ b/apps/project-renderer/src/components/project-form/page.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { map, zipObject } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ContentWrapper,
+	projectBlocks,
+	renderBlocks,
+} from '@crowdsignal/blocks';
+import { Form } from '@crowdsignal/form';
+
+const blockMap = zipObject( map( projectBlocks, 'blockName' ), projectBlocks );
+
+const ProjectPage = ( { blocks, onSubmit, projectCode } ) => {
+	const classes = classnames( 'wp-embed-responsive', 'crowdsignal-content', {
+		'crowdsignal-forms-form__content': !! onSubmit,
+	} );
+
+	if ( ! onSubmit ) {
+		return (
+			<ContentWrapper className={ classes }>
+				{ renderBlocks( blocks, blockMap ) }
+			</ContentWrapper>
+		);
+	}
+
+	return (
+		<Form
+			className="crowdsignal-forms-form"
+			name={ `f-${ projectCode }` }
+			onSubmit={ onSubmit }
+		>
+			<ContentWrapper className={ classes }>
+				{ renderBlocks( blocks, blockMap ) }
+			</ContentWrapper>
+		</Form>
+	);
+};
+
+export default ProjectPage;

--- a/apps/project-renderer/src/components/project-form/theme-provider.js
+++ b/apps/project-renderer/src/components/project-form/theme-provider.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useStylesheet } from '@crowdsignal/hooks';
+
+/*
+ * Wrapper component responsible for loading themes in the development environment.
+ * The reason this is a separate component instead of a HoC, hook
+ * or using useStylesheet inside ./page.js directly is we want it's lifecycle
+ * to be completely separate from the current form page component.
+ * So for example if the page component gets reloaded or replaced,
+ * or if we want to do animations, this wrapper always remains unaffected.
+ *
+ * In production, themes are loaded synchronously hence this becomes just a Fragment.
+ */
+
+const ProjectFormThemeProvider = ( { children, theme } ) => {
+	useStylesheet( `/ui/stable/theme-compatibility/base.css` );
+	useStylesheet( `https://app.crowdsignal.com/themes/${ theme }/style.css` );
+	useStylesheet( `/ui/stable/theme-compatibility/${ theme }.css` );
+
+	return <>{ children }</>;
+};
+
+export default process.env.NODE_ENV === 'production'
+	? Fragment
+	: ProjectFormThemeProvider;

--- a/apps/project-renderer/src/components/project-form/use-project-data.js
+++ b/apps/project-renderer/src/components/project-form/use-project-data.js
@@ -9,16 +9,12 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 import { setHostOption } from '@crowdsignal/http';
 import { fetchProjectForm, submitProjectForm } from '@crowdsignal/rest-api';
 
-export const useProjectData = ( {
-	projectCode,
-	preview = false,
-	startTime,
-} ) => {
+export const useProjectData = ( { projectCode, preview = false } ) => {
 	const [ theme, setTheme ] = useState();
-	const [ startDate, setStartDate ] = useState( startTime );
+	const [ startDate, setStartDate ] = useState();
+	const [ responseHash, setResponseHash ] = useState();
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ pageContent, setPageContent ] = useState();
-	const [ responseHash, setResponseHash ] = useState();
 	const [ isCompleted, setIsCompleted ] = useState( false );
 
 	useEffect( () => {
@@ -41,7 +37,7 @@ export const useProjectData = ( {
 
 				setTheme( res.data.theme );
 				setStartDate(
-					res.data.startTime || parseInt( Date.now() / 1000, 10 )
+					res.data.startTime || Math.round( Date.now() / 1000 )
 				);
 				return setPageContent( res.data.content );
 			} )
@@ -53,45 +49,50 @@ export const useProjectData = ( {
 			} );
 	}, [ projectCode, preview ] );
 
-	const handleSubmit = useCallback( ( data ) => {
-		if ( ! data ) {
-			data = {};
-		}
-
-		const form = new window.FormData();
-		form.append( 'p', currentPage );
-		form.append( 'r', responseHash );
-		form.append( 'startTime', startDate );
-		Object.keys( data ).forEach( ( key ) => {
-			if ( Array.isArray( data[ key ] ) ) {
-				data[ key ].forEach( ( value ) => form.append( key, value ) );
-			} else if ( data[ key ] instanceof window.FileList ) {
-				// TODO: figure out how to work with multiple files
-				form.append( key, data[ key ][ 0 ] );
-			} else {
-				form.append( key, data[ key ] );
+	const handleSubmit = useCallback(
+		( data ) => {
+			if ( ! data ) {
+				data = {};
 			}
-		} );
 
-		const query = preview && { preview };
+			const form = new window.FormData();
+			form.append( 'p', currentPage );
+			form.append( 'r', responseHash );
+			form.append( 'startTime', startDate );
+			Object.keys( data ).forEach( ( key ) => {
+				if ( Array.isArray( data[ key ] ) ) {
+					data[ key ].forEach( ( value ) =>
+						form.append( key, value )
+					);
+				} else if ( data[ key ] instanceof window.FileList ) {
+					// TODO: figure out how to work with multiple files
+					form.append( key, data[ key ][ 0 ] );
+				} else {
+					form.append( key, data[ key ] );
+				}
+			} );
 
-		return (
-			submitProjectForm( projectCode, form, query )
-				.then( ( { data: json } ) => {
-					if ( ! json || ! json.content ) {
-						throw new Error( 'Empty response' );
-					}
+			const query = preview && { preview };
 
-					setPageContent( json.content );
-					setIsCompleted( json.done );
-					setResponseHash( json.r );
-					setCurrentPage( parseInt( json.p, 10 ) );
-					window.scrollTo( 0, 0 );
-				} )
-				// eslint-disable-next-line no-console
-				.catch( ( err ) => console.error( err ) )
-		);
-	}, [] );
+			return (
+				submitProjectForm( projectCode, form, query )
+					.then( ( { data: json } ) => {
+						if ( ! json || ! json.content ) {
+							throw new Error( 'Empty response' );
+						}
+
+						setPageContent( json.content );
+						setIsCompleted( json.done );
+						setResponseHash( json.r );
+						setCurrentPage( parseInt( json.p, 10 ) );
+						window.scrollTo( 0, 0 );
+					} )
+					// eslint-disable-next-line no-console
+					.catch( ( err ) => console.error( err ) )
+			);
+		},
+		[ currentPage, responseHash, startDate ]
+	);
 
 	return {
 		pageContent,

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -21,7 +21,6 @@ const renderProject = () => {
 
 	if ( container.dataset.pid ) {
 		projectProps.projectCode = container.dataset.pid;
-		projectProps.startTime = container.dataset.startdate;
 	}
 
 	return render(

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -9,7 +9,7 @@ import { render } from '@wordpress/element';
 import { StyleProvider } from '@crowdsignal/components';
 import { setHostHeader } from '@crowdsignal/http';
 import { Route, Router } from '@crowdsignal/router';
-import App from './components/app';
+import ProjectForm from './components/project-form';
 
 const renderProject = () => {
 	const container = document.getElementById( 'crowdsignal-project' );
@@ -29,7 +29,7 @@ const renderProject = () => {
 			<Router>
 				<Route
 					path="/:projectCode"
-					component={ App }
+					component={ ProjectForm }
 					{ ...projectProps }
 				/>
 			</Router>


### PR DESCRIPTION
This patch is a major refactor of our project renderer code, necessary for the upcoming embed implementation.

The main goal here was to split our single large `<App />` component into several smaller ones to make it more manageable and easier to read, but also to have more control over how and when things are loaded.

D82681-code will enable styles to be loaded synchronously on production, but this patch still fixes the issues associated with asynchronously loading themes in the development environment: it only starts loading the theme once we know what theme it is, and it does so before the actual page content is rendered.

**Note**: Once merged, this will require D82681-code to run on production.

# Testing

Make sure projects are still rendered as they should and are submitted correctly.