### PR TITLE
Re-enable the core cover block

### DIFF
--- a/apps/dashboard/src/components/editor/settings.js
+++ b/apps/dashboard/src/components/editor/settings.js
@@ -26,6 +26,7 @@ const enabledBlocks = [
 	'core/buttons',
 	'core/code',
 	'core/columns',
+	'core/cover',
 	'core/embed',
 	'core/group',
 	'core/heading',


### PR DESCRIPTION
This patch re-enables the cover block in our editor that was accidentally removed when we fixed the issue that allowed the user to use any block regardless of the setting in #263.

# Testing

- Create/edit a project.
- You should be able to add cover blocks.
- You should be able to convert image blocks to cover blocks.