### PR TITLE
Adjust Share Modal styles

### DIFF
--- a/apps/dashboard/src/components/share-modal/index.js
+++ b/apps/dashboard/src/components/share-modal/index.js
@@ -22,6 +22,9 @@ import { ShareEmbedCard } from './share-embed/share-embed-card';
 
 const ShareModalDialog = styled( ModalDialog )`
 	max-width: 1350px;
+	height: 95%;
+	max-height: 800px;
+	min-height: 550px;
 `;
 
 const SharedModalFooterNote = styled.div`
@@ -31,7 +34,8 @@ const SharedModalFooterNote = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	padding: 160px 0;
+	justify-content: center;
+	flex-grow: 1;
 `;
 
 const ShareModal = ( { project, onClose } ) => {

--- a/apps/dashboard/src/components/share-modal/share-card/share-card.js
+++ b/apps/dashboard/src/components/share-modal/share-card/share-card.js
@@ -23,6 +23,7 @@ export const ShareCardBody = styled.div`
 	align-items: flex-start;
 	gap: 32px;
 	margin-bottom: 32px;
+	flex-grow: 1;
 
 	> * {
 		flex: 1;
@@ -63,6 +64,7 @@ export const SharedCardLink = styled.span`
 	overflow: hidden;
 	text-overflow: ellipsis;
 	flex-grow: 1;
+	white-space: nowrap;
 `;
 
 export const ShareCardButton = styled.button`


### PR DESCRIPTION
## Summary

This PR fixes an issue that makes the Share Modal's contents hidden on smaller screen sizes.

Ref: Automattic/crowdsignal#436

## Testing Instructions

* Open/create a project
* Publish it and click the Share button
* Reduce the screen height
* The cards content should remain visible even on smaller screens