### PR TITLE
Update Share Modal embed buttons

### DIFF
--- a/apps/dashboard/src/components/share-modal/share-card/share-card-button.js
+++ b/apps/dashboard/src/components/share-modal/share-card/share-card-button.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import classnames from 'classnames';
+import styled from '@emotion/styled';
+
+/**
+ * Internal dependencies
+ */
+import { CheckIcon } from '@crowdsignal/icons';
+
+const StyledShareCardButton = styled.button`
+	min-height: 36px;
+	font-size: 13px;
+	font-weight: 400;
+	line-height: normal;
+	color: var( --wp-admin-theme-color );
+	border: 1px solid currentColor;
+	border-radius: 2px;
+	background-color: transparent;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+
+	&.is-link-copied {
+		border: none;
+		outline: none;
+		cursor: default;
+		pointer-events: none;
+	}
+
+	svg {
+		width: 16px;
+
+		path {
+			stroke: currentColor;
+		}
+	}
+`;
+
+export const ShareCardButton = ( {
+	contentCopiedText,
+	defaultText,
+	shareContent,
+} ) => {
+	const [ linkCopied, setLinkCopied ] = useState( false );
+
+	const handleCopyShareContent = () => {
+		window.navigator.clipboard.writeText( shareContent ).then(
+			() => {
+				setLinkCopied( true );
+				setTimeout( () => setLinkCopied( false ), 3000 );
+			},
+			( err ) => {
+				// eslint-disable-next-line
+				window.alert( 'The content could not be copied to clipboard' );
+				// eslint-disable-next-line
+				console.error( err );
+			}
+		);
+
+		return false;
+	};
+
+	const classes = classnames( {
+		'is-link-copied': linkCopied,
+	} );
+
+	return (
+		<StyledShareCardButton
+			onClick={ handleCopyShareContent }
+			className={ classes }
+		>
+			{ ! linkCopied && defaultText }
+			{ linkCopied && (
+				<>
+					<CheckIcon />
+					<span>{ contentCopiedText }</span>
+				</>
+			) }
+		</StyledShareCardButton>
+	);
+};

--- a/apps/dashboard/src/components/share-modal/share-card/share-card.js
+++ b/apps/dashboard/src/components/share-modal/share-card/share-card.js
@@ -9,13 +9,28 @@ export const ShareCard = styled.div`
 	flex-direction: column;
 	padding: 16px;
 	border: 1px solid var( --color-border );
+
+	a {
+		color: var( --wp-admin-theme-color );
+		text-decoration: underline;
+		text-underline-offset: initial;
+	}
 `;
 
 export const ShareCardHeader = styled.h1`
+	position: relative;
 	font-size: 16px;
 	font-weight: 700;
 	margin-top: 0;
 	margin-bottom: 12px;
+
+	a {
+		position: absolute;
+		right: 0;
+		font-size: 11px;
+		text-decoration: none;
+		font-weight: normal;
+	}
 `;
 
 export const ShareCardBody = styled.div`
@@ -43,12 +58,6 @@ export const ShareCardContentText = styled.p`
 
 	&&& {
 		font-size: 12px;
-	}
-
-	a {
-		color: var( --color-primary-50 );
-		text-decoration: underline;
-		text-underline-offset: initial;
 	}
 `;
 

--- a/apps/dashboard/src/components/share-modal/share-card/share-card.js
+++ b/apps/dashboard/src/components/share-modal/share-card/share-card.js
@@ -55,7 +55,7 @@ export const ShareCardContentText = styled.p`
 export const ShareCardFooter = styled.div`
 	display: flex;
 	align-items: center;
-	gap: 32px;
+	gap: 16px;
 `;
 
 export const SharedCardLink = styled.span`
@@ -65,30 +65,4 @@ export const SharedCardLink = styled.span`
 	text-overflow: ellipsis;
 	flex-grow: 1;
 	white-space: nowrap;
-`;
-
-export const ShareCardButton = styled.button`
-	min-height: 36px;
-	font-size: 13px;
-	font-weight: 400;
-	line-height: normal;
-	color: var( --color-secondary-40 );
-	border: 1px solid currentColor;
-	border-radius: 2px;
-	background-color: transparent;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	flex-shrink: 0;
-
-	&.is-link-copied {
-		border: none;
-		outline: none;
-		cursor: default;
-		pointer-events: none;
-	}
-
-	svg {
-		width: 16px;
-	}
 `;

--- a/apps/dashboard/src/components/share-modal/share-embed/share-embed-card.js
+++ b/apps/dashboard/src/components/share-modal/share-embed/share-embed-card.js
@@ -17,23 +17,41 @@ import {
 } from '../share-card/share-card';
 import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareEmbedCardPreview } from './share-embed-card-preview';
+import { createInterpolateElement } from '@wordpress/element';
 
 const getEmbedCodeSnippet = ( projectUrl ) =>
 	'<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>\n' +
 	`<crowdsignal-card src="${ projectUrl }"></crowdsignal-card>`;
+
+const docsURL =
+	'https://crowdsignal.com/support/embed-your-survey-or-form-via-an-embed-iframe-or-an-embed-card/?embed-iframe#h2-embed-card';
 
 export const ShareEmbedCard = ( { link } ) => {
 	return (
 		<ShareCard>
 			<ShareCardHeader>
 				{ __( 'Embed Card', 'dashboard' ) }
+				<a href={ docsURL } target="_blank" rel="noreferrer">
+					{ __( 'Lean More', 'dashboard' ) }
+				</a>
 			</ShareCardHeader>
 			<ShareCardBody>
 				<ShareCardContent>
 					<ShareCardContentText>
-						{ __(
-							'Embed your form or survey onto your website using a card with a fixed format.',
-							'dashboard'
+						{ createInterpolateElement(
+							__(
+								'Embed your form or survey into your <a>WordPress site</a> or any <a>other website</a> via a card with a fixed format.',
+								'dashboard'
+							),
+							{
+								a: (
+									<a
+										href={ docsURL }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
 						) }
 					</ShareCardContentText>
 				</ShareCardContent>
@@ -42,11 +60,8 @@ export const ShareEmbedCard = ( { link } ) => {
 			<ShareCardFooter>
 				<SharedCardLink />
 				<ShareCardButton
-					contentCopiedText={ __(
-						'Embed link copied!',
-						'dashboard'
-					) }
-					defaultText={ __( 'Copy Embed Link', 'dashboard' ) }
+					contentCopiedText={ __( 'Link copied!', 'dashboard' ) }
+					defaultText={ __( 'Copy WordPress Link', 'dashboard' ) }
 					shareContent={ `${ link }?type=card` }
 				/>
 				<ShareCardButton
@@ -54,7 +69,7 @@ export const ShareEmbedCard = ( { link } ) => {
 						'Code snippet copied!',
 						'dashboard'
 					) }
-					defaultText={ __( 'Copy Javascript Code', 'dashboard' ) }
+					defaultText={ __( 'Copy JS Code Snippet', 'dashboard' ) }
 					shareContent={ getEmbedCodeSnippet( link ) }
 				/>
 			</ShareCardFooter>

--- a/apps/dashboard/src/components/share-modal/share-embed/share-embed-card.js
+++ b/apps/dashboard/src/components/share-modal/share-embed/share-embed-card.js
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import {
 	ShareCard,
-	ShareCardButton,
 	ShareCardBody,
 	ShareCardContentText,
 	ShareCardFooter,
@@ -18,47 +15,14 @@ import {
 	SharedCardLink,
 	ShareCardContent,
 } from '../share-card/share-card';
+import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareEmbedCardPreview } from './share-embed-card-preview';
-import { CheckIcon } from '@crowdsignal/icons';
 
 const getEmbedCodeSnippet = ( projectUrl ) =>
 	'<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>\n' +
 	`<crowdsignal-card src="${ projectUrl }"></crowdsignal-card>`;
 
 export const ShareEmbedCard = ( { link } ) => {
-	const [ linkCopied, setLinkCopied ] = useState( false );
-
-	const classes = classnames( {
-		'is-link-copied': linkCopied,
-	} );
-
-	const handleCopyShareLink = () => {
-		if ( link ) {
-			window.navigator.clipboard
-				.writeText( getEmbedCodeSnippet( link ) )
-				.then(
-					() => {
-						setLinkCopied( true );
-						setTimeout( () => setLinkCopied( false ), 3000 );
-					},
-					( err ) => {
-						// eslint-disable-next-line
-						window.alert(
-							'The embed code snippet could not be copied to clipboard'
-						);
-						// eslint-disable-next-line
-						console.error( err );
-					}
-				);
-		} else {
-			// eslint-disable-next-line
-			window.alert(
-				'The embed code snippet is only available for published projects'
-			);
-		}
-		return false;
-	};
-
 	return (
 		<ShareCard>
 			<ShareCardHeader>
@@ -78,19 +42,21 @@ export const ShareEmbedCard = ( { link } ) => {
 			<ShareCardFooter>
 				<SharedCardLink />
 				<ShareCardButton
-					onClick={ handleCopyShareLink }
-					className={ classes }
-				>
-					{ ! linkCopied && __( 'Copy code snippet', 'dashboard' ) }
-					{ linkCopied && (
-						<>
-							<CheckIcon />
-							<span>
-								{ __( 'Code snippet copied!', 'dashboard' ) }
-							</span>
-						</>
+					contentCopiedText={ __(
+						'Embed link copied!',
+						'dashboard'
 					) }
-				</ShareCardButton>
+					defaultText={ __( 'Copy Embed Link', 'dashboard' ) }
+					shareContent={ `${ link }?type=card` }
+				/>
+				<ShareCardButton
+					contentCopiedText={ __(
+						'Code snippet copied!',
+						'dashboard'
+					) }
+					defaultText={ __( 'Copy Javascript Code', 'dashboard' ) }
+					shareContent={ getEmbedCodeSnippet( link ) }
+				/>
 			</ShareCardFooter>
 		</ShareCard>
 	);

--- a/apps/dashboard/src/components/share-modal/share-embed/share-embed.js
+++ b/apps/dashboard/src/components/share-modal/share-embed/share-embed.js
@@ -17,23 +17,41 @@ import {
 } from '../share-card/share-card';
 import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareEmbedPreview } from './share-embed-preview';
+import { createInterpolateElement } from '@wordpress/element';
 
 const getEmbedCodeSnippet = ( projectUrl ) =>
 	'<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>\n' +
 	`<crowdsignal-embed src="${ projectUrl }"></crowdsignal-embed>`;
+
+const docsURL =
+	'https://crowdsignal.com/support/embed-your-survey-or-form-via-an-embed-iframe-or-an-embed-card/?embed-iframe#h2-embed-iframe';
 
 export const ShareEmbed = ( { link } ) => {
 	return (
 		<ShareCard>
 			<ShareCardHeader>
 				{ __( 'Embed iFrame', 'dashboard' ) }
+				<a href={ docsURL } target="_blank" rel="noreferrer">
+					{ __( 'Lean More', 'dashboard' ) }
+				</a>
 			</ShareCardHeader>
 			<ShareCardBody>
 				<ShareCardContent>
 					<ShareCardContentText>
-						{ __(
-							'Embed your form via a responsive iFrame. Your form will expand and responsively adjust to the available space on your page.',
-							'dashboard'
+						{ createInterpolateElement(
+							__(
+								'Embed your form or survey into your <a>WordPress site</a> or any <a>other website</a> via responsive iFrame.',
+								'dashboard'
+							),
+							{
+								a: (
+									<a
+										href={ docsURL }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
 						) }
 					</ShareCardContentText>
 				</ShareCardContent>
@@ -42,15 +60,12 @@ export const ShareEmbed = ( { link } ) => {
 			<ShareCardFooter>
 				<SharedCardLink />
 				<ShareCardButton
-					defaultText={ __( 'Copy embed link', 'dashboard' ) }
-					contentCopiedText={ __(
-						'Embed link copied!',
-						'dashboard'
-					) }
+					defaultText={ __( 'Copy WordPress Link', 'dashboard' ) }
+					contentCopiedText={ __( 'Link copied!', 'dashboard' ) }
 					shareContent={ link }
 				/>
 				<ShareCardButton
-					defaultText={ __( 'Copy Javascript Code', 'dashboard' ) }
+					defaultText={ __( 'Copy JS Code Snippet', 'dashboard' ) }
 					contentCopiedText={ __(
 						'Code snippet copied!',
 						'dashboard'

--- a/apps/dashboard/src/components/share-modal/share-embed/share-embed.js
+++ b/apps/dashboard/src/components/share-modal/share-embed/share-embed.js
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import {
 	ShareCard,
-	ShareCardButton,
 	ShareCardBody,
 	ShareCardContentText,
 	ShareCardFooter,
@@ -18,47 +15,14 @@ import {
 	SharedCardLink,
 	ShareCardContent,
 } from '../share-card/share-card';
+import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareEmbedPreview } from './share-embed-preview';
-import { CheckIcon } from '@crowdsignal/icons';
 
 const getEmbedCodeSnippet = ( projectUrl ) =>
 	'<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>\n' +
 	`<crowdsignal-embed src="${ projectUrl }"></crowdsignal-embed>`;
 
 export const ShareEmbed = ( { link } ) => {
-	const [ linkCopied, setLinkCopied ] = useState( false );
-
-	const classes = classnames( {
-		'is-link-copied': linkCopied,
-	} );
-
-	const handleCopyShareLink = () => {
-		if ( link ) {
-			window.navigator.clipboard
-				.writeText( getEmbedCodeSnippet( link ) )
-				.then(
-					() => {
-						setLinkCopied( true );
-						setTimeout( () => setLinkCopied( false ), 3000 );
-					},
-					( err ) => {
-						// eslint-disable-next-line
-						window.alert(
-							'The embed code snippet could not be copied to clipboard'
-						);
-						// eslint-disable-next-line
-						console.error( err );
-					}
-				);
-		} else {
-			// eslint-disable-next-line
-			window.alert(
-				'The embed code snippet is only available for published projects'
-			);
-		}
-		return false;
-	};
-
 	return (
 		<ShareCard>
 			<ShareCardHeader>
@@ -78,19 +42,21 @@ export const ShareEmbed = ( { link } ) => {
 			<ShareCardFooter>
 				<SharedCardLink />
 				<ShareCardButton
-					onClick={ handleCopyShareLink }
-					className={ classes }
-				>
-					{ ! linkCopied && __( 'Copy code snippet', 'dashboard' ) }
-					{ linkCopied && (
-						<>
-							<CheckIcon />
-							<span>
-								{ __( 'Code snippet copied!', 'dashboard' ) }
-							</span>
-						</>
+					defaultText={ __( 'Copy embed link', 'dashboard' ) }
+					contentCopiedText={ __(
+						'Embed link copied!',
+						'dashboard'
 					) }
-				</ShareCardButton>
+					shareContent={ link }
+				/>
+				<ShareCardButton
+					defaultText={ __( 'Copy Javascript Code', 'dashboard' ) }
+					contentCopiedText={ __(
+						'Code snippet copied!',
+						'dashboard'
+					) }
+					shareContent={ getEmbedCodeSnippet( link ) }
+				/>
 			</ShareCardFooter>
 		</ShareCard>
 	);

--- a/apps/dashboard/src/components/share-modal/share-link/share-link.js
+++ b/apps/dashboard/src/components/share-modal/share-link/share-link.js
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import {
 	ShareCard,
-	ShareCardButton,
 	ShareCardBody,
 	ShareCardContentText,
 	ShareCardFooter,
@@ -18,41 +15,10 @@ import {
 	SharedCardLink,
 	ShareCardContent,
 } from '../share-card/share-card';
+import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareLinkPreview } from './share-link-preview';
-import { CheckIcon } from '@crowdsignal/icons';
 
 export const ShareLink = ( { link } ) => {
-	const [ linkCopied, setLinkCopied ] = useState( false );
-
-	const classes = classnames( {
-		'is-link-copied': linkCopied,
-	} );
-
-	const handleCopyShareLink = () => {
-		if ( link ) {
-			window.navigator.clipboard.writeText( link ).then(
-				() => {
-					setLinkCopied( true );
-					setTimeout( () => setLinkCopied( false ), 3000 );
-				},
-				( err ) => {
-					// eslint-disable-next-line
-					window.alert(
-						'Share URL could not be copied to clipboard'
-					);
-					// eslint-disable-next-line
-					console.error( err );
-				}
-			);
-		} else {
-			// eslint-disable-next-line
-			window.alert(
-				'Share URL will is only available for published projects'
-			);
-		}
-		return false;
-	};
-
 	return (
 		<ShareCard>
 			<ShareCardHeader>{ __( 'Link', 'dashboard' ) }</ShareCardHeader>
@@ -83,17 +49,10 @@ export const ShareLink = ( { link } ) => {
 			<ShareCardFooter>
 				<SharedCardLink>{ link }</SharedCardLink>
 				<ShareCardButton
-					onClick={ handleCopyShareLink }
-					className={ classes }
-				>
-					{ ! linkCopied && __( 'Copy Link', 'dashboard' ) }
-					{ linkCopied && (
-						<>
-							<CheckIcon />
-							<span>{ __( 'Link copied!', 'dashboard' ) }</span>
-						</>
-					) }
-				</ShareCardButton>
+					contentCopiedText={ __( 'Link copied!', 'dashboard' ) }
+					defaultText={ __( 'Copy Link', 'dashboard' ) }
+					shareContent={ link }
+				/>
 			</ShareCardFooter>
 		</ShareCard>
 	);

--- a/apps/dashboard/src/components/share-modal/share-link/share-link.js
+++ b/apps/dashboard/src/components/share-modal/share-link/share-link.js
@@ -21,27 +21,16 @@ import { ShareLinkPreview } from './share-link-preview';
 export const ShareLink = ( { link } ) => {
 	return (
 		<ShareCard>
-			<ShareCardHeader>{ __( 'Link', 'dashboard' ) }</ShareCardHeader>
+			<ShareCardHeader>
+				{ __( 'Link - Full Page', 'dashboard' ) }
+			</ShareCardHeader>
 			<ShareCardBody>
 				<ShareCardContent>
 					<ShareCardContentText>
 						{ __(
-							'Share your form or survey via a link.',
+							'Share your form via a link, and present it on its own page.',
 							'dashboard'
 						) }
-					</ShareCardContentText>
-					<ShareCardContentText>
-						<span>
-							{ __( '(Customize the link with ', 'dashboard' ) }
-						</span>
-						<a
-							href="https://crowdsignal.com/support/domain-mapping/"
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ __( 'your own domain', 'dashboard' ) }
-						</a>
-						<span>.)</span>
 					</ShareCardContentText>
 				</ShareCardContent>
 				<ShareLinkPreview />


### PR DESCRIPTION
## Summary

This PR adds two more buttons to the embed sharing options to allow the user to copy the project's embed link.

Design: yKrlfbUJTFt0EMKheKh15c-fi-1953%3A37219

Fixes Automattic/crowdsignal#439

## Testing Instruction
* Open or create a project
* Make sure the project is published
* Click the Share button
* Check if the embed options match the Figma design and work correctly