### PR TITLE
Update Text Input Form block to support multiline

### DIFF
--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -9,12 +9,18 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { FormInputWrapper, FormTextInput } from '@crowdsignal/blocks';
+import {
+	FormInputWrapper,
+	FormTextarea,
+	FormTextInput,
+} from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
 import { useClientId } from '@crowdsignal/hooks';
 
 const EditTextInput = ( props ) => {
+	const MULTILINE_THRESHOLD = 70;
+
 	const { attributes, setAttributes, className, isSelected } = props;
 
 	useClientId( props );
@@ -66,12 +72,29 @@ const EditTextInput = ( props ) => {
 					height: `${ attributes.inputHeight }px`,
 				} }
 			>
-				<FormTextInput
-					placeholder={ __( 'Enter placeholder', 'block-editor' ) }
-					value={ attributes.placeholder }
-					onChange={ handleChangePlaceholder }
-					className="crowdsignal-forms-text-input-block__wrapper"
-				/>
+				{ attributes.inputHeight < MULTILINE_THRESHOLD ? (
+					<FormTextInput
+						placeholder={ __(
+							'Enter placeholder',
+							'block-editor'
+						) }
+						value={ attributes.placeholder }
+						onChange={ handleChangePlaceholder }
+						className="crowdsignal-forms-text-input-block__wrapper"
+					/>
+				) : (
+					<FormTextarea
+						placeholder={ __(
+							'Enter placeholder',
+							'block-editor'
+						) }
+						value={ attributes.placeholder }
+						onChange={ handleChangePlaceholder }
+						style={ {
+							height: '100%',
+						} }
+					/>
+				) }
 			</ResizableBox>
 		</FormInputWrapper>
 	);

--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -13,14 +13,13 @@ import {
 	FormInputWrapper,
 	FormTextarea,
 	FormTextInput,
+	TextInput,
 } from '@crowdsignal/blocks';
 import { useColorStyles } from '@crowdsignal/styles';
 import Sidebar from './sidebar';
 import { useClientId } from '@crowdsignal/hooks';
 
 const EditTextInput = ( props ) => {
-	const MULTILINE_THRESHOLD = 70;
-
 	const { attributes, setAttributes, className, isSelected } = props;
 
 	useClientId( props );
@@ -72,7 +71,7 @@ const EditTextInput = ( props ) => {
 					height: `${ attributes.inputHeight }px`,
 				} }
 			>
-				{ attributes.inputHeight < MULTILINE_THRESHOLD ? (
+				{ attributes.inputHeight < TextInput.MULTILINE_THRESHOLD ? (
 					<FormTextInput
 						placeholder={ __(
 							'Enter placeholder',
@@ -93,6 +92,7 @@ const EditTextInput = ( props ) => {
 						style={ {
 							height: '100%',
 						} }
+						className="crowdsignal-forms-text-input-block__wrapper"
 					/>
 				) }
 			</ResizableBox>

--- a/packages/blocks/src/components/form-textarea/index.js
+++ b/packages/blocks/src/components/form-textarea/index.js
@@ -17,8 +17,8 @@ const FormTextarePreviewWrapper = styled.div`
 `;
 
 const Textarea = styled.textarea`
-	border-style: solid;
-	border-width: 1px;
+	//border-style: solid;
+	//border-width: 1px;
 	box-sizing: border-box;
 	width: 100%;
 	padding: 8px;

--- a/packages/blocks/src/components/form-textarea/index.js
+++ b/packages/blocks/src/components/form-textarea/index.js
@@ -17,8 +17,6 @@ const FormTextarePreviewWrapper = styled.div`
 `;
 
 const Textarea = styled.textarea`
-	//border-style: solid;
-	//border-width: 1px;
 	box-sizing: border-box;
 	width: 100%;
 	padding: 8px;

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -10,11 +10,18 @@ import { isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { useColorStyles } from '@crowdsignal/styles';
-import { ErrorMessage, FormInputWrapper, FormTextInput } from '../components';
+import {
+	ErrorMessage,
+	FormInputWrapper,
+	FormTextarea,
+	FormTextInput,
+} from '../components';
 import { useField } from '@crowdsignal/form';
 import validator from './validations';
 
 const TextInput = ( { attributes, className } ) => {
+	const MULTILINE_THRESHOLD = 70;
+
 	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
@@ -48,15 +55,26 @@ const TextInput = ( { attributes, className } ) => {
 			<FormInputWrapper.Label className="crowdsignal-forms-text-input-block__label">
 				<RawHTML>{ attributes.label }</RawHTML>
 			</FormInputWrapper.Label>
-			<FormTextInput
-				onChange={ onChange }
-				placeholder={ attributes.placeholder }
-				style={ {
-					width: attributes.inputWidth,
-					height: `${ attributes.inputHeight }px`,
-				} }
-				value={ fieldValue }
-			/>
+			{ attributes.inputHeight < MULTILINE_THRESHOLD ? (
+				<FormTextInput
+					onChange={ onChange }
+					placeholder={ attributes.placeholder }
+					style={ {
+						width: attributes.inputWidth,
+						height: `${ attributes.inputHeight }px`,
+					} }
+					value={ fieldValue }
+				/>
+			) : (
+				<FormTextarea
+					onChange={ onChange }
+					placeholder={ attributes.placeholder }
+					style={ {
+						height: `${ attributes.inputHeight }px`,
+					} }
+					value={ fieldValue }
+				/>
+			) }
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>
 	);

--- a/packages/blocks/src/text-input/index.js
+++ b/packages/blocks/src/text-input/index.js
@@ -19,9 +19,9 @@ import {
 import { useField } from '@crowdsignal/form';
 import validator from './validations';
 
-const TextInput = ( { attributes, className } ) => {
-	const MULTILINE_THRESHOLD = 70;
+const MULTILINE_THRESHOLD = 70;
 
+const TextInput = ( { attributes, className } ) => {
 	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }[text]`,
 		validation: ( value ) => {
@@ -81,5 +81,6 @@ const TextInput = ( { attributes, className } ) => {
 };
 
 TextInput.blockName = 'crowdsignal-forms/text-input';
+TextInput.MULTILINE_THRESHOLD = MULTILINE_THRESHOLD;
 
 export default TextInput;

--- a/packages/theme-compatibility/src/leven/base.scss
+++ b/packages/theme-compatibility/src/leven/base.scss
@@ -46,9 +46,11 @@ body {
 	background-color: var(--crowdsignal-forms-submit-button-background-color);
 }
 
-.crowdsignal-forms-text-input-block input,
-.crowdsignal-forms-text-question-block textarea {
-	border: 1px solid var(--crowdsignal-forms-input-border-color);
+.crowdsignal-forms-text-input-block,
+.crowdsignal-forms-text-question-block {
+	input, textarea {
+		border: 1px solid var(--crowdsignal-forms-input-border-color);
+	}
 }
 
 .wp-block-image {

--- a/packages/theme-compatibility/src/p2/base.scss
+++ b/packages/theme-compatibility/src/p2/base.scss
@@ -23,11 +23,13 @@ input, textarea {
 	font-family: inherit;
 }
 
-.crowdsignal-forms-text-input-block input,
-.crowdsignal-forms-text-question-block textarea {
-	border: 1px solid var(--p2-color-border);
-	padding: 12px 8px;
-	border-radius: 2px;
+.crowdsignal-forms-text-input-block,
+.crowdsignal-forms-text-question-block {
+	input, textarea {
+		border: 1px solid var(--p2-color-border);
+		padding: 12px 8px;
+		border-radius: 2px;
+	}
 }
 
 .crowdsignal-forms-question-wrapper {

--- a/packages/theme-compatibility/src/twentynineteen/base.scss
+++ b/packages/theme-compatibility/src/twentynineteen/base.scss
@@ -23,7 +23,7 @@ body {
 	}
 }
 
-input {
+input, textarea {
 	border: 1px solid #CCC;
 }
 


### PR DESCRIPTION
## Summary

This PR adds a feature to turn the Text Input Form into a multiline text input if the input height is higher than 70px.

## Testing Instructions
* Open or create a project and add a Text Input Form block
* Increase the input height to a value higher than 70px
* The input now should be a textarea
* Check the Renderer to confirm if it's working as expected