### PR TITLE
Fix Page Navigation dropdown

### DIFF
--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -124,5 +124,9 @@ export const PagePreviewMoreMenu = styled.div`
 		.components-button {
 			width: 100%;
 		}
+
+		.components-menu-item__button {
+			width: 120px;
+		}
 	}
 `;

--- a/apps/dashboard/src/components/editor/styles/page-preview.js
+++ b/apps/dashboard/src/components/editor/styles/page-preview.js
@@ -103,7 +103,7 @@ export const PagePreviewMoreMenu = styled.div`
 	width: 36px;
 
 	&& {
-		display: none;
+		//display: none;
 	}
 
 	${ PagePreviewWrapper }:hover && {
@@ -127,6 +127,10 @@ export const PagePreviewMoreMenu = styled.div`
 
 		.components-menu-item__button {
 			width: 120px;
+		}
+
+		.components-menu-item__item {
+			min-width: unset;
 		}
 	}
 `;


### PR DESCRIPTION
## Summary

This PR adds a fixed width to the Page Navigation dropdown menu to prevent it from being cut.
Tried playing with the positioning props, but it didn't work as expected.

Fixes Automattic/crowdsignal#432

## Testing Instructions

* Open or create a project
* Hover the mouse over a page preview and click the three dots button
* The Dropdown menu should appear, and the text shouldn't be cut