### PR TITLE
Add @crowdisgnal/embed to build-release flow

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -7,6 +7,7 @@ TARGET_DIR="$PROJECT_DIR/dist"
 
 APPS=(
 	"dashboard"
+	"embed"
 	"project-renderer"
 )
 


### PR DESCRIPTION
This adds `@crowdsignal/embed` to our build release script.

# Testing

- Run `yarn build`.
- The `embed` target should be included inside the `dist` directory.