### PR TITLE
Allow defining a style nonce for the embed popup

### DIFF
--- a/apps/embed/src/popup.js
+++ b/apps/embed/src/popup.js
@@ -27,10 +27,17 @@ class CrowdsignalPopup extends window.HTMLElement {
 	 */
 	#settings;
 
+	/**
+	 * Allow defining a nonce for more environments with more restrictive CSP rules
+	 */
+	#styleNonce;
+
 	connectedCallback() {
 		const isWpEditor =
 			this.ownerDocument.body.className.indexOf( 'wp-block-embed' ) !==
 			-1;
+
+		this.#styleNonce = this.getAttribute( 'style-nonce' ) ?? '';
 
 		if ( isWpEditor ) {
 			this.#showPlaceholder();
@@ -91,7 +98,7 @@ class CrowdsignalPopup extends window.HTMLElement {
 
 		this.#wrapper = document.createElement( 'div' );
 		this.#wrapper.innerHTML = `
-			<style>
+			<style nonce="${ this.#styleNonce }">
 				body {
 					font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 					color: #1e1e1e;
@@ -154,7 +161,7 @@ class CrowdsignalPopup extends window.HTMLElement {
 
 	#showPopup() {
 		this.innerHTML += `
-			<style>
+			<style nonce="${ this.#styleNonce }">
 				.crowdsignal-web-popup__wrapper {
 					width: 400px;
 					max-width: 100%;


### PR DESCRIPTION
## Summary

This PR changes the `<crowdsignal-popup />` component to allow defining a `style-nonce` for environments with more restrictive CSP rules.

## Testing Instructions

The easiest way to test it is to build and reference the JavaScript file in a simple HTML file.
You can use the one here: `apps/embed/test.html.`

* Checkout this branch and run `yarn install & yarn build` in the root directory
* It should create the file `apps/embed/dist/main.js`
* Edit the [test HTML](https://github.com/Automattic/crowdsignal-ui/blob/main/apps/embed/test.html#L241-L242) file and change the reference from `https://app.crowdsignal.com/embed.js` to the recently built file (`apps/embed/dist/main.js`)
* Change the `<crowdsignal-popup />` and add a `style-nonce` and a valid `src`  property.
* Open the test HTML file and inspect the page source code.
* You should see the `nonce` attribute in all the `<style />` tags the `<crowdsignal-popup />` creates