### PR TITLE
Update embedPopup reducer default value to show default values for new Projects

### DIFF
--- a/apps/dashboard/src/data/editor/reducer.js
+++ b/apps/dashboard/src/data/editor/reducer.js
@@ -212,7 +212,7 @@ const embedCard = ( state = {}, action ) => {
  * @param  {Object} action Action object.
  * @return {Object}        Updated embed popup settings.
  */
-const embedPopup = ( state = {}, action ) => {
+const embedPopup = ( state = null, action ) => {
 	if ( action.type === EDITOR_INIT ) {
 		return action.embedPopup;
 	}


### PR DESCRIPTION
## Summary

As title

## Testing Instructions
* Create a new project a publish it
* Click the Share button and check if the Embed Popup default settings are filled