### PR TITLE
Add time picker variation to date picker

### DIFF
--- a/packages/block-editor/src/date-time-picker/attributes.js
+++ b/packages/block-editor/src/date-time-picker/attributes.js
@@ -17,4 +17,20 @@ export default {
 	backgroundColor: {
 		type: 'string',
 	},
+	showTimeInput: {
+		type: 'boolean',
+		default: false,
+	},
+	showTimeSelectOnly: {
+		type: 'boolean',
+		default: false,
+	},
+	dateFormat: {
+		type: 'string',
+		default: 'MMMM d, yyyy',
+	},
+	placeholderText: {
+		type: 'string',
+		default: 'July 16, 1969',
+	},
 };

--- a/packages/block-editor/src/date-time-picker/edit.js
+++ b/packages/block-editor/src/date-time-picker/edit.js
@@ -45,7 +45,10 @@ const EditDateTimePicker = ( props ) => {
 					value={ attributes.label }
 				/>
 			</FormInputWrapper.Label>
-			<FormDatePicker placeholderText={ attributes.placeholderText } />
+			<FormDatePicker
+				placeholderText={ attributes.placeholderText }
+				showTimeSelectOnly={ attributes.showTimeSelectOnly }
+			/>
 		</FormInputWrapper>
 	);
 };

--- a/packages/block-editor/src/date-time-picker/edit.js
+++ b/packages/block-editor/src/date-time-picker/edit.js
@@ -45,7 +45,7 @@ const EditDateTimePicker = ( props ) => {
 					value={ attributes.label }
 				/>
 			</FormInputWrapper.Label>
-			<FormDatePicker selected={ new Date() } />
+			<FormDatePicker placeholderText={ attributes.placeholderText } />
 		</FormInputWrapper>
 	);
 };

--- a/packages/block-editor/src/date-time-picker/index.js
+++ b/packages/block-editor/src/date-time-picker/index.js
@@ -9,6 +9,7 @@ import { DateTimePicker } from '@crowdsignal/blocks';
 import { DatePickerIcon } from '@crowdsignal/icons';
 import attributes from './attributes';
 import EditDateTimePicker from './edit';
+import variation from './variations';
 
 const settings = {
 	apiVersion: 1,
@@ -21,6 +22,7 @@ const settings = {
 		__( 'calendar', 'block-editor' ),
 	],
 	icon: <DatePickerIcon />,
+	variations: variation,
 	edit: EditDateTimePicker,
 	attributes,
 	example: {

--- a/packages/block-editor/src/date-time-picker/variations.js
+++ b/packages/block-editor/src/date-time-picker/variations.js
@@ -1,0 +1,36 @@
+/**
+ * external dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * internal dependencies
+ */
+import { TimePickerIcon } from '@crowdsignal/icons';
+
+export default [
+	{
+		name: 'crowdsignal-forms/time-picker',
+		isDefault: false,
+		title: __( 'Time Picker', 'block-editor' ),
+		description: __(
+			'Allow your audience to set a time in your form.',
+			'block-editor'
+		),
+		icon: <TimePickerIcon />,
+		attributes: {
+			label: __( 'Enter time', 'block-editor' ),
+			placeholderText: '12:00 PM',
+			showTimeInput: true,
+			showTimeSelectOnly: true,
+			dateFormat: 'h:mm aa',
+		},
+		keywords: [
+			__( 'time input', 'block-editor' ),
+			__( 'clock', 'block-editor' ),
+			__( 'hour', 'block-editor' ),
+		],
+		isActive: ( blockAttributes, variationAttributes ) =>
+			blockAttributes.label === variationAttributes.label,
+	},
+];

--- a/packages/blocks/src/components/form-date-picker/index.js
+++ b/packages/blocks/src/components/form-date-picker/index.js
@@ -25,7 +25,6 @@ const FormDatePicker = ( props ) => {
 	return (
 		<DatePickerWrapper>
 			<DatePicker
-				dateFormat="MMMM d, yyyy"
 				popperModifiers={ [
 					{
 						name: 'arrow',

--- a/packages/blocks/src/date-time-picker/index.js
+++ b/packages/blocks/src/date-time-picker/index.js
@@ -15,7 +15,7 @@ import { useField } from '@crowdsignal/form';
 const DateTimePicker = ( { attributes, className } ) => {
 	const { error, onChange, fieldValue } = useField( {
 		fieldName: `q_${ attributes.clientId }[text]`,
-		initialValue: new Date().toDateString(),
+		initialValue: new Date(),
 		validation: ( value ) => {
 			if ( attributes.mandatory && isEmpty( value ) ) {
 				return __( 'This field is required', 'blocks' );
@@ -24,10 +24,18 @@ const DateTimePicker = ( { attributes, className } ) => {
 	} );
 
 	const handleDateChange = ( e ) => {
-		onChange( e.toDateString() );
+		if ( attributes.showTimeSelectOnly ) {
+			onChange( e.toTimeString() );
+		} else {
+			onChange( e.toDateString() );
+		}
 	};
 
 	const parsedDate = useMemo( () => {
+		if ( attributes.showTimeSelectOnly ) {
+			// the DatePicker component has to have a fully formatted date, adding an arbitrary date to value
+			return Date.parse( 'Thu Sep 29 2022 ' + fieldValue );
+		}
 		return Date.parse( fieldValue );
 	}, [ fieldValue ] );
 
@@ -51,6 +59,10 @@ const DateTimePicker = ( { attributes, className } ) => {
 			<FormDatePicker
 				selected={ parsedDate }
 				onChange={ handleDateChange }
+				showTimeInput={ attributes.showTimeInput }
+				showTimeSelectOnly={ attributes.showTimeSelectOnly }
+				dateFormat={ attributes.dateFormat }
+				placeholderText={ attributes.placeholderText }
 			/>
 			{ error && <ErrorMessage>{ error }</ErrorMessage> }
 		</FormInputWrapper>

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -16,6 +16,7 @@ export * from './rating-scale-question';
 export * from './single-choice';
 export * from './single-choice-dropdown';
 export * from './submit-button';
+export * from './time-picker';
 export * from './text-input';
 export * from './text-question';
 export * from './email-input';

--- a/packages/icons/src/time-picker.js
+++ b/packages/icons/src/time-picker.js
@@ -1,4 +1,4 @@
-export const CheckIcon = () => (
+export const TimePickerIcon = () => (
 	<svg
 		width="25"
 		height="24"


### PR DESCRIPTION
The last of the blocks for CS-UI, the time picker block!  this is created as a variation of the date picker block.  It leverages the React-Datepicker's ability to show a time selector only, giving us a whole separate block.

To be fair I'm not 100% thrilled with the UI on the time picker (click on the clock icon once you click the time to get a set of dropdowns to adjust the time).  But, it's what the component has, and in the interest of speeding up deployment, I ran with it.

![Screen Shot 2022-09-29 at 3 24 00 PM](https://user-images.githubusercontent.com/12895386/193123893-c38ced89-6ba9-4e05-b786-db1e502a3a78.png)

Testing, you may need to run yarn-install again.  Open up the editor, add the time picker from the block library and off you go.  Add it to a project, respond and then check the results.  The patch for the date picker works for this too, so you don't need any backend patches.