### PR TITLE
Enable Branding for Projects

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -19,7 +19,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@automattic/isolated-block-editor": "2.18.0",
+    "@automattic/isolated-block-editor": "2.18.1",
     "@crowdsignal/block-editor": "^0.1.0",
     "@crowdsignal/block-editor-filters": "^0.1.0",
     "@crowdsignal/blocks": "^0.1.0",

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -67,6 +67,7 @@ const Editor = ( { project } ) => {
 
 	const {
 		currentPreviewType,
+		currentUser,
 		editorId,
 		editorSettings,
 		editorTheme,
@@ -201,17 +202,19 @@ const Editor = ( { project } ) => {
 					version={ version }
 				/>
 				<FooterSlot>
-					<StickyFooter>
-						<CrowdsignalFooter
-							logo
-							upgradeLink
-							source="editor-footer"
-							message={ __(
-								'Collect your own feedback with Crowdsignal',
-								'dashboard'
-							) }
-						/>
-					</StickyFooter>
+					{ currentUser.isFree && (
+						<StickyFooter>
+							<CrowdsignalFooter
+								logo
+								upgradeLink
+								source="editor-footer"
+								message={ __(
+									'Collect your own feedback with Crowdsignal',
+									'dashboard'
+								) }
+							/>
+						</StickyFooter>
+					) }
 				</FooterSlot>
 			</EditorWrapper>
 

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -202,7 +202,7 @@ const Editor = ( { project } ) => {
 					version={ version }
 				/>
 				<FooterSlot>
-					{ currentUser.isFree && (
+					{ currentUser?.isFree && (
 						<StickyFooter>
 							<CrowdsignalFooter
 								logo

--- a/apps/dashboard/src/components/editor/editor.js
+++ b/apps/dashboard/src/components/editor/editor.js
@@ -7,13 +7,18 @@ import { __ } from '@wordpress/i18n';
 import { kebabCase, noop } from 'lodash';
 import IsolatedBlockEditor, {
 	EditorHeadingSlot,
+	FooterSlot,
 } from '@automattic/isolated-block-editor'; // eslint-disable-line import/default
 import { Global } from '@emotion/react';
 
 /**
  * Internal dependencies
  */
-import { NavigationBar } from '@crowdsignal/components';
+import {
+	CrowdsignalFooter,
+	NavigationBar,
+	StickyFooter,
+} from '@crowdsignal/components';
 import { registerBlocks } from './blocks';
 import { registerPatterns } from './patterns';
 import { STORE_NAME } from '../../data';
@@ -195,6 +200,19 @@ const Editor = ( { project } ) => {
 					onRestore={ restoreDraft }
 					version={ version }
 				/>
+				<FooterSlot>
+					<StickyFooter>
+						<CrowdsignalFooter
+							logo
+							upgradeLink
+							source="editor-footer"
+							message={ __(
+								'Collect your own feedback with Crowdsignal',
+								'dashboard'
+							) }
+						/>
+					</StickyFooter>
+				</FooterSlot>
 			</EditorWrapper>
 
 			{ ! showWizard && showEditorGuide && (

--- a/apps/dashboard/src/components/editor/styles-resolver.js
+++ b/apps/dashboard/src/components/editor/styles-resolver.js
@@ -66,7 +66,7 @@ const PreviewStylesResolver = ( { theme } ) => {
 				editor: {
 					__unstableResolvedAssets: {
 						styles: [
-							`${ externalStyles }<style>${ inlineStyles }</style>`,
+							`<style>${ inlineStyles }</style>${ externalStyles }`,
 						],
 					},
 				},

--- a/apps/dashboard/src/components/editor/use-editor-content.js
+++ b/apps/dashboard/src/components/editor/use-editor-content.js
@@ -145,6 +145,7 @@ export const useEditorContent = ( project ) => {
 		editorSettings,
 		editorTheme,
 		currentPreviewType,
+		currentUser,
 		confirmationPage,
 		currentPage,
 		totalPages: editorPages.length,

--- a/apps/dashboard/src/data/users/selectors.js
+++ b/apps/dashboard/src/data/users/selectors.js
@@ -12,6 +12,24 @@ import {
 	getAccountPartnerUserId,
 } from '../accounts/selectors';
 
+const ACCOUNT_TYPES = {
+	FREE: 10,
+	PWYW_9: 12,
+	PWYW_19: 13,
+	PWYW_29: 14,
+	PWYW_39: 15,
+	PWYW_49: 16,
+	PRO: 20,
+	JETPACKPRO: 22,
+	CORPORATE: 30,
+	CORPORATE_6_MONTHLY: 32,
+	ENTERPRISE: 35,
+	VIP: 40,
+	PREMIUM: 50,
+	BUSINESS: 60,
+	TEAM: 70,
+};
+
 export const getUserAccountId = ( state, userId ) =>
 	get( state, [ 'users', userId, 'account' ], 0 );
 
@@ -59,6 +77,7 @@ export const getUser = ( state, userId ) => {
 		profile: getUserProfile( state, userId ),
 		signalCount: getUserSignalCount( state, userId ),
 		type: getUserAccountType( state, userId ),
+		isFree: getUserAccountType( state, userId ) === ACCOUNT_TYPES.FREE,
 	};
 };
 

--- a/apps/project-renderer/src/components/project-form/index.js
+++ b/apps/project-renderer/src/components/project-form/index.js
@@ -19,6 +19,7 @@ const ProjectForm = ( props ) => {
 		fetchProject,
 		theme,
 		totalPages,
+		showBranding,
 	} = useProjectData( props );
 
 	useEffect( () => {
@@ -63,6 +64,7 @@ const ProjectForm = ( props ) => {
 				onSubmit={ submitPage }
 				projectCode={ props.projectCode }
 				totalPages={ totalPages }
+				showBranding={ showBranding }
 			/>
 		</ProjectFormThemeProvider>
 	);

--- a/apps/project-renderer/src/components/project-form/page.js
+++ b/apps/project-renderer/src/components/project-form/page.js
@@ -30,6 +30,7 @@ const ProjectPage = ( {
 	onSubmit,
 	projectCode,
 	totalPages,
+	showBranding,
 } ) => {
 	const classes = classnames( 'wp-embed-responsive', 'crowdsignal-content', {
 		'crowdsignal-forms-form__content': !! onSubmit,
@@ -58,16 +59,18 @@ const ProjectPage = ( {
 			<ContentWrapper className={ classes }>
 				{ renderBlocks( blocks, blockMap ) }
 			</ContentWrapper>
-			<StickyFooter>
-				<CrowdsignalFooter
-					logo
-					source="project-footer"
-					message={ __(
-						'Collect your own feedback with Crowdsignal',
-						'project-renderer'
-					) }
-				/>
-			</StickyFooter>
+			{ showBranding && (
+				<StickyFooter>
+					<CrowdsignalFooter
+						logo
+						source="project-footer"
+						message={ __(
+							'Collect your own feedback with Crowdsignal',
+							'project-renderer'
+						) }
+					/>
+				</StickyFooter>
+			) }
 		</Form>
 	);
 };

--- a/apps/project-renderer/src/components/project-form/page.js
+++ b/apps/project-renderer/src/components/project-form/page.js
@@ -13,7 +13,12 @@ import {
 	renderBlocks,
 } from '@crowdsignal/blocks';
 import { Form } from '@crowdsignal/form';
-import { NavigationBar } from '@crowdsignal/components';
+import {
+	CrowdsignalFooter,
+	NavigationBar,
+	StickyFooter,
+} from '@crowdsignal/components';
+import { __ } from '@wordpress/i18n';
 
 const blockMap = zipObject( map( projectBlocks, 'blockName' ), projectBlocks );
 
@@ -53,6 +58,16 @@ const ProjectPage = ( {
 			<ContentWrapper className={ classes }>
 				{ renderBlocks( blocks, blockMap ) }
 			</ContentWrapper>
+			<StickyFooter>
+				<CrowdsignalFooter
+					logo
+					source="project-footer"
+					message={ __(
+						'Collect your own feedback with Crowdsignal',
+						'project-renderer'
+					) }
+				/>
+			</StickyFooter>
 		</Form>
 	);
 };

--- a/apps/project-renderer/src/components/project-form/use-project-data.js
+++ b/apps/project-renderer/src/components/project-form/use-project-data.js
@@ -19,6 +19,7 @@ export const useProjectData = ( { projectCode, preview = false } ) => {
 	const [ pageContent, setPageContent ] = useState();
 	const [ navigationSettings, setNavigationSettings ] = useState( {} );
 	const [ isCompleted, setIsCompleted ] = useState( false );
+	const [ showBranding, setShowBranding ] = useState( false );
 
 	useEffect( () => {
 		if ( preview ) {
@@ -43,6 +44,7 @@ export const useProjectData = ( { projectCode, preview = false } ) => {
 
 				setTheme( res.data.theme );
 				setTotalPages( res.data.totalPages );
+				setShowBranding( res.data.branding );
 				setStartDate(
 					res.data.startTime || Math.round( Date.now() / 1000 )
 				);
@@ -118,5 +120,6 @@ export const useProjectData = ( { projectCode, preview = false } ) => {
 		fetchProject,
 		theme,
 		navigationSettings,
+		showBranding,
 	};
 };

--- a/packages/components/src/crowdsignal-footer/index.js
+++ b/packages/components/src/crowdsignal-footer/index.js
@@ -1,34 +1,20 @@
 /**
  * External dependencies
  */
-import { createInterpolateElement } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Footer, FooterLink, Logo, UpgradeTooltip } from './styles.js';
-
-export const CrowdsignalFooterUpgradeLink = ( { source } ) => (
-	<UpgradeTooltip>
-		{ createInterpolateElement(
-			__(
-				'Hide Crowdsignal ads <br />and get unlimited <br /> signals - <a>Upgrade</a>',
-				'components'
-			),
-			{
-				br: <br />,
-				a: (
-					<a
-						href={ `https://crowdsignal.com/pricing?ref=${ source }` }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			}
-		) }
-	</UpgradeTooltip>
-);
+import {
+	Footer,
+	FooterLink,
+	Logo,
+	UpgradeLink,
+	UpgradeTooltip,
+	UpgradeWrapper,
+} from './styles.js';
 
 const CrowdsignalFooter = ( {
 	logo,
@@ -36,44 +22,59 @@ const CrowdsignalFooter = ( {
 	source,
 	style = {},
 	upgradeLink,
-} ) => (
-	<Footer>
-		<FooterLink
-			as="a"
-			href={ `https://crowdsignal.com?ref=${ source }` }
-			target="_blank"
-			rel="noopener noreferrer"
-			style={ style }
-		>
-			{ message }
-		</FooterLink>
+} ) => {
+	const [ showUpgradeTooltip, setShowUpgradeTooltip ] = useState( false );
 
-		{ upgradeLink && (
-			<>
-				<UpgradeTooltip source={ source } />
-				<a
-					href={ `https://crowdsignal.com/pricing?ref=${ source }` }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					{ __( 'Hide', 'components' ) }
-				</a>
-			</>
-		) }
-
-		{ logo && (
-			<Logo
+	return (
+		<Footer>
+			<FooterLink
+				as="a"
 				href={ `https://crowdsignal.com?ref=${ source }` }
 				target="_blank"
 				rel="noopener noreferrer"
+				style={ style }
 			>
-				<img
-					src="https://app.crowdsignal.com/images/svg/cs-logo-dots.svg"
-					alt="Crowdsignal"
-				/>
-			</Logo>
-		) }
-	</Footer>
-);
+				{ message }
+			</FooterLink>
+
+			{ upgradeLink && (
+				<UpgradeWrapper>
+					<UpgradeLink
+						href={ `https://crowdsignal.com/pricing?ref=${ source }` }
+						target="_blank"
+						rel="noopener noreferrer"
+						onMouseOver={ () => setShowUpgradeTooltip( true ) }
+						onMouseLeave={ () => setShowUpgradeTooltip( false ) }
+					>
+						{ __( 'Hide', 'components' ) }
+					</UpgradeLink>
+					{ showUpgradeTooltip && (
+						<UpgradeTooltip>
+							{ __(
+								'Hide Crowdsignal ads and get unlimited signals',
+								'components'
+							) }
+						</UpgradeTooltip>
+					) }
+				</UpgradeWrapper>
+			) }
+
+			{ logo && (
+				<Logo
+					href={ `https://crowdsignal.com?ref=${ source }` }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<img
+						src="https://app.crowdsignal.com/images/svg/cs-logo-dots.svg"
+						alt="Crowdsignal"
+					/>
+				</Logo>
+			) }
+		</Footer>
+	);
+};
+
+CrowdsignalFooter.Wrapper = Footer;
 
 export default CrowdsignalFooter;

--- a/packages/components/src/crowdsignal-footer/styles.js
+++ b/packages/components/src/crowdsignal-footer/styles.js
@@ -4,46 +4,63 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
-/**
- * Internal dependencies
- */
-import { color } from '@crowdsignal/styles';
-
 export const Footer = styled.div`
 	align-items: center;
+	justify-content: center;
 	display: flex;
 	margin-top: 16px;
 	width: 100%;
 `;
 
-export const FooterLink = styled.div( ( { style } ) => {
+export const FooterLink = styled.div( () => {
 	return css`
 		display: inline-flex;
 		text-decoration: none;
 		text-transform: uppercase;
 		vertical-align: middle;
+		line-height: normal;
 
 		&:not( :hover ) {
-			color: ${ style.color || color( 'text' ) };
-			opacity: 0.4;
+			opacity: 0.7;
 		}
 	`;
 } );
 
-export const UpgradeTooltip = styled.span`
-	background-color: #a4a4a4;
-	border: 0;
-	border-radius: 2px;
-	box-shadow: none;
-	color: ${ color( 'text-inverted' ) };
-	cursor: pointer;
-	display: inline-flex;
-	font-family: sans-serif;
-	font-size: 10px;
+export const UpgradeWrapper = styled.div`
+	position: relative;
 	margin-left: 16px;
-	padding: 2px 8px;
+	display: flex;
+	justify-content: center;
+`;
+
+export const UpgradeLink = styled.a`
+	position: relative;
+	background-color: var( --color-neutral-50 );
+	display: inline-flex;
+	justify-content: center;
+	font-size: 10px;
 	text-decoration: none;
-	vertical-align: middle;
+	color: var( --color-text-inverted );
+	border-radius: 2px;
+	padding: 4px 8px;
+
+	&:hover {
+		color: var( --color-text-inverted );
+	}
+`;
+
+export const UpgradeTooltip = styled.div`
+	width: 120px;
+	position: absolute;
+	bottom: calc( 100% + 8px );
+	background-color: var( --color-neutral-50 );
+	border-radius: 2px;
+	color: var( --color-text-inverted );
+	display: block;
+	justify-content: center;
+	font-size: 10px;
+	padding: 4px 8px;
+	text-align: center;
 `;
 
 export const Logo = styled.div`

--- a/packages/components/src/crowdsignal-footer/styles.js
+++ b/packages/components/src/crowdsignal-footer/styles.js
@@ -3,6 +3,7 @@
  */
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+import { breakpoint } from '@crowdsignal/styles';
 
 export const Footer = styled.div`
 	align-items: center;
@@ -22,6 +23,10 @@ export const FooterLink = styled.div( () => {
 
 		&:not( :hover ) {
 			opacity: 0.7;
+		}
+
+		${ breakpoint( '<480px' ) } {
+			text-align: center;
 		}
 	`;
 } );
@@ -61,6 +66,10 @@ export const UpgradeTooltip = styled.div`
 	font-size: 10px;
 	padding: 4px 8px;
 	text-align: center;
+
+	${ breakpoint( '<480px' ) } {
+		right: 0;
+	}
 `;
 
 export const Logo = styled.div`

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -14,5 +14,6 @@ export { default as Popover } from './popover';
 export { default as PopoverMenu } from './popover-menu';
 export { default as PopoverNotice } from './popover-notice';
 export { default as Sandbox } from './sandbox';
+export { default as StickyFooter } from './sticky-footer';
 export { default as StyleProvider } from './style-provider';
 export { default as TabNavigation } from './tab-navigation';

--- a/packages/components/src/sticky-footer/index.js
+++ b/packages/components/src/sticky-footer/index.js
@@ -11,8 +11,6 @@ const Footer = styled.div`
 	box-sizing: border-box;
 	background-color: var( --cs--style--color--background, white );
 	padding: 12px;
-	filter: drop-shadow( 0 0 6px rgba( 0, 0, 0, 0.02 ) )
-		drop-shadow( 0 2px 4px rgba( 0, 0, 0, 0.08 ) );
 
 	${ CrowdsignalFooter.Wrapper } {
 		margin: 0;

--- a/packages/components/src/sticky-footer/index.js
+++ b/packages/components/src/sticky-footer/index.js
@@ -3,6 +3,7 @@ import CrowdsignalFooter from '../crowdsignal-footer';
 
 const Footer = styled.div`
 	position: sticky;
+	z-index: 1000;
 	bottom: 0;
 	background-color: var( --cs--style--color--background, white );
 	padding: 12px;

--- a/packages/components/src/sticky-footer/index.js
+++ b/packages/components/src/sticky-footer/index.js
@@ -5,6 +5,10 @@ const Footer = styled.div`
 	position: sticky;
 	z-index: 1000;
 	bottom: 0;
+	height: 50px;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
 	background-color: var( --cs--style--color--background, white );
 	padding: 12px;
 	filter: drop-shadow( 0 0 6px rgba( 0, 0, 0, 0.02 ) )

--- a/packages/components/src/sticky-footer/index.js
+++ b/packages/components/src/sticky-footer/index.js
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+import CrowdsignalFooter from '../crowdsignal-footer';
+
+const Footer = styled.div`
+	position: sticky;
+	bottom: 0;
+	background-color: var( --cs--style--color--background, white );
+	padding: 12px;
+	filter: drop-shadow( 0 0 6px rgba( 0, 0, 0, 0.02 ) )
+		drop-shadow( 0 2px 4px rgba( 0, 0, 0, 0.08 ) );
+
+	${ CrowdsignalFooter.Wrapper } {
+		margin: 0;
+		font-size: 13px;
+	}
+`;
+
+const StickyFooter = ( { children } ) => {
+	return <Footer className="crowdsignal-sticky-footer">{ children }</Footer>;
+};
+
+StickyFooter.Wrapper = Footer;
+
+export default StickyFooter;

--- a/packages/styles/src/reset.js
+++ b/packages/styles/src/reset.js
@@ -23,10 +23,6 @@ export const resetStyles = ( { shadowRoot = false } ) => css`
 		padding: 0;
 	}
 
-	a {
-		color: var( --color-text );
-	}
-
 	button,
 	input,
 	textarea {

--- a/packages/theme-compatibility/package.json
+++ b/packages/theme-compatibility/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Automattic/crowdsignal-ui/issues"
   },
   "devDependencies": {
-    "@automattic/isolated-block-editor": "2.18.0"
+    "@automattic/isolated-block-editor": "2.18.1"
   },
   "scripts": {
     "build": "calypso-build"

--- a/packages/theme-compatibility/src/base/base.scss
+++ b/packages/theme-compatibility/src/base/base.scss
@@ -391,3 +391,8 @@ body {
 	}
 }
 
+#crowdsignal-project .crowdsignal-sticky-footer {
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+}

--- a/packages/theme-compatibility/src/base/editor.scss
+++ b/packages/theme-compatibility/src/base/editor.scss
@@ -131,6 +131,8 @@ body.editor-styles-wrapper
 	}
 
 	.block-editor-block-list__layout.is-root-container {
+		min-height: calc(100% - 50px);
+		box-sizing: border-box;
 		padding: var(--cs--content-padding-top) var(--cs--content-padding-horizontal) var(--cs--content-padding-bottom);
 		overflow: hidden;
 	}

--- a/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
@@ -58,7 +58,3 @@ body {
 		color: var(--wp--preset--color--foreground);
 	}
 }
-
-.crowdsignal-sticky-footer.crowdsignal-sticky-footer {
-	filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.06)) drop-shadow(0 2px 4px rgba(255, 255, 255, 0.1));
-}

--- a/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
+++ b/packages/theme-compatibility/src/twentytwentytwo-dark/base.scss
@@ -58,3 +58,7 @@ body {
 		color: var(--wp--preset--color--foreground);
 	}
 }
+
+.crowdsignal-sticky-footer.crowdsignal-sticky-footer {
+	filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.06)) drop-shadow(0 2px 4px rgba(255, 255, 255, 0.1));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.5.0.tgz#27f69e2569062258f24ca50f0a4b8a572a00e287"
   integrity sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==
 
-"@automattic/isolated-block-editor@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@automattic/isolated-block-editor/-/isolated-block-editor-2.18.0.tgz#f7b3a8f3f1fa7f04f2093d69dff20776aaeb6df2"
-  integrity sha512-XahoG2WoQmF7kWP5xxFxxn+BtKit9dO3/CSDbsY46QFZ8TdVAD0JgRdJBLrthD8jpw8meIq7UM0kFPDpZOVduw==
+"@automattic/isolated-block-editor@2.18.1":
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/@automattic/isolated-block-editor/-/isolated-block-editor-2.18.1.tgz#c9490ece513c4de4eb1cdbb6dd17fdfccdbd5148"
+  integrity sha512-NgNWsnf+jWLEGHBS6oE4TqsrWPrN3IRIHDuLz48DyJksZD3mlf5ArJ9hnRdjLgyJBLgkIOWdbA51JlB+tiGKBQ==
   dependencies:
     "@wordpress/a11y" "3.12.0"
     "@wordpress/annotations" "2.12.0"


### PR DESCRIPTION
## Summary

This PR enables branding on Projects.
When creating projects, free users will see a sticky branding footer with a "Hide" button redirecting them to the Crowdsignal pricing page

![Screen Shot 2022-09-30 at 16 12 34](https://user-images.githubusercontent.com/7811225/193340861-67a89919-753a-4dd8-81d3-6d6ca242bcef.png)

On the Renderer, since it's intended to be accessed by the user's audience, the "Hide" button isn't shown.

Depends on: D88938-code

## Testing Instructions

* Apply backend changes (D88938-code)
* Using a free account, open/create a project
* You should see the branding on the footer of the Editor and the Renderer
* Change to a non-free account
* Now, you shouldn't see the branding