### PR TITLE
Fine tune crowdsignal's embed components

### DIFF
--- a/apps/embed/src/card.js
+++ b/apps/embed/src/card.js
@@ -12,12 +12,6 @@ class CrowdsignalCard extends window.HTMLElement {
 	 */
 	#frame;
 
-	constructor() {
-		super();
-
-		this.attachShadow( { mode: 'open' } );
-	}
-
 	connectedCallback() {
 		const viewportWidth = parseInt(
 			this.getAttribute( 'viewport-width', 10 )
@@ -30,7 +24,7 @@ class CrowdsignalCard extends window.HTMLElement {
 		embedUrl.searchParams.append( 'iframe', 1 );
 
 		this.#wrapper = document.createElement( 'div' );
-		this.shadowRoot.appendChild( this.#wrapper );
+		this.appendChild( this.#wrapper );
 
 		this.#frame = document.createElement( 'iframe' );
 		this.#frame.src = embedUrl.toString();

--- a/apps/embed/src/embed.js
+++ b/apps/embed/src/embed.js
@@ -7,12 +7,6 @@ class CrowdsignalEmbed extends window.HTMLElement {
 	 */
 	#frame;
 
-	constructor() {
-		super();
-
-		this.attachShadow( { mode: 'open' } );
-	}
-
 	connectedCallback() {
 		this.#frame = document.createElement( 'iframe' );
 		this.#frame.src = this.getAttribute( 'src' );
@@ -22,7 +16,7 @@ class CrowdsignalEmbed extends window.HTMLElement {
 		this.#frame.width = '100%';
 		this.#frame.scrolling = 'no';
 
-		this.shadowRoot.appendChild( this.#frame );
+		this.appendChild( this.#frame );
 
 		window.addEventListener( 'message', ( event ) => {
 			if ( this.getAttribute( 'src' ).indexOf( event.origin ) !== 0 ) {

--- a/apps/embed/src/index.js
+++ b/apps/embed/src/index.js
@@ -4,5 +4,10 @@
 import CrowdsignalCard from './card';
 import CrowdsignalEmbed from './embed';
 
-window.customElements.define( 'crowdsignal-card', CrowdsignalCard );
-window.customElements.define( 'crowdsignal-embed', CrowdsignalEmbed );
+if ( window.customElements.get( 'crowdsignal-card' ) === undefined ) {
+	window.customElements.define( 'crowdsignal-card', CrowdsignalCard );
+}
+
+if ( window.customElements.get( 'crowdsignal-embed' ) === undefined ) {
+	window.customElements.define( 'crowdsignal-embed', CrowdsignalEmbed );
+}


### PR DESCRIPTION
When adding our updated oembed provider to WordPress, I discovered a few issues with our current components:

- Use of shadowRoot inside our components prevents the rendering document from seeing any changes inside the component itself. Normally this isn't an issue, but since Gutenberg renders embed previews in an iframe and is using a similar trick to us, it's preventing the preview from resizing correctly. As we're using iframes anyway, there really isn't any worthwile advantage to 'encapsulating them even more' with shadowRoot.
- If multiple embeds are added on a page through oembed, the script will also be loaded multiple times, and it will try to define our custom elements each time resulting in warnings.

This patch fixes these issues.

# Testing

- You can use `yarn start` in combination with `yarn storybook` to verify that our embeds are no longer rendered inside shadowRoot in developer tools.
- Create a separate html document and try adding our embed script to it multiple times. There shouldn't be any warnings about the same element being defined again.