### PR TITLE
Fix input placeholders

### DIFF
--- a/packages/block-editor/src/text-input/edit.js
+++ b/packages/block-editor/src/text-input/edit.js
@@ -21,8 +21,8 @@ const EditTextInput = ( props ) => {
 
 	const handleChangeLabel = ( label ) => setAttributes( { label } );
 
-	const handleChangePlaceholder = ( event ) =>
-		setAttributes( { placeholder: event.target.value } );
+	const handleChangePlaceholder = ( placeholder ) =>
+		setAttributes( { placeholder } );
 
 	const handleResizeInput = ( event, handle, element ) => {
 		if ( handle !== 'bottom' && handle !== 'right' ) {

--- a/packages/block-editor/src/text-question/edit.js
+++ b/packages/block-editor/src/text-question/edit.js
@@ -25,8 +25,8 @@ const EditTextQuestion = ( props ) => {
 
 	const handleChangeQuestion = ( question ) => setAttributes( { question } );
 
-	const handleChangePlaceholder = ( event ) =>
-		setAttributes( { placeholder: event.target.value } );
+	const handleChangePlaceholder = ( placeholder ) =>
+		setAttributes( { placeholder } );
 
 	const handleResizeInput = ( event, handle, element ) => {
 		if ( handle !== 'bottom' ) {


### PR DESCRIPTION
This patch fixes an issue accidentally introduced in #274, which led to placeholder values for the text question block and text input block no longer being editable as the input change handlers now receive the input value directly instead of an event.

# Testing

- Create a project with a text question and a text input block.
- Make sure the placeholder for the inputs is editable.