### PR TITLE
Clean up Embed Popup cookie logic

### DIFF
--- a/apps/dashboard/src/components/share-modal/index.js
+++ b/apps/dashboard/src/components/share-modal/index.js
@@ -60,10 +60,7 @@ const ShareModal = ( { project, onClose } ) => {
 					<ShareLink link={ project.permalink } />
 					<ShareEmbedCard link={ project.permalink } />
 					<ShareEmbed link={ project.permalink } />
-					<ShareEmbedPopup
-						link={ project.permalink }
-						projectId={ project.id }
-					/>
+					<ShareEmbedPopup link={ project.permalink } />
 				</ShareModalGrid>
 			</ShareModalDialog>
 		</ModalWrapper>

--- a/apps/dashboard/src/components/share-modal/share-embed/share-embed-popup.js
+++ b/apps/dashboard/src/components/share-modal/share-embed/share-embed-popup.js
@@ -19,14 +19,14 @@ import { ShareCardButton } from '../share-card/share-card-button';
 import { ShareEmbedPopupPreview } from './share-embed-popup-preview';
 import { createInterpolateElement } from '@wordpress/element';
 
-const getEmbedCodeSnippet = ( projectUrl, projectId ) =>
+const getEmbedCodeSnippet = ( projectUrl ) =>
 	'<script type="text/javascript" src="https://app.crowdsignal.com/embed.js" async></script>\n' +
-	`<crowdsignal-popup src="${ projectUrl }" id="${ projectId }"></crowdsignal-popup>`;
+	`<crowdsignal-popup src="${ projectUrl }"></crowdsignal-popup>`;
 
 const docsURL =
 	'https://crowdsignal.com/support/embed-your-survey-or-form-via-an-embed-iframe-or-an-embed-card/?embed-iframe#h2-embed-popup';
 
-export const ShareEmbedPopup = ( { link, projectId } ) => {
+export const ShareEmbedPopup = ( { link } ) => {
 	return (
 		<ShareCard>
 			<ShareCardHeader>
@@ -70,7 +70,7 @@ export const ShareEmbedPopup = ( { link, projectId } ) => {
 						'dashboard'
 					) }
 					defaultText={ __( 'Copy JS Code Snippet', 'dashboard' ) }
-					shareContent={ getEmbedCodeSnippet( link, projectId ) }
+					shareContent={ getEmbedCodeSnippet( link ) }
 				/>
 			</ShareCardFooter>
 		</ShareCard>

--- a/apps/embed/src/popup.js
+++ b/apps/embed/src/popup.js
@@ -17,14 +17,15 @@ class CrowdsignalPopup extends window.HTMLElement {
 	 */
 	#frame;
 
+	/**
+	 * Reference to the project code
+	 */
+	#projectCode;
+
 	connectedCallback() {
 		const isWpEditor =
 			this.ownerDocument.body.className.indexOf( 'wp-block-embed' ) !==
 			-1;
-
-		if ( this.#getPopupClosedCookie() ) {
-			return;
-		}
 
 		if ( isWpEditor ) {
 			this.#showPlaceholder();
@@ -42,12 +43,13 @@ class CrowdsignalPopup extends window.HTMLElement {
 
 			if (
 				event.data.type === 'crowdsignal-forms-project-page-loaded' &&
-				event.data.pageHeight > 0
+				event.data.pageHeight > 0 &&
+				! this.#getPopupClosedCookie( event.data.projectCode )
 			) {
-				this.#wrapper.style.height = `${
-					event.data.pageHeight + 12
-				}px`;
+				const height = event.data.pageHeight + 12;
+				this.#wrapper.style.height = `${ height }px`;
 				this.#wrapper.style.bottom = '20px';
+				this.#projectCode = event.data.projectCode;
 
 				// We want the animation to play only on the first load
 				// Need to add some timeout here to wait the first animation to play
@@ -195,18 +197,20 @@ class CrowdsignalPopup extends window.HTMLElement {
 	}
 
 	#setPopupClosedCookie() {
-		const id = this.getAttribute( 'id' );
 		const expireDays = 30;
 		const expires = new Date();
 		expires.setTime( expires.getTime() + expireDays * 24 * 60 * 60 * 1000 );
-		document.cookie = `cs-popup-closed-${ id }=true; expires=${ expires.toUTCString() }; Secure`;
+		document.cookie = `cs-popup-closed-${
+			this.#projectCode
+		}=true; expires=${ expires.toUTCString() }; Secure`;
 	}
 
-	#getPopupClosedCookie() {
-		const id = this.getAttribute( 'id' );
+	#getPopupClosedCookie( projectCode ) {
 		return document.cookie
 			.split( '; ' )
-			.find( ( row ) => row.startsWith( `cs-popup-closed-${ id }` ) );
+			.find( ( row ) =>
+				row.startsWith( `cs-popup-closed-${ projectCode }` )
+			);
 	}
 }
 

--- a/scripts/build-development.sh
+++ b/scripts/build-development.sh
@@ -2,4 +2,5 @@
 
 yarn workspace @crowdsignal/dashboard start &
 yarn workspace @crowdsignal/project-renderer start &
-yarn workspace @crowdsignal/theme-compatibility build --watch
+yarn workspace @crowdsignal/theme-compatibility build --watch &
+yarn workspace @crowdsignal/embed build --watch


### PR DESCRIPTION
## Summary

This PR cleans the embed popup logic to remove the need for the project id.

## Testing Instructions
* Open or create a project and make sure it's published
* Click the Share button and copy the Popup code snippet
* Paste the snippet on a simple HTML file
* Confirm that the `id` attribute isn't present on the `<crowdsignal-popup />` element
*  Open the HTML file in your browser
* The popup should appear
* Close the popup and refresh the page
* The popup shouldn't appear again