### PR TITLE
Add formatting options to the Ranking Answers

### DIFF
--- a/packages/block-editor/src/components/edit-button/index.js
+++ b/packages/block-editor/src/components/edit-button/index.js
@@ -19,6 +19,14 @@ const ButtonContent = styled.div`
 		flex: 1;
 		text-align: left;
 	}
+
+	${ Button.Wrapper }.text-align-center & .rich-text {
+		text-align: center;
+	}
+
+	${ Button.Wrapper }.text-align-right & .rich-text {
+		text-align: right;
+	}
 `;
 
 const EditButtonAnswer = ( {
@@ -30,6 +38,14 @@ const EditButtonAnswer = ( {
 	onReplace,
 	onSplit,
 	onDelete,
+	allowedFormats = [
+		'core/bold',
+		'core/italic',
+		'core/code',
+		'core/strikethrough',
+		'core/subscript',
+		'core/superscript',
+	],
 } ) => {
 	const width = attributes.width ? `${ attributes.width }%` : null;
 
@@ -55,7 +71,7 @@ const EditButtonAnswer = ( {
 					value={ value || attributes.label }
 					multiline={ false }
 					preserveWhiteSpace={ false }
-					allowedFormats={ [] }
+					allowedFormats={ allowedFormats }
 					withoutInteractiveFormatting
 				/>
 			</ButtonContent>

--- a/packages/block-editor/src/ranking-answer/attributes.js
+++ b/packages/block-editor/src/ranking-answer/attributes.js
@@ -21,4 +21,7 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	textAlign: {
+		type: 'string',
+	},
 };

--- a/packages/block-editor/src/ranking-answer/edit.js
+++ b/packages/block-editor/src/ranking-answer/edit.js
@@ -11,6 +11,7 @@ import { useClientId } from '@crowdsignal/hooks';
 import { withSharedSiblingAttributes } from '../util/with-shared-sibling-attributes';
 import EditButtonAnswer from '../components/edit-button';
 import Sidebar from './sidebar';
+import Toolbar from './toolbar';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DragHandle } from '@crowdsignal/icons';
@@ -64,6 +65,7 @@ const EditRankingAnswer = ( props ) => {
 
 	return (
 		<div className={ classes }>
+			<Toolbar { ...props } />
 			<Sidebar { ...props } />
 			<DragHandle />
 			<EditButtonAnswer

--- a/packages/block-editor/src/ranking-answer/toolbar.js
+++ b/packages/block-editor/src/ranking-answer/toolbar.js
@@ -1,0 +1,12 @@
+import { AlignmentControl, BlockControls } from '@wordpress/block-editor';
+
+export default ( { attributes, setAttributes } ) => (
+	<BlockControls group="block">
+		<AlignmentControl
+			value={ attributes.textAlign }
+			onChange={ ( nextAlign ) => {
+				setAttributes( { textAlign: nextAlign } );
+			} }
+		/>
+	</BlockControls>
+);

--- a/packages/blocks/src/components/button-answer/index.js
+++ b/packages/blocks/src/components/button-answer/index.js
@@ -21,6 +21,14 @@ const ButtonContent = styled.span`
 		position: absolute;
 		left: -999px;
 	}
+
+	${ Button.Wrapper }.text-align-center & {
+		justify-content: center;
+	}
+
+	${ Button.Wrapper }.text-align-right & {
+		justify-content: flex-end;
+	}
 `;
 
 const ButtonAnswer = ( {

--- a/packages/blocks/src/components/button/index.js
+++ b/packages/blocks/src/components/button/index.js
@@ -53,6 +53,7 @@ const Button = ( {
 			'wp-block-button',
 			{
 				'is-style-outline': outline,
+				[ `text-align-${ attributes.textAlign }` ]: attributes.textAlign,
 			}
 		) }
 	>
@@ -70,8 +71,10 @@ const Button = ( {
 	</StyledButtonWrapper>
 );
 
-Button.Wrapper = StyledButtonWrapper;
-
-export default forwardRef( ( props, ref ) => (
+const ForwardingRefButton = forwardRef( ( props, ref ) => (
 	<Button fRef={ ref } { ...props } />
 ) );
+
+ForwardingRefButton.Wrapper = StyledButtonWrapper;
+
+export default ForwardingRefButton;


### PR DESCRIPTION
## Summary

This PR adds text alignment and formatting options to the Ranking Question Answers.

Solves: 397-gh-Automattic/crowdsignal

## Testing Instructions

* Create a project and add a Ranking Question block
* Add some options, check if the text alignment and formatting options are available, and work as expected on both the Editor and the Renderer.

## Screenshots

![image](https://user-images.githubusercontent.com/7811225/174665360-ea128188-272b-4350-9aa3-de8f559f529b.png)
![image](https://user-images.githubusercontent.com/7811225/174665417-7d2d2bf2-354b-4a65-a48b-725a719031ab.png)
