### PR TITLE
Update embed card to handle default viewport settings form the backend

### DIFF
--- a/apps/embed/src/card.js
+++ b/apps/embed/src/card.js
@@ -26,11 +26,14 @@ class CrowdsignalCard extends window.HTMLElement {
 			this.getAttribute( 'viewport-height', 10 )
 		);
 
+		const embedUrl = new window.URL( this.getAttribute( 'src' ) );
+		embedUrl.searchParams.append( 'iframe', 1 );
+
 		this.#wrapper = document.createElement( 'div' );
 		this.shadowRoot.appendChild( this.#wrapper );
 
 		this.#frame = document.createElement( 'iframe' );
-		this.#frame.src = this.getAttribute( 'src' );
+		this.#frame.src = embedUrl.toString();
 
 		this.#frame.setAttribute( 'frameBorder', '0' );
 		this.#frame.scrolling = 'no';

--- a/apps/project-renderer/src/index.js
+++ b/apps/project-renderer/src/index.js
@@ -46,5 +46,15 @@ window.addEventListener( 'load', () => {
 		);
 	}
 
+	if ( !! window.embedCardSettings ) {
+		window.parent.postMessage(
+			{
+				type: 'crowdsignal-forms-project-embed-card',
+				embedCardSettings: window.embedCardSettings,
+			},
+			'*'
+		);
+	}
+
 	renderProject();
 } );


### PR DESCRIPTION
This patch adds the capability for our embed card to read fallback viewport settings provided by the backend (see D84264-code) if none are explicitly set.  
Note that manually settings `viewport-width` or `viewport-height` will override these fallbacks as expected.

Also, if no viewport attributes are given and if no fallback values have been set in the editor, it will use hardcoded defaults: `width: 1000` and `height: 600`, which seems like a reasonable starting point. Likely to be fine tuned.

# Testing

Because of our app architecture, it's quite difficult to test this. I found the easiest way to do it was manually by creating a `*.html` file in our repository root and adding this snippet to it:

```html
<crowdsignal-card src="https://crowdsignal.localhost:9001/9A0AA5EACBF3BDFD" viewport-width="600" viewport-height="600"></crowdsignal-card>
<script type="text/javascript" src="apps/embed/dist/main.js" async></script>
```

- Run `NODE_ENV=production yarn workspace @crowdsignal/embed build` to build the embed.
- Run `yarn start`.
- Open the html file you created in a browser, you should see the project from the link and if you inspect it the wrapper will be `600px` by `600px` as given by `viewport-width` and `viewport-height`. (It can also be smaller depending on your browser window size, but should remain at a square aspect ratio and scale rather than be responsive).
- Delete `viewport-width` and `viewport-height` attributes from `<crowdsignal-card>` and refresh the page.
- The embed card should now be using the hardcoded defaults of `1000px` by `600px`.
- Finally, add the following snippet at the top of `apps/project-renderer/src/index.js` and refresh the page:
```
window.embedCardSettings = {
	viewport: {
		width: 800,
		height: 400,
	},
};
```
- The embed card should now be using settings from that object, that is `800px` by `400px`.
- Leave the snippet in and re-assign `viewport-width` and `viewport-height`. They should still override the values from `window.embedCardSettings`.