### PR TITLE
Update Templates Modal to use images

### DIFF
--- a/apps/dashboard/src/components/new-project-wizard/index.js
+++ b/apps/dashboard/src/components/new-project-wizard/index.js
@@ -70,6 +70,7 @@ const NewProjectWizard = ( { onSelect, onChangeThemeClick } ) => {
 							<TemplatePreview
 								key={ `${ editorTheme }_${ template.name }` }
 								template={ template }
+								theme={ editorTheme }
 								onSelect={ onSelect }
 							/>
 						) ) }

--- a/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/styles/template-preview.js
@@ -56,3 +56,18 @@ export const TemplatePreviewDescription = styled.p`
 	line-height: 1.5em;
 	margin: 0;
 `;
+
+export const TemplatePreviewImageWrapper = styled.div`
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+`;
+
+export const TemplatePreviewImage = styled.img`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: auto;
+`;

--- a/apps/dashboard/src/components/new-project-wizard/template-preview.js
+++ b/apps/dashboard/src/components/new-project-wizard/template-preview.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BlockPreview } from '@wordpress/block-editor';
+import { kebabCase } from 'lodash';
 
 /**
  * Style dependencies
@@ -9,11 +9,13 @@ import { BlockPreview } from '@wordpress/block-editor';
 import {
 	TemplatePreviewDescription,
 	TemplatePreviewFrame,
+	TemplatePreviewImage,
+	TemplatePreviewImageWrapper,
 	TemplatePreviewName,
 	TemplatePreviewWrapper,
 } from './styles/template-preview';
 
-const TemplatePreview = ( { onSelect, template } ) => {
+const TemplatePreview = ( { onSelect, template, theme } ) => {
 	const handleSelect = () => onSelect( template );
 
 	const PreviewComponent = template.preview;
@@ -24,10 +26,13 @@ const TemplatePreview = ( { onSelect, template } ) => {
 				{ PreviewComponent && <PreviewComponent /> }
 
 				{ ! PreviewComponent && (
-					<BlockPreview
-						blocks={ template.project.draftContent.pages[ 0 ] }
-						viewportWidth={ 1380 }
-					/>
+					<TemplatePreviewImageWrapper>
+						<TemplatePreviewImage
+							src={ `https://app.crowdsignal.com/templates/${ theme }/${ kebabCase(
+								template.name
+							) }.png` }
+						/>
+					</TemplatePreviewImageWrapper>
 				) }
 			</TemplatePreviewFrame>
 


### PR DESCRIPTION
## Summary

This PR changes the Template Modal previews to use images.

Depends on D87032-code

Fixes Automattic/crowdsignal#446

## Testing Instructions

* Apply the backend changes
* Open the project creation URL
* On the Templates Modal, check if the previews are using images
* Make sure to test it for all themes