### PR TITLE
use-field hook Refactoring

### DIFF
--- a/packages/blocks/src/components/button-answer/index.js
+++ b/packages/blocks/src/components/button-answer/index.js
@@ -35,11 +35,14 @@ const ButtonAnswer = ( {
 	attributes,
 	children,
 	className,
-	inputProps,
 	isMultiSelect,
+	isSelected,
+	onChange,
 	showCheckmark,
+	value,
 } ) => {
 	const width = attributes.width ? `${ attributes.width }%` : null;
+	const type = isMultiSelect ? 'checkbox' : 'radio';
 
 	return (
 		<Button
@@ -52,12 +55,18 @@ const ButtonAnswer = ( {
 			outline
 		>
 			<ButtonContent>
-				{ inputProps && <FormCheckbox { ...inputProps } /> }
+				<FormCheckbox
+					checked={ isSelected }
+					isMultiSelect={ isMultiSelect }
+					onChange={ onChange }
+					type={ type }
+					value={ value }
+				/>
 				<RawHTML>{ children }</RawHTML>
 				{ showCheckmark && (
 					<Checkmark
 						isMultiSelect={ isMultiSelect }
-						isSelected={ inputProps.checked }
+						isSelected={ isSelected }
 					/>
 				) }
 			</ButtonContent>

--- a/packages/blocks/src/components/checkbox-answer/index.js
+++ b/packages/blocks/src/components/checkbox-answer/index.js
@@ -9,13 +9,28 @@ import { RawHTML } from '@wordpress/element';
 import { useColorStyles } from '@crowdsignal/styles';
 import FormCheckbox from '../form-checkbox';
 
-const CheckboxAnswer = ( { attributes, className, inputProps } ) => {
+const CheckboxAnswer = ( {
+	attributes,
+	className,
+	isMultiSelect,
+	isSelected,
+	onChange,
+	value,
+} ) => {
+	const type = isMultiSelect ? 'checkbox' : 'radio';
+
 	return (
 		<FormCheckbox.Label
 			className={ className }
 			style={ useColorStyles( attributes ) }
 		>
-			<FormCheckbox { ...inputProps } />
+			<FormCheckbox
+				checked={ isSelected }
+				isMultiSelect={ isMultiSelect }
+				onChange={ onChange }
+				type={ type }
+				value={ value }
+			/>
 
 			<RawHTML>{ attributes.label }</RawHTML>
 		</FormCheckbox.Label>

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -94,15 +94,28 @@ const CheckboxInput = styled.input`
 	width: 1px;
 `;
 
-const FormCheckbox = ( { className, ...props } ) => {
+const FormCheckbox = ( {
+	checked,
+	className,
+	onChange,
+	type = 'checkbox',
+	value,
+	...props
+} ) => {
 	const classes = classnames( className, {
-		'is-selected': props.checked,
-		'is-radio': props.type === 'radio',
+		'is-selected': checked,
+		'is-radio': type === 'radio',
 	} );
 
 	return (
 		<CheckboxWrapper className={ classes }>
-			<CheckboxInput type="checkbox" { ...props } />
+			<CheckboxInput
+				type={ type }
+				checked={ checked }
+				value={ value }
+				onChange={ onChange }
+				{ ...props }
+			/>
 		</CheckboxWrapper>
 	);
 };

--- a/packages/blocks/src/components/form-checkbox/index.js
+++ b/packages/blocks/src/components/form-checkbox/index.js
@@ -110,10 +110,10 @@ const FormCheckbox = ( {
 	return (
 		<CheckboxWrapper className={ classes }>
 			<CheckboxInput
-				type={ type }
 				checked={ checked }
+				onChange={ ( event ) => onChange( event.target.value ) }
+				type={ type }
 				value={ value }
-				onChange={ onChange }
 				{ ...props }
 			/>
 		</CheckboxWrapper>

--- a/packages/blocks/src/components/form-file-input/index.js
+++ b/packages/blocks/src/components/form-file-input/index.js
@@ -48,8 +48,7 @@ const FileInputFileRemove = styled.a`
 	display: block;
 `;
 
-const FormFileInput = ( { inputProps, attributes } ) => {
-	const { files, onChange } = inputProps;
+const FormFileInput = ( { attributes, files, onChange } ) => {
 	const inputFile = useRef( null );
 
 	const handleFileInputClick = ( event ) => {
@@ -63,7 +62,7 @@ const FormFileInput = ( { inputProps, attributes } ) => {
 		// It doesn't seem easy to manage files individually on an input file field.
 		// Since we only support single files ATM, this is not a problem.
 		// We'll need to figure out how to handle this to add support for multiple files
-		onChange( { target: { value: null } } );
+		onChange( { target: { files: null } } );
 	};
 
 	let outputMessage = attributes.message;
@@ -78,7 +77,7 @@ const FormFileInput = ( { inputProps, attributes } ) => {
 
 	return (
 		<FileInputWrapper>
-			<input { ...inputProps } ref={ inputFile } />
+			<input type="file" onChange={ onChange } ref={ inputFile } />
 			<FileInputButton onClick={ handleFileInputClick } outline>
 				{ attributes.buttonLabel }
 			</FileInputButton>

--- a/packages/blocks/src/components/form-file-input/index.js
+++ b/packages/blocks/src/components/form-file-input/index.js
@@ -62,7 +62,7 @@ const FormFileInput = ( { attributes, files, onChange } ) => {
 		// It doesn't seem easy to manage files individually on an input file field.
 		// Since we only support single files ATM, this is not a problem.
 		// We'll need to figure out how to handle this to add support for multiple files
-		onChange( { target: { files: null } } );
+		onChange( null );
 	};
 
 	let outputMessage = attributes.message;
@@ -77,7 +77,11 @@ const FormFileInput = ( { attributes, files, onChange } ) => {
 
 	return (
 		<FileInputWrapper>
-			<input type="file" onChange={ onChange } ref={ inputFile } />
+			<input
+				onChange={ ( event ) => onChange( event.target.files ) }
+				ref={ inputFile }
+				type="file"
+			/>
 			<FileInputButton onClick={ handleFileInputClick } outline>
 				{ attributes.buttonLabel }
 			</FileInputButton>

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -26,8 +26,14 @@ const Input = styled.input`
 	}
 `;
 
-const FormTextInput = ( { style = {}, ...props } ) => (
-	<Input type="text" style={ { ...style } } { ...props } />
+const FormTextInput = ( { value, onChange, style = {}, ...props } ) => (
+	<Input
+		type="text"
+		value={ value }
+		onChange={ onChange }
+		style={ { ...style } }
+		{ ...props }
+	/>
 );
 
 FormTextInput.Preview = ( { className, ...props } ) => (

--- a/packages/blocks/src/components/form-text-input/index.js
+++ b/packages/blocks/src/components/form-text-input/index.js
@@ -26,12 +26,12 @@ const Input = styled.input`
 	}
 `;
 
-const FormTextInput = ( { value, onChange, style = {}, ...props } ) => (
+const FormTextInput = ( { onChange, style = {}, value, ...props } ) => (
 	<Input
+		onChange={ ( event ) => onChange( event.target.value ) }
+		style={ { ...style } }
 		type="text"
 		value={ value }
-		onChange={ onChange }
-		style={ { ...style } }
 		{ ...props }
 	/>
 );

--- a/packages/blocks/src/components/form-textarea/index.js
+++ b/packages/blocks/src/components/form-textarea/index.js
@@ -16,13 +16,22 @@ const FormTextarePreviewWrapper = styled.div`
 	width: 100%;
 `;
 
-const FormTextarea = styled.textarea`
+const Textarea = styled.textarea`
 	border-style: solid;
 	border-width: 1px;
 	box-sizing: border-box;
 	width: 100%;
 	padding: 8px;
 `;
+
+const FormTextarea = ( { onChange, style, value, ...props } ) => (
+	<Textarea
+		onChange={ ( event ) => onChange( event.target.value ) }
+		style={ style }
+		value={ value }
+		{ ...props }
+	/>
+);
 
 FormTextarea.Preview = ( { style, ...props } ) => (
 	<FormTextarePreviewWrapper>

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -18,14 +18,10 @@ import { useField } from '@crowdsignal/form';
 
 const DropdownInput = ( { attributes, className } ) => {
 	const multipleChoice = attributes.maximumChoices > 1;
-	const {
-		error,
-		inputProps: { onChange, value },
-	} = useField( {
-		name: `q_${ attributes.clientId }[choice]${
+	const { error, onUpdate, fieldValue } = useField( {
+		fieldName: `q_${ attributes.clientId }[choice]${
 			multipleChoice ? '[]' : ''
 		}`,
-		type: 'dropdown',
 		defaultValue: multipleChoice ? [] : '',
 		validation: ( val ) => {
 			if ( attributes.mandatory && isEmpty( val ) ) {
@@ -61,8 +57,8 @@ const DropdownInput = ( { attributes, className } ) => {
 			<FormDropdownInput
 				buttonLabel={ attributes.buttonLabel || defaultButtonLabel }
 				options={ attributes.options }
-				onChange={ onChange }
-				value={ value }
+				onChange={ onUpdate }
+				value={ fieldValue }
 				width={ attributes.inputWidth }
 				multipleChoice={ multipleChoice }
 				maxChoices={ attributes.maximumChoices }

--- a/packages/blocks/src/dropdown-input/index.js
+++ b/packages/blocks/src/dropdown-input/index.js
@@ -18,7 +18,7 @@ import { useField } from '@crowdsignal/form';
 
 const DropdownInput = ( { attributes, className } ) => {
 	const multipleChoice = attributes.maximumChoices > 1;
-	const { error, onUpdate, fieldValue } = useField( {
+	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }[choice]${
 			multipleChoice ? '[]' : ''
 		}`,
@@ -57,7 +57,7 @@ const DropdownInput = ( { attributes, className } ) => {
 			<FormDropdownInput
 				buttonLabel={ attributes.buttonLabel || defaultButtonLabel }
 				options={ attributes.options }
-				onChange={ onUpdate }
+				onChange={ onChange }
 				value={ fieldValue }
 				width={ attributes.inputWidth }
 				multipleChoice={ multipleChoice }

--- a/packages/blocks/src/file-input/index.js
+++ b/packages/blocks/src/file-input/index.js
@@ -13,9 +13,8 @@ import { useColorStyles } from '@crowdsignal/styles';
 import { useField } from '@crowdsignal/form';
 
 const FileInput = ( { attributes, className } ) => {
-	const { inputProps, error } = useField( {
-		name: `q_${ attributes.clientId }_upload`,
-		type: 'file',
+	const { error, fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ attributes.clientId }_upload`,
 		validation: ( files ) => {
 			if ( attributes.mandatory && ( ! files || files.length === 0 ) ) {
 				return __( 'This field is required', 'blocks' );
@@ -60,7 +59,8 @@ const FileInput = ( { attributes, className } ) => {
 			</FormInputWrapper.Label>
 			<FormFileInput
 				attributes={ attributes }
-				inputProps={ inputProps }
+				files={ fieldValue }
+				onChange={ ( event ) => onUpdate( event.target.files ) }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/blocks/src/file-input/index.js
+++ b/packages/blocks/src/file-input/index.js
@@ -13,7 +13,7 @@ import { useColorStyles } from '@crowdsignal/styles';
 import { useField } from '@crowdsignal/form';
 
 const FileInput = ( { attributes, className } ) => {
-	const { error, fieldValue, onUpdate } = useField( {
+	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }_upload`,
 		validation: ( files ) => {
 			if ( attributes.mandatory && ( ! files || files.length === 0 ) ) {
@@ -60,7 +60,7 @@ const FileInput = ( { attributes, className } ) => {
 			<FormFileInput
 				attributes={ attributes }
 				files={ fieldValue }
-				onChange={ ( event ) => onUpdate( event.target.files ) }
+				onChange={ onChange }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/blocks/src/matrix-question/cell.js
+++ b/packages/blocks/src/matrix-question/cell.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { filter, uniq } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { useField } from '@crowdsignal/form';
@@ -10,25 +15,35 @@ import { FormCheckbox } from '../components';
 import { MatrixCell } from './styles';
 
 const Cell = ( { column, multipleChoice, questionClientId, row } ) => {
-	const { fieldValue, onUpdate } = useField( {
+	const { fieldValue, onChange } = useField( {
 		fieldName: `q_${ questionClientId }[${ row.clientId }]${
 			multipleChoice ? '[]' : ''
 		}`,
-		isMultiSelect: multipleChoice,
+		defaultValue: multipleChoice ? [] : '',
 	} );
 
 	const isSelected = multipleChoice
 		? fieldValue.includes( column.clientId )
 		: fieldValue === column.clientId;
 
+	const onChangeHandler = ( value ) => {
+		let newValue = value;
+
+		if ( multipleChoice ) {
+			newValue = ! isSelected
+				? uniq( [ ...fieldValue, value ] )
+				: filter( fieldValue, ( v ) => v !== value );
+		}
+
+		onChange( newValue );
+	};
+
 	return (
 		<MatrixCell as="label">
 			<FormCheckbox
 				checked={ isSelected }
 				isMultiSelect={ multipleChoice }
-				onChange={ ( event ) =>
-					onUpdate( event.target.value, isSelected )
-				}
+				onChange={ onChangeHandler }
 				type={ multipleChoice ? 'checkbox' : 'radio' }
 				value={ column.clientId }
 			/>

--- a/packages/blocks/src/matrix-question/cell.js
+++ b/packages/blocks/src/matrix-question/cell.js
@@ -10,17 +10,28 @@ import { FormCheckbox } from '../components';
 import { MatrixCell } from './styles';
 
 const Cell = ( { column, multipleChoice, questionClientId, row } ) => {
-	const { inputProps } = useField( {
-		name: `q_${ questionClientId }[${ row.clientId }]${
+	const { fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ questionClientId }[${ row.clientId }]${
 			multipleChoice ? '[]' : ''
 		}`,
-		type: multipleChoice ? 'checkbox' : 'radio',
-		value: column.clientId,
+		isMultiSelect: multipleChoice,
 	} );
+
+	const isSelected = multipleChoice
+		? fieldValue.includes( column.clientId )
+		: fieldValue === column.clientId;
 
 	return (
 		<MatrixCell as="label">
-			<FormCheckbox { ...inputProps } />
+			<FormCheckbox
+				checked={ isSelected }
+				isMultiSelect={ multipleChoice }
+				onChange={ ( event ) =>
+					onUpdate( event.target.value, isSelected )
+				}
+				type={ multipleChoice ? 'checkbox' : 'radio' }
+				value={ column.clientId }
+			/>
 		</MatrixCell>
 	);
 };

--- a/packages/blocks/src/multiple-choice-answer/index.js
+++ b/packages/blocks/src/multiple-choice-answer/index.js
@@ -15,22 +15,24 @@ import CheckboxAnswer from '../components/checkbox-answer';
 
 const MultipleChoiceAnswer = ( { attributes, className } ) => {
 	const parentQuestion = useContext( MultipleChoiceQuestion.Context );
-
 	const isMultiSelect = parentQuestion.maximumChoices !== 1;
 
-	const { inputProps } = useField( {
-		name: `q_${ parentQuestion.clientId }[choice]${
+	const { fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ parentQuestion.clientId }[choice]${
 			isMultiSelect ? '[]' : ''
 		}`,
-		type: isMultiSelect ? 'checkbox' : 'radio',
-		value: attributes.clientId,
+		isMultiSelect,
 	} );
+
+	const isSelected = isMultiSelect
+		? fieldValue.includes( attributes.clientId )
+		: fieldValue === attributes.clientId;
 
 	const classes = classnames(
 		'crowdsignal-forms-multiple-choice-answer-block',
 		className,
 		{
-			'is-selected': inputProps.checked,
+			'is-selected': isSelected,
 		}
 	);
 
@@ -46,7 +48,12 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 			<CheckboxAnswer
 				attributes={ attributes }
 				className={ classes }
-				inputProps={ inputProps }
+				isMultiSelect={ isMultiSelect }
+				isSelected={ isSelected }
+				onChange={ ( event ) =>
+					onUpdate( event.target.value, isSelected )
+				}
+				value={ attributes.clientId }
 			/>
 		);
 	}
@@ -55,8 +62,10 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 		<ButtonAnswer
 			attributes={ attributes }
 			className={ classes }
-			inputProps={ inputProps }
 			isMultiSelect={ isMultiSelect }
+			isSelected={ isSelected }
+			onChange={ ( event ) => onUpdate( event.target.value, isSelected ) }
+			value={ attributes.clientId }
 			showCheckmark
 		>
 			{ attributes.label }

--- a/packages/blocks/src/multiple-choice-answer/index.js
+++ b/packages/blocks/src/multiple-choice-answer/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { useContext } from '@wordpress/element';
+import { filter, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,16 +18,28 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 	const parentQuestion = useContext( MultipleChoiceQuestion.Context );
 	const isMultiSelect = parentQuestion.maximumChoices !== 1;
 
-	const { fieldValue, onUpdate } = useField( {
+	const { fieldValue, onChange } = useField( {
 		fieldName: `q_${ parentQuestion.clientId }[choice]${
 			isMultiSelect ? '[]' : ''
 		}`,
-		isMultiSelect,
+		defaultValue: isMultiSelect ? [] : '',
 	} );
 
 	const isSelected = isMultiSelect
 		? fieldValue.includes( attributes.clientId )
 		: fieldValue === attributes.clientId;
+
+	const onChangeHandler = ( value ) => {
+		let newValue = value;
+
+		if ( isMultiSelect ) {
+			newValue = ! isSelected
+				? uniq( [ ...fieldValue, value ] )
+				: filter( fieldValue, ( v ) => v !== value );
+		}
+
+		onChange( newValue );
+	};
 
 	const classes = classnames(
 		'crowdsignal-forms-multiple-choice-answer-block',
@@ -50,9 +63,7 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 				className={ classes }
 				isMultiSelect={ isMultiSelect }
 				isSelected={ isSelected }
-				onChange={ ( event ) =>
-					onUpdate( event.target.value, isSelected )
-				}
+				onChange={ onChangeHandler }
 				value={ attributes.clientId }
 			/>
 		);
@@ -64,7 +75,7 @@ const MultipleChoiceAnswer = ( { attributes, className } ) => {
 			className={ classes }
 			isMultiSelect={ isMultiSelect }
 			isSelected={ isSelected }
-			onChange={ ( event ) => onUpdate( event.target.value, isSelected ) }
+			onChange={ onChangeHandler }
 			value={ attributes.clientId }
 			showCheckmark
 		>

--- a/packages/blocks/src/ranking-question/index.js
+++ b/packages/blocks/src/ranking-question/index.js
@@ -25,7 +25,7 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 		[ children ]
 	);
 
-	const { onUpdate } = useField( {
+	const { onChange } = useField( {
 		fieldName: `q_${ attributes.clientId }[ranking][]`,
 		initialValue: map( answers, 'props.attributes.clientId' ),
 	} );
@@ -38,7 +38,7 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 
 		const [ removed ] = answers.splice( source.index, 1 );
 		answers.splice( destination.index, 0, removed );
-		onUpdate( map( answers, 'props.attributes.clientId' ) );
+		onChange( map( answers, 'props.attributes.clientId' ) );
 	};
 
 	const classes = classnames(

--- a/packages/blocks/src/ranking-question/index.js
+++ b/packages/blocks/src/ranking-question/index.js
@@ -25,8 +25,8 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 		[ children ]
 	);
 
-	const { onSort } = useField( {
-		name: `q_${ attributes.clientId }[ranking][]`,
+	const { onUpdate } = useField( {
+		fieldName: `q_${ attributes.clientId }[ranking][]`,
 		initialValue: map( answers, 'props.attributes.clientId' ),
 	} );
 
@@ -38,7 +38,7 @@ const RankingQuestion = ( { attributes, children, className } ) => {
 
 		const [ removed ] = answers.splice( source.index, 1 );
 		answers.splice( destination.index, 0, removed );
-		onSort( answers );
+		onUpdate( map( answers, 'props.attributes.clientId' ) );
 	};
 
 	const classes = classnames(

--- a/packages/blocks/src/rating-scale-answer/index.js
+++ b/packages/blocks/src/rating-scale-answer/index.js
@@ -16,19 +16,18 @@ const RatingScaleAnswer = ( { attributes, className } ) => {
 	const parentQuestion = useContext( RatingScaleQuestion.Context );
 
 	// fixing the input array-ish as rating, solve the ID on backend
-	const { inputProps } = useField( {
-		name: `q_${ parentQuestion.clientId }[rating]`,
-		type: 'radio',
-		value: attributes.clientId,
+	const { fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ parentQuestion.clientId }[rating]`,
 	} );
 
+	const isSelected = fieldValue === attributes.clientId;
 	const blockStyle = getBlockStyle( parentQuestion.className );
 
 	const classes = classnames(
 		'crowdsignal-forms-rating-scale-answer-block',
 		className,
 		{
-			'is-selected': inputProps.checked,
+			'is-selected': isSelected,
 			'is-style-emoji': blockStyle === RatingScaleQuestion.Style.EMOJI,
 			'is-style-text': blockStyle === RatingScaleQuestion.Style.TEXT,
 		}
@@ -42,8 +41,10 @@ const RatingScaleAnswer = ( { attributes, className } ) => {
 		<ButtonAnswer
 			attributes={ attributes }
 			className={ classes }
-			inputProps={ inputProps }
 			isMultiSelect={ false }
+			isSelected={ isSelected }
+			onChange={ ( event ) => onUpdate( event.target.value, isSelected ) }
+			value={ attributes.clientId }
 		>
 			{ blockStyle === RatingScaleQuestion.Style.EMOJI
 				? attributes.emoji

--- a/packages/blocks/src/rating-scale-answer/index.js
+++ b/packages/blocks/src/rating-scale-answer/index.js
@@ -16,7 +16,7 @@ const RatingScaleAnswer = ( { attributes, className } ) => {
 	const parentQuestion = useContext( RatingScaleQuestion.Context );
 
 	// fixing the input array-ish as rating, solve the ID on backend
-	const { fieldValue, onUpdate } = useField( {
+	const { fieldValue, onChange } = useField( {
 		fieldName: `q_${ parentQuestion.clientId }[rating]`,
 	} );
 
@@ -43,7 +43,7 @@ const RatingScaleAnswer = ( { attributes, className } ) => {
 			className={ classes }
 			isMultiSelect={ false }
 			isSelected={ isSelected }
-			onChange={ ( event ) => onUpdate( event.target.value, isSelected ) }
+			onChange={ onChange }
 			value={ attributes.clientId }
 		>
 			{ blockStyle === RatingScaleQuestion.Style.EMOJI

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -15,8 +15,8 @@ import { useField } from '@crowdsignal/form';
 import validator from './validations';
 
 const TextInput = ( { attributes, className } ) => {
-	const { inputProps, error } = useField( {
-		name: `q_${ attributes.clientId }[text]`,
+	const { error, fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This field is required', 'blocks' );
@@ -49,12 +49,13 @@ const TextInput = ( { attributes, className } ) => {
 				<RawHTML>{ attributes.label }</RawHTML>
 			</FormInputWrapper.Label>
 			<FormTextInput
+				value={ fieldValue }
+				placeholder={ attributes.placeholder }
+				onChange={ ( event ) => onUpdate( event.target.value ) }
 				style={ {
 					width: attributes.inputWidth,
 					height: `${ attributes.inputHeight }px`,
 				} }
-				placeholder={ attributes.placeholder }
-				{ ...inputProps }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -15,7 +15,7 @@ import { useField } from '@crowdsignal/form';
 import validator from './validations';
 
 const TextInput = ( { attributes, className } ) => {
-	const { error, fieldValue, onUpdate } = useField( {
+	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
@@ -49,13 +49,13 @@ const TextInput = ( { attributes, className } ) => {
 				<RawHTML>{ attributes.label }</RawHTML>
 			</FormInputWrapper.Label>
 			<FormTextInput
-				value={ fieldValue }
+				onChange={ onChange }
 				placeholder={ attributes.placeholder }
-				onChange={ ( event ) => onUpdate( event.target.value ) }
 				style={ {
 					width: attributes.inputWidth,
 					height: `${ attributes.inputHeight }px`,
 				} }
+				value={ fieldValue }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/blocks/src/text-question/index.js
+++ b/packages/blocks/src/text-question/index.js
@@ -19,7 +19,7 @@ import {
 } from '../components';
 
 const TextQuestion = ( { attributes, className } ) => {
-	const { error, fieldValue, onUpdate } = useField( {
+	const { error, fieldValue, onChange } = useField( {
 		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
@@ -50,7 +50,7 @@ const TextQuestion = ( { attributes, className } ) => {
 				</QuestionHeader>
 
 				<FormTextarea
-					onChange={ ( event ) => onUpdate( event.target.value ) }
+					onChange={ onChange }
 					placeholder={ attributes.placeholder }
 					style={ style }
 					value={ fieldValue }

--- a/packages/blocks/src/text-question/index.js
+++ b/packages/blocks/src/text-question/index.js
@@ -19,8 +19,8 @@ import {
 } from '../components';
 
 const TextQuestion = ( { attributes, className } ) => {
-	const { inputProps, error } = useField( {
-		name: `q_${ attributes.clientId }[text]`,
+	const { error, fieldValue, onUpdate } = useField( {
+		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This question is required', 'blocks' );
@@ -38,6 +38,10 @@ const TextQuestion = ( { attributes, className } ) => {
 		}
 	);
 
+	const style = {
+		height: attributes.inputHeight,
+	};
+
 	return (
 		<JustificationWrapper justification={ attributes.justification }>
 			<QuestionWrapper attributes={ attributes } className={ classes }>
@@ -46,11 +50,10 @@ const TextQuestion = ( { attributes, className } ) => {
 				</QuestionHeader>
 
 				<FormTextarea
-					style={ {
-						height: attributes.inputHeight,
-					} }
+					onChange={ ( event ) => onUpdate( event.target.value ) }
 					placeholder={ attributes.placeholder }
-					{ ...inputProps }
+					style={ style }
+					value={ fieldValue }
 				/>
 				{ error && <ErrorMessage>{ error }</ErrorMessage> }
 			</QuestionWrapper>

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -32,13 +32,13 @@ const MyForm = () => {
 import { useField } from '@crowdsignal/form';
 
 const TextInput = () => {
-	const { error, inputProps } = useField( {
+	const { error, onChange, fieldValue } = useField( {
 		name: 'example',
 	} );
 
 	return (
 		<div className="text-input">
-			<input className="text-input__input" { ...inputProps } />
+			<input className="text-input__input" onChange={ onChange } value={ fieldValue } />
 			{ error && ( <span className="text-input__error">{ error }</span> ) }
 		</div>
 	);

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -17,7 +17,6 @@ export const useField = ( {
 	fieldName,
 	initialValue,
 	validation,
-	defaultValue,
 } ) => {
 	const { name: formName } = useContext( Form.Context );
 	const { setFieldValue } = useDispatch( STORE_NAME );

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -3,7 +3,7 @@
  */
 import { useContext, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { filter, isNil, uniq } from 'lodash';
+import { isNil } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,9 +13,9 @@ import { STORE_NAME } from '../data';
 import { useValidation } from './use-validation';
 
 export const useField = ( {
+	defaultValue = '',
 	fieldName,
 	initialValue,
-	isMultiSelect,
 	validation,
 	defaultValue,
 } ) => {
@@ -40,22 +40,14 @@ export const useField = ( {
 		}
 	}, [] );
 
-	const onUpdate = ( value, isSelected ) => {
-		let newValue = value;
-
-		if ( isMultiSelect ) {
-			newValue = ! isSelected
-				? uniq( [ ...fieldValue, value ] )
-				: filter( fieldValue, ( v ) => v !== value );
-		}
-
-		setFieldValue( formName, fieldName, newValue );
-		validateField( newValue );
+	const onChange = ( value ) => {
+		setFieldValue( formName, fieldName, value );
+		validateField( value );
 	};
 
 	return {
 		error,
 		fieldValue,
-		onUpdate,
+		onChange,
 	};
 };

--- a/packages/form/src/hooks/use-field.js
+++ b/packages/form/src/hooks/use-field.js
@@ -3,7 +3,7 @@
  */
 import { useContext, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { filter, includes, isNil, map, uniq } from 'lodash';
+import { filter, isNil, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,83 +13,26 @@ import { STORE_NAME } from '../data';
 import { useValidation } from './use-validation';
 
 export const useField = ( {
-	name: fieldName,
-	type,
-	value,
-	validation,
+	fieldName,
 	initialValue,
+	isMultiSelect,
+	validation,
 	defaultValue,
 } ) => {
 	const { name: formName } = useContext( Form.Context );
 	const { setFieldValue } = useDispatch( STORE_NAME );
 	const { error, validateField } = useValidation( { fieldName, validation } );
-	const currentValue = useSelect(
+	const fieldValue = useSelect(
 		( select ) => {
-			const fieldValue = select( STORE_NAME ).getFieldValue(
+			const value = select( STORE_NAME ).getFieldValue(
 				formName,
 				fieldName
 			);
-			return ! isNil( fieldValue ) ? fieldValue : defaultValue;
+
+			return ! isNil( value ) ? value : defaultValue;
 		},
 		[ formName, fieldName ]
 	);
-
-	const onChange = ( event ) => {
-		let newValue = event?.target?.value;
-
-		if ( type === 'checkbox' ) {
-			newValue = event.target.checked
-				? uniq( [ ...( currentValue || [] ), event.target.value ] )
-				: filter(
-						currentValue || [],
-						( v ) => v !== event.target.value
-				  );
-		} else if ( type === 'file' ) {
-			newValue = event.target.files;
-		} else if ( type === 'dropdown' ) {
-			newValue = event;
-		}
-
-		setFieldValue( formName, fieldName, newValue );
-
-		if ( [ 'file', 'dropdown' ].includes( type ) ) {
-			validateField( newValue );
-		}
-	};
-
-	const onBlur = () => {
-		validateField( currentValue );
-	};
-
-	const onSort = ( items ) => {
-		const values = map( items, ( item ) => item.props.attributes.clientId );
-		setFieldValue( formName, fieldName, values );
-	};
-
-	const fieldValue =
-		type === 'checkbox' || type === 'radio' ? value : currentValue || '';
-
-	const inputProps = {
-		name: fieldName,
-		onChange,
-	};
-
-	if ( type ) {
-		inputProps.type = type;
-	}
-
-	if ( includes( [ 'checkbox', 'radio', 'dropdown' ], type ) ) {
-		inputProps.onBlur = onBlur;
-		inputProps.value = fieldValue;
-	}
-
-	if ( type === 'checkbox' ) {
-		inputProps.checked = includes( currentValue, value );
-	} else if ( type === 'radio' ) {
-		inputProps.checked = currentValue === value;
-	} else if ( type === 'file' ) {
-		inputProps.files = currentValue || [];
-	}
 
 	useEffect( () => {
 		if ( initialValue ) {
@@ -97,9 +40,22 @@ export const useField = ( {
 		}
 	}, [] );
 
+	const onUpdate = ( value, isSelected ) => {
+		let newValue = value;
+
+		if ( isMultiSelect ) {
+			newValue = ! isSelected
+				? uniq( [ ...fieldValue, value ] )
+				: filter( fieldValue, ( v ) => v !== value );
+		}
+
+		setFieldValue( formName, fieldName, newValue );
+		validateField( newValue );
+	};
+
 	return {
 		error,
-		inputProps,
-		onSort,
+		fieldValue,
+		onUpdate,
 	};
 };

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -16,6 +16,7 @@ body {
 	--color-text: #444;
 
 	--cs--style--button--border-radius: 9px;
+	--cs--style--answer--selected--background: #1285ce;
 }
 
 body {


### PR DESCRIPTION
## Summary

This is a clean-up/housekeeping PR that aims to simplify the `use-field` hook.
It now doesn't care about the field type. The type-specific logic was moved to the components.
The hook, now, takes a `fieldName` and a flag to define if it can handle multiple values.
It'll return the current `fieldValue` and an `onUpdate` handler to allow values updates.


## Testing Instructions
* Create a project and add at least one of each Crowdsignal block
* Play with the blocks, especially the validations
* Go to the renderer and check if the blocks behave as expected and if the responses are collected correctly