### PR TITLE
change the word wait to a more detailed message

### DIFF
--- a/apps/project-renderer/src/components/project-form/index.js
+++ b/apps/project-renderer/src/components/project-form/index.js
@@ -50,7 +50,7 @@ const ProjectForm = ( props ) => {
 	};
 
 	if ( ! pageContent ) {
-		return 'Wait...';
+		return 'Please wait, connecting to Crowdsignal...';
 	}
 
 	return (


### PR DESCRIPTION
Fixes 448-gh-Automattic/crowdsignal

Quick PR to change the word "Wait" to a more verbose "Please wait, connecting to Crowdsignal..." when the project renderer is loading.  Typically this happens too fast to read, but if for some reason there's a slow down rendering projects, this will give visitors something to look at before the render.

Testing:

Apply this PR, start a new project or load a project in crowdsignal.localhost:9000  Click on Preview and watch very closely.  The message will very briefly show up before the project renders.  Blink and you'll miss it :)
