### PR TITLE
Append ?iframe=1 to iframe embed URLs

### DIFF
--- a/apps/embed/src/embed.js
+++ b/apps/embed/src/embed.js
@@ -15,7 +15,11 @@ class CrowdsignalEmbed extends window.HTMLElement {
 
 	connectedCallback() {
 		this.#frame = document.createElement( 'iframe' );
-		this.#frame.src = this.getAttribute( 'src' );
+
+		const embedUrl = new window.URL( this.getAttribute( 'src' ) );
+		embedUrl.searchParams.append( 'iframe', 1 );
+
+		this.#frame.src = embedUrl.toString();
 
 		this.#frame.setAttribute( 'frameBorder', '0' );
 


### PR DESCRIPTION
This patch adds an `?iframe=1` query param to all iframe embed URLs, to prevent the cookie banner from appearing which isn't necessary inside embeds.

# Testing

- Run `yarn start` and `yarn storybook`
- Inside storybook, validate that both card and iframe embeds have a `?iframe=1` param appended to the urls in the iframe's `src` attribute.
- There should be no cookie banners inside the embeds.