### PR TITLE
Add a card embed format

### DIFF
--- a/apps/embed/src/card.js
+++ b/apps/embed/src/card.js
@@ -1,0 +1,52 @@
+/**
+ * Crowdsignal embed component.
+ */
+class CrowdsignalCard extends window.HTMLElement {
+	/**
+	 * Reference to the main iframe
+	 */
+	#frame;
+
+	constructor() {
+		super();
+
+		this.attachShadow( { mode: 'open' } );
+	}
+
+	connectedCallback() {
+		const viewportWidth = parseInt(
+			this.getAttribute( 'viewport-width', 10 )
+		);
+		const viewportHeight = parseInt(
+			this.getAttribute( 'viewport-height', 10 )
+		);
+
+		const wrapper = document.createElement( 'div' );
+		wrapper.style.width = '100%';
+		wrapper.style.maxWidth = `${ viewportWidth }px`;
+		this.shadowRoot.appendChild( wrapper );
+
+		// Measure the wrapper width after it mounts to determine the scale factor
+		const scale = wrapper.offsetWidth / viewportWidth;
+
+		wrapper.style.width = `${ Math.floor( viewportWidth * scale ) }px`;
+		wrapper.style.height = `${ Math.floor( viewportHeight * scale ) }px`;
+		wrapper.style.position = 'relative';
+
+		this.#frame = document.createElement( 'iframe' );
+		this.#frame.src = this.getAttribute( 'src' );
+
+		this.#frame.setAttribute( 'frameBorder', '0' );
+		this.#frame.scrolling = 'no';
+
+		this.#frame.style.maxWidth = null;
+		this.#frame.style.width = `${ viewportWidth }px`;
+		this.#frame.style.height = `${ viewportHeight }px`;
+		this.#frame.style.transform = `scale(${ scale })`;
+		this.#frame.style.transformOrigin = 'top left';
+
+		wrapper.appendChild( this.#frame );
+	}
+}
+
+export default CrowdsignalCard;

--- a/apps/embed/src/index.js
+++ b/apps/embed/src/index.js
@@ -1,6 +1,8 @@
 /**
  * Internal dependencies
  */
+import CrowdsignalCard from './card';
 import CrowdsignalEmbed from './embed';
 
+window.customElements.define( 'crowdsignal-card', CrowdsignalCard );
 window.customElements.define( 'crowdsignal-embed', CrowdsignalEmbed );

--- a/apps/embed/src/stories/index.js
+++ b/apps/embed/src/stories/index.js
@@ -1,8 +1,10 @@
 /**
  * Internal dependencies
  */
+import CrowdsignalCard from '../card.js';
 import CrowdsignalEmbed from '../embed.js';
 
+window.customElements.define( 'crowdsignal-card', CrowdsignalCard );
 window.customElements.define( 'crowdsignal-embed', CrowdsignalEmbed );
 
 export default {
@@ -10,6 +12,9 @@ export default {
 };
 
 const wrapperStyles = {
+	display: 'flex',
+	flexDirection: 'column',
+	justifyItems: 'center',
 	margin: '50px auto',
 	maxWidth: '660px',
 };
@@ -18,4 +23,23 @@ export const Default = () => (
 	<div style={ wrapperStyles }>
 		<crowdsignal-embed src="https://crowdsignal.localhost:9001/B2A9100BBAB921D0" />
 	</div>
+);
+
+export const Card = () => (
+	<>
+		<div style={ wrapperStyles }>
+			<crowdsignal-card
+				src="https://crowdsignal.localhost:9001/B2A9100BBAB921D0"
+				viewport-width="1200"
+				viewport-height="600"
+			/>
+		</div>
+		<div style={ wrapperStyles }>
+			<crowdsignal-card
+				src="https://crowdsignal.localhost:9001/B2A9100BBAB921D0"
+				viewport-width="300"
+				viewport-height="300"
+			/>
+		</div>
+	</>
 );


### PR DESCRIPTION
This patch adds support for a second embed type: project cards. As proposed by @digitalwaveride, the idea is cards would have a fixed 'viewport size' and scale the content to fit the available area on the page while keeping the same aspect ratio.

As they work slightly differently, I figured the cleanest way to implement/share them would be to give them their own component:

```
<crowdsignal-card src="YOUR_PROJECT_URL" viewport-width="1200" viewport-height="600"></crowdsignal-card>
```

Viewport width and height accept pixel values for the desired, let's call it 'preview size' of the project. The card will never exceed these dimensions but it can be smaller, in which case the aspect ratio is preserved and the content is scaled down.

![Screenshot 2022-06-22 at 20 21 15](https://user-images.githubusercontent.com/8056203/175109931-00bce876-129d-4bb1-9c8f-db52d0f12644.png)

Note that the implementation is still a little quirky and there's still things to figure out, this patch really serves as a proof of concept to get a better feeling for how the format works before committing to more work on it.

# Testing

- Run `yarn start` and `yarn storybook`.
- Inside storybook you should now see a new card embed type.
- Note that with the current example, it's actually impossible to submit it (scrolling is disabled).