### PR TITLE
chore: pin marvinpinto/action-automatic-releases to v1.2.1 SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -55,7 +55,7 @@ jobs:
                   cd ..
 
             - name: Create GH release
-              uses: marvinpinto/action-automatic-releases@latest
+              uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   automatic_release_tag: latest

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -55,7 +55,7 @@ jobs:
                   cd ..
 
             - name: Create GH release
-              uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
+              uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1 # latest @ 2022-01-29 (untagged rolling build, 3 dist rebuilds past v1.2.1)
               with:
                   repo_token: ${{ secrets.GITHUB_TOKEN }}
                   automatic_release_tag: latest


### PR DESCRIPTION
Pins `marvinpinto/action-automatic-releases@latest` to `d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1`, the commit `@latest` currently resolves to (2022-01-29). Freezes the mutable tag without changing behavior.

Verify:

    gh api repos/marvinpinto/action-automatic-releases/commits/latest --jq .sha
    # => d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1

Tracking: DEVPROD-1072.
