### PR TITLE
Fix Preview Styles

### DIFF
--- a/apps/dashboard/src/components/editor/styles-resolver.js
+++ b/apps/dashboard/src/components/editor/styles-resolver.js
@@ -16,6 +16,10 @@ window.__editorAssets = window.__editorAssets || {
 	scripts: '',
 };
 
+const IFRAME_SELECTOR =
+	'.block-editor-block-preview__container iframe, .edit-post-visual-editor__content-area iframe';
+const WRAPPER_DIV_SELECTOR = 'body > div:first-child';
+
 const PreviewStylesResolver = ( { theme } ) => {
 	const { updateEditorSettings } = useDispatch( STORE_NAME );
 
@@ -64,6 +68,27 @@ const PreviewStylesResolver = ( { theme } ) => {
 					},
 				},
 			} );
+
+			// Gutenberg tries to get styles from the current document and include in the previews
+			// https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/iframe/index.js#L360-L363
+			// This logic fails to get external stylesheets and since it resides inside the iframe body
+			// it has higher precedence and it's messing with our previews styles
+			// This logic will try to remove these <link> tags from the preview body
+			Array.from( document.querySelectorAll( IFRAME_SELECTOR ) ).forEach(
+				( iframe ) => {
+					const wrapper = iframe.contentDocument.querySelector(
+						WRAPPER_DIV_SELECTOR
+					);
+
+					// The div added to wrap the stylesheets doesn't have any better
+					// attribute to target this condition ¯\_(ツ)_/¯
+					if ( wrapper && wrapper.style.display === 'none' ) {
+						wrapper
+							.querySelectorAll( 'link' )
+							.forEach( ( n ) => n.remove() );
+					}
+				}
+			);
 		}, 1000 ),
 		[ theme ]
 	);


### PR DESCRIPTION
## Summary

Our page previews are not looking very good, especially for themes other than Leven.
It's due to a [Gutenberg logic](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/iframe/index.js#L360-L363) that tries to get styles from the parent document and include them into the previews.
This logic fails to get external styles, and since it's adding some `<link>` tags inside the iframe body, those styles are overriding the styles from the `<head>` and messing stuff.

This PR includes a script that will try to remove these `<link>` tags from the iframe body.

## Testing Instructions

* Open/create a project
* Switch to a few themes or all of them and check if the previews look better