### PR TITLE
Fix Templates Order

### DIFF
--- a/apps/dashboard/src/components/editor/index.js
+++ b/apps/dashboard/src/components/editor/index.js
@@ -9,7 +9,7 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import HeaderMeta from '../header-meta';
-import { blankProjectTemplate } from '../new-project-wizard/templates';
+import { blankProjectTemplate } from '../new-project-wizard/templates/blank';
 import { STORE_NAME } from '../../data';
 import BlockEditor from './editor';
 import EditorLoadingPlaceholder from './loading-placeholder';

--- a/apps/dashboard/src/components/new-project-wizard/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/index.js
@@ -18,7 +18,7 @@ import {
 import { STORE_NAME } from '../../data';
 import ActiveTheme from './active-theme';
 import TemplatePreview from './template-preview';
-import * as projectTemplates from './templates';
+import projectTemplates from './templates';
 
 /**
  * Style dependencies

--- a/apps/dashboard/src/components/new-project-wizard/templates/customer-satisfaction-survey.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/customer-satisfaction-survey.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { createTemplate } from './create-template';
 
-export const CustomerSatisfactionSurveyTemplate = createTemplate(
+export const customerSatisfactionSurveyTemplate = createTemplate(
 	__( 'Customer Satisfaction Survey', 'dashboard' ),
 	__(
 		'Collect qualitative and quantitative data about your customer’s experiences.'

--- a/apps/dashboard/src/components/new-project-wizard/templates/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/templates/index.js
@@ -1,9 +1,21 @@
-export * from './blank';
-export * from './customer-satisfaction-survey';
-export * from './customer-service-feedback';
-export * from './event-ticket-registration';
-export * from './job-listing-application-flow';
-export * from './join-our-community';
-export * from './join-waitlist';
-export * from './product-feedback';
-export * from './team-member-onboarding-survey';
+import { blankProjectTemplate } from './blank';
+import { customerServiceFeedbackTemplate } from './customer-service-feedback';
+import { teamMemberOnboardingSurveyTemplate } from './team-member-onboarding-survey';
+import { productFeedbackTemplate } from './product-feedback';
+import { jobListingApplicationFlowTemplate } from './job-listing-application-flow';
+import { eventTicketRegistrationTemplate } from './event-ticket-registration';
+import { customerSatisfactionSurveyTemplate } from './customer-satisfaction-survey';
+import { joinWaitlistTemplate } from './join-waitlist';
+import { joinOutCommunityTemplate } from './join-our-community';
+
+export default [
+	blankProjectTemplate,
+	customerServiceFeedbackTemplate,
+	teamMemberOnboardingSurveyTemplate,
+	productFeedbackTemplate,
+	jobListingApplicationFlowTemplate,
+	eventTicketRegistrationTemplate,
+	customerSatisfactionSurveyTemplate,
+	joinWaitlistTemplate,
+	joinOutCommunityTemplate,
+];


### PR DESCRIPTION
## Summary

As per @digitalwaveride recommendation, we need to update the order in which the templates are shown.
The recommended order is:

1. Empty Canvas
2. Customer Service Feedback
3. Team Member Onboarding Survey
4. Product Feedback
5. Job Listing – Application Form
6. Event Registration Form
7. Customer Satisfaction Survey
8. Join Waitlist
9. Join Our Community

Also, as the template list was being exported as a JS module, it seems that the templates inside the module were always in alphabetical order when building the bundle for production.
To ensure we get the order we want, I needed to export the templates as an array explicitly.

## Testing Instructions

* Open the project page and check if the templates are in the correct order
* Run `yarn build`
* Copy all the content inside the `dist/` folder and paste inside the folders `stable/` and `next/` on `app.crowdsignal.com/public_html/ui/` from your Sandbox
* Make sure you're sanboxed and open https://app.crowdsignal.com/project
* Check if the templates are in the correct order