### PR TITLE
Update Share Modal styles to make it more responsive

### DIFF
--- a/apps/dashboard/src/components/share-modal/index.js
+++ b/apps/dashboard/src/components/share-modal/index.js
@@ -21,10 +21,18 @@ import { ShareEmbed } from './share-embed/share-embed';
 import { ShareEmbedCard } from './share-embed/share-embed-card';
 
 const ShareModalDialog = styled( ModalDialog )`
+	width: 100%;
 	max-width: 1350px;
 	height: 95%;
 	max-height: 800px;
 	min-height: 550px;
+	overflow: auto;
+	padding: 40px;
+`;
+
+const ShareModalGrid = styled( ModalTemplateGrid )`
+	overflow: unset;
+	margin-bottom: 40px;
 `;
 
 const SharedModalFooterNote = styled.div`
@@ -46,7 +54,10 @@ const ShareModal = ( { project, onClose } ) => {
 	};
 	return (
 		<ModalWrapper onClick={ onWrapperClickHandler }>
-			<ShareModalDialog id="crowdsignal-share-modal">
+			<ShareModalDialog
+				id="crowdsignal-share-modal"
+				className="crowdsignal-share-modal"
+			>
 				<ModalNavigation>
 					<ModalCloseButton onClick={ onClose } />
 				</ModalNavigation>
@@ -56,11 +67,11 @@ const ShareModal = ( { project, onClose } ) => {
 				<ModalHeaderNote>
 					{ __( "It's time to collect some signals.", 'dashboard' ) }
 				</ModalHeaderNote>
-				<ModalTemplateGrid>
+				<ShareModalGrid className="crowdsignal-share-modal__grid">
 					<ShareLink link={ project.permalink } />
 					<ShareEmbedCard link={ project.permalink } />
 					<ShareEmbed link={ project.permalink } />
-				</ModalTemplateGrid>
+				</ShareModalGrid>
 				<SharedModalFooterNote>
 					<span>
 						{ __(

--- a/apps/dashboard/src/components/share-modal/share-card/share-card.js
+++ b/apps/dashboard/src/components/share-modal/share-card/share-card.js
@@ -35,13 +35,17 @@ export const ShareCardHeader = styled.h1`
 
 export const ShareCardBody = styled.div`
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	gap: 32px;
 	margin-bottom: 32px;
 	flex-grow: 1;
 
 	> * {
 		flex: 1;
+	}
+
+	svg {
+		height: 200px;
 	}
 `;
 

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -317,3 +317,21 @@ body {
 		}
 	}
 }
+
+.crowdsignal-share-modal {
+	@include break-huge {
+		padding: 40px 60px;
+	}
+
+	&__grid {
+		grid-template-columns: 1fr;
+
+		@include break-large {
+			grid-template-columns: 1fr 1fr;
+		}
+
+		@include break-wide {
+			grid-template-columns: 1fr 1fr 1fr;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds some style adjustments to the Share Modal to make it more responsive.

Fixes Automattic/crowdsignal#440

## Testing Instructions
* Open or create a project
* Make sure the project is published
* Click the Share button
* Play with the screen size and check if the modal layout is adapting to small screen sizes