### PR TITLE
Prevent external styles form affecting embed components

### DIFF
--- a/apps/embed/src/card.js
+++ b/apps/embed/src/card.js
@@ -12,6 +12,12 @@ class CrowdsignalCard extends window.HTMLElement {
 	 */
 	#frame;
 
+	constructor() {
+		super();
+
+		this.attachShadow( { mode: 'open' } );
+	}
+
 	connectedCallback() {
 		const viewportWidth = parseInt(
 			this.getAttribute( 'viewport-width', 10 )
@@ -24,7 +30,7 @@ class CrowdsignalCard extends window.HTMLElement {
 		embedUrl.searchParams.append( 'iframe', 1 );
 
 		this.#wrapper = document.createElement( 'div' );
-		this.appendChild( this.#wrapper );
+		this.shadowRoot.appendChild( this.#wrapper );
 
 		this.#frame = document.createElement( 'iframe' );
 		this.#frame.src = embedUrl.toString();
@@ -76,6 +82,9 @@ class CrowdsignalCard extends window.HTMLElement {
 		this.#frame.style.height = `${ viewportHeight }px`;
 		this.#frame.style.transform = `scale(${ scale })`;
 		this.#frame.style.transformOrigin = 'top left';
+
+		this.setAttribute( 'width', this.#frame.style.width );
+		this.setAttribute( 'height', this.#frame.style.height );
 	}
 }
 

--- a/apps/embed/src/embed.js
+++ b/apps/embed/src/embed.js
@@ -7,6 +7,12 @@ class CrowdsignalEmbed extends window.HTMLElement {
 	 */
 	#frame;
 
+	constructor() {
+		super();
+
+		this.attachShadow( { mode: 'open' } );
+	}
+
 	connectedCallback() {
 		this.#frame = document.createElement( 'iframe' );
 
@@ -20,7 +26,7 @@ class CrowdsignalEmbed extends window.HTMLElement {
 		this.#frame.width = '100%';
 		this.#frame.scrolling = 'no';
 
-		this.appendChild( this.#frame );
+		this.shadowRoot.appendChild( this.#frame );
 
 		window.addEventListener( 'message', ( event ) => {
 			if ( this.getAttribute( 'src' ).indexOf( event.origin ) !== 0 ) {
@@ -29,6 +35,7 @@ class CrowdsignalEmbed extends window.HTMLElement {
 
 			if ( event.data.type === 'crowdsignal-forms-project-page-loaded' ) {
 				this.#frame.height = `${ event.data.pageHeight }px`;
+				this.setAttribute( 'height', this.#frame.height );
 			}
 		} );
 	}

--- a/apps/embed/test.html
+++ b/apps/embed/test.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>
-<crowdsignal-embed src="https://automattic.crowdsignal.net/crowdsignal-test-embed-project" />
-<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>
-</body>
-</html>


### PR DESCRIPTION
This patch resolves some of the issues noticed by @digitalwaveride  when using our embeds on WordPress' P2 theme.  
While the issues come from the theme itself and affect all embeds, there are still a few things we can do:

In #291, I removed the use of `shadowRoot` from our web components however it seems the P2 theme (and presumably other themes/websites out there) contains CSS styles which target the `iframe` inside our web component directly messing up the layout.

To fix this, I reintroduced `shadowRoot` and added explicit `height` and `width` attributes on the web component itself, so these can be tracked/picked up by a script correctly if our embed is rendered within another iframe - like it is in the Gutenberg editor.

# Testing

- Run `NODE_ENV=production yarn workspace @crowdsignal/embed build`.
- Replace `app.crowdsignal.com/ui/stable/embed/main.js` with the newly built `apps/embed/dist/main.js`.
- Create a new post on a WP.com site with the P2 theme enabled.
- Paste a link for both a regular and a card embed (append `?type=card` for a card embed)
- Publish/preview the post and ensure the embeds are sized correctly.