### PR TITLE
Include Editor Patterns

### DIFF
--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -40,6 +40,7 @@ import {
 } from './styles/editor';
 
 registerBlocks();
+const baseSettings = registerPatterns( editorSettings );
 
 const Editor = ( { project } ) => {
 	const [ showWizard, setShowWizard ] = useState( ! project.id );
@@ -97,13 +98,11 @@ const Editor = ( { project } ) => {
 	};
 
 	const settings = useMemo( () => {
-		const newSettings = registerPatterns( editorSettings );
-
 		if ( ! confirmationPage ) {
-			return newSettings;
+			return baseSettings;
 		}
 
-		return tap( cloneDeep( newSettings ), ( { editor, iso } ) => {
+		return tap( cloneDeep( baseSettings ), ( { editor, iso } ) => {
 			iso.blocks.allowBlocks = filter(
 				iso.blocks.allowBlocks,
 				( block ) => ! block.match( /^crowdsignal\-forms\/.+/ )

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -13,6 +13,7 @@ import { Global } from '@emotion/react';
  */
 import { editorSettings } from './settings';
 import { registerBlocks } from './blocks';
+import { registerPatterns } from './patterns';
 import { STORE_NAME } from '../../data';
 import { useEditorContent } from './use-editor-content';
 import AutoSubmitButton from './auto-submit-button';
@@ -96,11 +97,13 @@ const Editor = ( { project } ) => {
 	};
 
 	const settings = useMemo( () => {
+		const newSettings = registerPatterns( editorSettings );
+
 		if ( ! confirmationPage ) {
-			return editorSettings;
+			return newSettings;
 		}
 
-		return tap( cloneDeep( editorSettings ), ( { editor, iso } ) => {
+		return tap( cloneDeep( newSettings ), ( { editor, iso } ) => {
 			iso.blocks.allowBlocks = filter(
 				iso.blocks.allowBlocks,
 				( block ) => ! block.match( /^crowdsignal\-forms\/.+/ )

--- a/apps/dashboard/src/components/editor/patterns/categories.js
+++ b/apps/dashboard/src/components/editor/patterns/categories.js
@@ -1,0 +1,10 @@
+const CONTACT_FORMS = {
+	name: 'crowdsignal-contact-forms',
+	label: 'Contact Forms',
+};
+
+export const CATEGORY_NAMES = {
+	CONTACT_FORMS: CONTACT_FORMS.name,
+};
+
+export const CATEGORIES = [ CONTACT_FORMS ];

--- a/apps/dashboard/src/components/editor/patterns/index.js
+++ b/apps/dashboard/src/components/editor/patterns/index.js
@@ -1,3 +1,12 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import { serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
 import { CATEGORIES } from './categories';
 import PATTERNS from './patterns';
 
@@ -7,7 +16,10 @@ export const registerPatterns = ( settings ) => {
 		editor: {
 			...settings.editor,
 			__experimentalBlockPatternCategories: CATEGORIES,
-			__experimentalBlockPatterns: PATTERNS,
+			__experimentalBlockPatterns: map( PATTERNS, ( pattern ) => ( {
+				...pattern,
+				content: serialize( pattern.content ),
+			} ) ),
 		},
 	};
 };

--- a/apps/dashboard/src/components/editor/patterns/index.js
+++ b/apps/dashboard/src/components/editor/patterns/index.js
@@ -1,0 +1,13 @@
+import { CATEGORIES } from './categories';
+import PATTERNS from './patterns';
+
+export const registerPatterns = ( settings ) => {
+	return {
+		...settings,
+		editor: {
+			...settings.editor,
+			__experimentalBlockPatternCategories: CATEGORIES,
+			__experimentalBlockPatterns: PATTERNS,
+		},
+	};
+};

--- a/apps/dashboard/src/components/editor/patterns/patterns.js
+++ b/apps/dashboard/src/components/editor/patterns/patterns.js
@@ -1,12 +1,14 @@
+/**
+ * Internal dependencies
+ */
 import { CATEGORY_NAMES } from './categories';
-import { serialize } from '@wordpress/blocks';
 
 const SIMPLE_CONTACT_FORM_01 = {
 	name: 'simple-contact-form-01',
 	title: 'Simple Contact Form',
 	description: 'A simple contact form',
 	categories: [ CATEGORY_NAMES.CONTACT_FORMS ],
-	content: serialize( [
+	content: [
 		{
 			name: 'crowdsignal-forms/text-input',
 			attributes: {
@@ -29,7 +31,7 @@ const SIMPLE_CONTACT_FORM_01 = {
 			},
 			innerBlocks: [],
 		},
-	] ),
+	],
 };
 
 export default [ SIMPLE_CONTACT_FORM_01 ];

--- a/apps/dashboard/src/components/editor/patterns/patterns.js
+++ b/apps/dashboard/src/components/editor/patterns/patterns.js
@@ -1,0 +1,35 @@
+import { CATEGORY_NAMES } from './categories';
+import { serialize } from '@wordpress/blocks';
+
+const SIMPLE_CONTACT_FORM_01 = {
+	name: 'simple-contact-form-01',
+	title: 'Simple Contact Form',
+	description: 'A simple contact form',
+	categories: [ CATEGORY_NAMES.CONTACT_FORMS ],
+	content: serialize( [
+		{
+			name: 'crowdsignal-forms/text-input',
+			attributes: {
+				label: 'Name',
+			},
+			innerBlocks: [],
+		},
+		{
+			name: 'crowdsignal-forms/text-input',
+			attributes: {
+				label: 'Email',
+				validation: [ 'emailValidation' ],
+			},
+			innerBlocks: [],
+		},
+		{
+			name: 'crowdsignal-forms/submit-button',
+			attributes: {
+				label: 'Submit',
+			},
+			innerBlocks: [],
+		},
+	] ),
+};
+
+export default [ SIMPLE_CONTACT_FORM_01 ];

--- a/apps/dashboard/src/components/editor/styles/editor.js
+++ b/apps/dashboard/src/components/editor/styles/editor.js
@@ -23,9 +23,9 @@ export const editorGlobalStyles = css`
 `;
 
 export const EditorLayout = styled.div`
-	--wp-admin-theme-color: var( --color-neutral-80 );
-	--wp-admin-theme-color-darker-10: var( --color-neutral-90 );
-	--wp-admin-theme-color-darker-20: var( --color-neutral-100 );
+	--wp-admin-theme-color: var( --color-primary-50 );
+	--wp-admin-theme-color-darker-10: var( --color-primary-60 );
+	--wp-admin-theme-color-darker-20: var( --color-primary-70 );
 
 	flex: 1;
 	position: relative;

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -206,3 +206,7 @@ html {
 .crowdsignal-forms-ranking-question-block .block-list-appender {
 	display: none;
 }
+
+.edit-post-editor__inserter-panel-header {
+	display: none;
+}


### PR DESCRIPTION
## Summary

This PR includes the base changes to enable patterns on the Editor.
So far, there is only one basic contact form pattern.
More patterns will be added later.

_Known issue:_ The pattern preview on the 'Explore' window isn't working correctly. It will be handled next.

## Testing Instructions

* Create/edit a project
* Open the Block Library and check if the Patterns tab is available
* You should be able to click the available pattern to add the blocks to your project